### PR TITLE
Add a new option showLoginNotifications

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -239,7 +239,7 @@ browserAction.setRememberPopup = function(tabId, username, password, url, userna
 
         browserAction.show(null, {'id': id});
 
-        if (page.settings.showNotifications) {
+        if (page.settings.showLoginNotifications) {
             showNotification('Create or modify the credentials by clicking on the extension icon.');
         }
     });

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -5,7 +5,8 @@ const defaultSettings = {
     usePasswordGenerator: true,
     autoFillSingleEntry: false,
     autoRetrieveCredentials: true,
-    showNotifications: true
+    showNotifications: true,
+    showLoginNotifications: true
 };
 
 var page = {};
@@ -37,6 +38,9 @@ page.initSettings = function() {
             }
             if (!('showNotifications' in page.settings)) {
                 page.settings.showNotifications = defaultSettings.showNotifications;
+            }
+            if (!('showLoginNotifications' in page.settings)) {
+                page.settings.showLoginNotifications = defaultSettings.showLoginNotifications;
             }
             browser.storage.local.set({'settings': page.settings});
             resolve(page.settings);

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -130,7 +130,12 @@
             <label class="checkbox">
               <input type="checkbox" name="showNotifications" value="true" /> Show notifications.
             </label>
-            <span class="help-block">Allow KeePassXC-Browser to show notifications when user interaction is needed from the extension icon.</span>
+            <span class="help-block">Show notifications for errors and when user interaction is required.</span>
+          </div>
+          <div class="checkbox">
+            <label class="checkbox">
+              <input type="checkbox" name="showLoginNotifications" value="true" /> Show a notification when new credentials can be saved to the database.
+            </label>
           </div>
         </p>
         <hr />


### PR DESCRIPTION
Adds a new option `Show notification also when new credentials are detected`. Earlier the only possibility to disable this (which can be an annoying notification) was to disable all notifications. This ensures that error notifications (see https://github.com/keepassxreboot/keepassxc-browser/pull/53) are still shown correctly even when login notifications are hidden.