### PR TITLE
Prevent multiple page_clear_logins

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -256,8 +256,10 @@ kpxcEvent.onMultipleFieldsPopup = function(callback, tab) {
     browserAction.show(null, tab);
 };
 
-kpxcEvent.pageClearLogins = function(callback, tab) {
-    page.clearLogins(tab.id);
+kpxcEvent.pageClearLogins = function(callback, tab, alreadyCalled) {
+    if (!alreadyCalled) {
+        page.clearLogins(tab.id);
+    }
     callback();
 };
 

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1,6 +1,7 @@
 // contains already called method names
 var _called = {};
 _called.retrieveCredentials = false;
+_called.clearLogins = false;
 _called.manualFillRequested = 'none';
 
 // Count of detected form fields on the page
@@ -1213,7 +1214,8 @@ cip.initCredentialFields = function(forceCall) {
     }
     _called.initCredentialFields = true;
 
-    browser.runtime.sendMessage({ 'action': 'page_clear_logins' }).then(() => {
+    browser.runtime.sendMessage({ 'action': 'page_clear_logins', args: [_called.clearLogins] }).then(() => {
+        _called.clearLogins = true;
         const inputs = cipFields.getAllFields();
         cipFields.prepareVisibleFieldsWithID('select');
         cip.initPasswordGenerator(inputs);

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -1,6 +1,6 @@
 $(function() {
     browser.runtime.getBackgroundPage().then((global) => {
-        browser.tabs.query({"active": true, "currentWindow": true}).then((tabs) => {
+        browser.tabs.query({'active': true, 'currentWindow': true}).then((tabs) => {
             if (tabs.length === 0) {
                 return; // For example: only the background devtools or a popup are opened
             }


### PR DESCRIPTION
Prevents multiple `page_clear_logins` commands. In some cases the credentals are already cleared and if `cip.initCredentialFields` is then called again the already retrieved credentials will be cleared from the popup_login.html.