### PR TITLE
Remove alert and show autocomplete instead

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -75,9 +75,10 @@ kpxcEvent.invoke = function(handler, callback, senderTabId, args, secondTime) {
     }).catch((e) => {console.log(e);});
 };
 
-kpxcEvent.onShowAlert = function(callback, tab, message) {
-    if (page.settings.supressAlerts) { console.log(message); }
-    else { alert(message); }
+kpxcEvent.onShowNotification = function(callback, tab, message) {
+    if (page.settings.showNotifications) {
+        showNotification(message);
+    }
 };
 
 kpxcEvent.showStatus = function(configured, tab, callback) {
@@ -274,7 +275,6 @@ kpxcEvent.checkDatabaseHash = function(callback, tab) {
 // all methods named in this object have to be declared BEFORE this!
 kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
-    'alert': kpxcEvent.onShowAlert,
     'associate': keepass.associate,
     'check_databasehash': kpxcEvent.checkDatabaseHash,
     'check_update_keepassxc': kpxcEvent.onCheckUpdateKeePassXC,
@@ -298,6 +298,7 @@ kpxcEvent.messageHandlers = {
     'update_credentials': keepass.updateCredentials,
     'save_settings': kpxcEvent.onSaveSettings,
     'set_remember_credentials': kpxcEvent.onSetRememberPopup,
+    'show_notification': kpxcEvent.onShowNotification,
     'stack_add': browserAction.stackAdd,
     'update_available_keepassxc': kpxcEvent.onUpdateAvailableKeePassXC
 };

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1656,12 +1656,10 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
             // user has to select correct credentials by himself
             if (countPasswords > 1) {
                 if (!suppressWarnings) {
-                    const message = 'Error #105\nMore than one login was found in KeePassXC!\n' +
-                    'Press the KeePassXC-Browser icon for more options.';
-                    browser.runtime.sendMessage({
-                        action: 'alert',
-                        args: [message]
-                    });
+                    const $target = onlyPassword ? pField : uField;
+                    cipAutocomplete.init($target);
+                    $target.focus();
+                    jQuery($target).autocomplete('search', jQuery($target).val());
                 }
             }
             else if (countPasswords < 1) {
@@ -1676,12 +1674,10 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
         }
         else {
             if (!suppressWarnings) {
-                    const message = 'Error #104\nMore than one login was found in KeePassXC!\n' +
-                    'Press the KeePassXC-Browser icon for more options.';
-                browser.runtime.sendMessage({
-                    action: 'alert',
-                    args: [message]
-                });
+                const $target = onlyPassword ? pField : uField;
+                cipAutocomplete.init($target);
+                $target.focus();
+                jQuery($target).autocomplete('search', jQuery($target).val());
             }
         }
     }

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -305,7 +305,11 @@ cipPassword.createDialog = function() {
                                 $password = $password.substring(0, field.attr('maxlength'));
                                 jQuery('input#cip-genpw-textfield-password:first').val($password);
                                 jQuery('#cip-genpw-btn-clipboard:first').removeClass('b2c-btn-success');
-                                alert('The generated password is longer than the allowed length!\nIt has been cut to fit the length.\n\nPlease remember the new password!');
+                                const message = 'Error:\nThe generated password is longer than the allowed length!\nIt has been cut to fit the length.\n\nPlease remember the new password!';
+                                browser.runtime.sendMessage({
+                                    action: 'show_notification',
+                                    args: [message]
+                                });
                             }
                         }
 
@@ -1455,9 +1459,9 @@ cip.fillInFromActiveElement = function(suppressWarnings, passOnly = false) {
 
     if (passOnly) {
         if (!_f(combination.password)) {
-            const message = 'Unable to find a password field';
+            const message = 'Error:\nUnable to find a password field';
             browser.runtime.sendMessage({
-                action: 'alert',
+                action: 'show_notification',
                 args: [message]
             });
             return;
@@ -1539,9 +1543,9 @@ cip.setValueWithChange = function(field, value) {
 cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
     // no credentials available
     if (cip.credentials.length === 0 && !suppressWarnings) {
-        const message = 'No logins found.';
+        const message = 'Error:\nNo logins found.';
         browser.runtime.sendMessage({
-            action: 'alert',
+            action: 'show_notification',
             args: [message]
         });
         return;
@@ -1572,9 +1576,9 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
 
         if (!filledIn) {
             if (!suppressWarnings) {
-                const message = 'Error #101\nCannot find fields to fill in.';
+                const message = 'Error:\nCannot find fields to fill in.';
                 browser.runtime.sendMessage({
-                    action: 'alert',
+                    action: 'show_notification',
                     args: [message]
                 });
             }
@@ -1602,9 +1606,9 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
 
         if (!filledIn) {
             if (!suppressWarnings) {
-                const message = 'Error #102\nCannot find fields to fill in.';
+                const message = 'Error:\nCannot find fields to fill in.';
                 browser.runtime.sendMessage({
-                    action: 'alert',
+                    action: 'show_notification',
                     args: [message]
                 });
             }
@@ -1631,7 +1635,7 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
                 }
             }
 
-            // for the correct alert message: 0 = no logins, X > 1 = too many logins
+            // for the correct notification message: 0 = no logins, X > 1 = too many logins
             if (countPasswords === 0) {
                 countPasswords = cip.credentials.length;
             }
@@ -1664,9 +1668,9 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
             }
             else if (countPasswords < 1) {
                 if (!suppressWarnings) {
-                    const message = 'Error #103\nNo credentials for given username found.';
+                    const message = 'Error:\nNo credentials for given username found.';
                     browser.runtime.sendMessage({
-                        action: 'alert',
+                        action: 'show_notification',
                         args: [message]
                     });
                 }
@@ -1713,7 +1717,11 @@ cip.contextMenuRememberCredentials = function() {
     }
 
     if (!cip.rememberCredentials(usernameValue, passwordValue)) {
-        alert('Could not detect changed credentials.');
+        const message = 'Error:\nCould not detect changed credentials.';
+        browser.runtime.sendMessage({
+            action: 'show_notification',
+            args: [message]
+        });
     }
 };
 


### PR DESCRIPTION
When doing a fill from context menu or from keyboard shortcut an alert is shown when multiple credentials are present. Instead of this alert show the user the autocomplete menu. If only password is filled the focus is changed to password input and only it is filled.

Also, all other alerts are removed and are showing a notification instead.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/52.