### PR TITLE
Fixes checking an input type

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1446,7 +1446,7 @@ cip.fillInFromActiveElement = function(suppressWarnings, passOnly = false) {
     cipFields.setUniqueId(jQuery(el));
     const fieldId = cipFields.prepareId(jQuery(el).attr('data-cip-id'));
     let combination = null;
-    if ($(el).toType === 'password') {
+    if ($(el).attr('type') === 'password') {
         combination = cipFields.getCombination('password', fieldId);
     }
     else {
@@ -1695,7 +1695,7 @@ cip.contextMenuRememberCredentials = function() {
     cipFields.setUniqueId(jQuery(el));
     const fieldId = cipFields.prepareId(jQuery(el).attr('data-cip-id'));
     let combination = null;
-    if ($(el).toType === 'password') {
+    if ($(el).attr('type') === 'password') {
         combination = cipFields.getCombination('password', fieldId);
     }
     else {


### PR DESCRIPTION
After jQuery update `.type()` was deprecated. This fixes the input type check. Previous method always returned `undefined`.

This also fixes issue https://github.com/keepassxreboot/keepassxc-browser/issues/22.