### PR TITLE
Fix memory leaks

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const browserAction = {};
 
 const BLINK_TIMEOUT_DEFAULT = 7500;

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const kpxcEvent = {};
 
 kpxcEvent.onMessage = function(request, sender, callback) {
@@ -264,19 +266,10 @@ kpxcEvent.pageClearLogins = function(callback, tab, alreadyCalled) {
     callback();
 };
 
-kpxcEvent.oldDatabaseHash = 'no-hash';
-kpxcEvent.checkDatabaseHash = function(callback, tab) {
-    keepass.checkDatabaseHash((response) => {
-        callback({old: kpxcEvent.oldDatabaseHash, new: response});
-        kpxcEvent.oldDatabaseHash = response;
-    });
-};
-
 // all methods named in this object have to be declared BEFORE this!
 kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
     'associate': keepass.associate,
-    'check_databasehash': kpxcEvent.checkDatabaseHash,
     'check_update_keepassxc': kpxcEvent.onCheckUpdateKeePassXC,
     'generate_password': keepass.generatePassword,
     'get_connected_database': kpxcEvent.onGetConnectedDatabase,

--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const httpAuth = {};
 
 httpAuth.requests = [];

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -1,3 +1,5 @@
+'use strict';
+
 keepass.migrateKeyRing().then(() => {
     page.initSettings().then(() => {
         page.initOpenedTabs().then(() => {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const defaultSettings = {
     checkUpdateKeePassXC: 3,
     autoCompleteUsernames: true,
@@ -11,9 +13,9 @@ const defaultSettings = {
 };
 
 var page = {};
-page.tabs = {};
+page.tabs = [];
 page.currentTabId = -1;
-page.blockedTabs = {};
+page.blockedTabs = [];
 
 page.initSettings = function() {
     return new Promise((resolve, reject) => {
@@ -109,7 +111,7 @@ page.createTabEntry = function(tabId) {
     page.tabs[tabId] = {
         'stack': [],
         'errorMessage': null,
-        'loginList': {}
+        'loginList': []
     };
 };
 

--- a/keepassxc-browser/global.js
+++ b/keepassxc-browser/global.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var isFirefox = function() {
     if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
         return true;

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -1,3 +1,5 @@
+'use strict';
+
 if (jQuery) {
     var $ = jQuery.noConflict(true);
 }

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function status_response(r) {
     $('#initial-state').hide();
     $('#error-encountered').hide();

--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var $ = jQuery.noConflict(true);
 
 function updateAvailableResponse(available) {

--- a/keepassxc-browser/popups/popup_httpauth.js
+++ b/keepassxc-browser/popups/popup_httpauth.js
@@ -1,3 +1,5 @@
+'use strict';
+
 $(function() {
     browser.runtime.getBackgroundPage().then((global) => {
         browser.tabs.query({'active': true, 'currentWindow': true}).then((tabs) => {

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -1,3 +1,5 @@
+'use strict';
+
 $(function() {
     browser.runtime.getBackgroundPage().then((global) => {
         browser.tabs.query({'active': true, 'currentWindow': true}).then((tabs) => {

--- a/keepassxc-browser/popups/popup_remember.js
+++ b/keepassxc-browser/popups/popup_remember.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _tab;
 
 function _initialize(tab) {


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/57.

This PR changes the old `setInterval` based polling system to asynchronous one that triggers instantly when database related changes happen in KeePassXC. `setInterval` is not safe when using `browser.runtime.sendMessage` inside its scope. The memory heap keeps growing and garbage collector has never a chance to do its work.

Also, `use strict` is enabled in all scripts. This prevents the use of undeclared or accidental global variables.