### PR TITLE
Add support to Firefox ESR

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -104,7 +104,7 @@
 	"applications": {
        "gecko": {
            "id": "keepassxc-browser@keepassxc.org",
-           "strict_min_version": "55.0"
+           "strict_min_version": "52.0"
        }
    }
 }


### PR DESCRIPTION
Solves https://github.com/keepassxreboot/keepassxc-browser/issues/26.

This has a few limitations because of an older WebExtension API:
- Showing context menus on password fields (menus.ContextType)
- HTTP Auth support (webRequest.onAuthRequired)

User's should be notified for these if the wish to use Firefox ESR.