### PR TITLE
Hide all popup elements by default

### DIFF
--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -18,7 +18,7 @@
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> Choose own credential fields for this page</button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
-        <div id="update-available" class="alert alert-danger">
+        <div id="update-available" class="alert alert-danger" style="display: none">
           You use an old version of KeePassXC.
           <br />
           <a target="_blank" class="alert-link" href="https://keepassxc.org/download">Please download the latest version from keepassxc.org</a>.

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -6,6 +6,7 @@ function status_response(r) {
     $('#configured-and-associated').hide();
     $('#configured-not-associated').hide();
     $('#lock-database-button').hide();
+    $('#update-available').hide();
 
     if (!r.keePassXCAvailable) {
         $('#error-message').html(r.error);

--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -4,9 +4,6 @@ function updateAvailableResponse(available) {
     if (available) {
         $('#update-available').show();
     }
-    else {
-        $('#update-available').hide();
-    }
 }
 
 function initSettings() {


### PR DESCRIPTION
This hides all popup elements by default. On some machines (for example slower virtual ones) certain elements flashed in the popup every time it loads.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/77.