### PR TITLE
Prevents password fill if input already has some data

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -148,7 +148,7 @@ cipAutocomplete.onBlur = function() {
     else {
         const fieldId = cipFields.prepareId(jQuery(this).attr('data-cip-id'));
         const fields = cipFields.getCombination('username', fieldId);
-        if (_f(fields.password) && _f(fields.password).data('unchanged') !== true && jQuery(this).val() !== '') {
+        if (_f(fields.password) && _f(fields.password).data('unchanged') !== true && jQuery(this).val() !== '' && _detectedFields > 1) {
             cip.fillInCredentials(fields, true, true);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/40.

If you have just the password field visible and you try to enter a password or TOTP manually the extension wanted to override the value with the credential password when losing the focus. This doesn't happen anymore.