### PR TITLE
Choose credential fields works with multiple windows visible

### DIFF
--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -15,11 +15,16 @@ function initSettings() {
     });
 
     $('#settings #btn-choose-credential-fields').click(function() {
-        browser.runtime.getBackgroundPage().then((global) => {
-            browser.tabs.sendMessage(global.page.currentTabId, {
-                action: 'choose_credential_fields'
+        browser.windows.getCurrent().then((win) => {
+            browser.tabs.query({ 'active': true, 'currentWindow': true }).then((tabs) => {
+                const tab = tabs[0];
+                browser.runtime.getBackgroundPage().then((global) => {
+                    browser.tabs.sendMessage(tab.id, {
+                        action: 'choose_credential_fields'
+                    });
+                    close();
+                });
             });
-            close();
         });
     });
 }


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/21. Choosing credential fields now query the active window before getting the tabs. Before this always returned the last active tab ID which could've been in different window than the active one.