### PR TITLE
Fixes search all databases

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -214,15 +214,24 @@ keepass.retrieveCredentials = function(callback, tab, url, submiturl, forceCallb
         }
 
         let entries = [];
+        let keys = [];
         const kpAction = kpActions.GET_LOGINS;
         const nonce = keepass.getNonce();
         const incrementedNonce = keepass.incrementedNonce(nonce);
         const {dbid} = keepass.getCryptoKey();
+    
+        for (let keyHash in keepass.keyRing) {
+            keys.push({
+                id: keepass.keyRing[keyHash].id,
+                key: keepass.keyRing[keyHash].key
+            });
+        }
 
         let messageData = {
             action: kpAction,
             id: dbid,
-            url: url
+            url: url,
+            keys: keys
         };
 
         if (submiturl) {
@@ -704,7 +713,7 @@ keepass.isAssociated = function() {
 keepass.migrateKeyRing = function() {
     return new Promise((resolve, reject) => {
         browser.storage.local.get('keyRing').then((item) => {
-             const keyring = item.keyRing;
+            const keyring = item.keyRing;
             // Change dates to numbers, for compatibilty with Chromium based browsers
             if (keyring) {
                 let num = 0;

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -158,7 +158,14 @@ Unencrypted message:
 {
 	"action": "get-logins",
 	"url": "<snip>",
-	"submitUrl": optional
+	"submitUrl": optional,
+	"keys": [
+		{
+			"id": <connected_id>,
+			"key": <connected_key>
+		},
+		...
+	]
 }
 ```
 


### PR DESCRIPTION
With the current implementation (also valid for passifox/chromeipass/KeePassHTTP-Connector) searching from all databases returns entries also from non-connected databases. This change passes the connected database id's and key's to `get-logins`. A modified handling mechanism is needed to KeePassXC side that ignores non-connected databases based on this new array.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/83.

This PR can be merged after the KeePassXC side. Doesn't affect the functionality with the older releases.