### PR TITLE
Password generator fixes

### DIFF
--- a/keepassxc-browser/keepassxc-browser.css
+++ b/keepassxc-browser/keepassxc-browser.css
@@ -60,7 +60,7 @@ input.genpw-text {
     font-size: inherit !important;
     background-color: #eee;
     border: 1px solid #ccc;
-    padding: .4em;
+    padding: .2em;
     border-radius: 4px;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
@@ -100,6 +100,10 @@ input.genpw-text {
 
 #cip-genpw-btn-fillin {
     margin-right: 5px;
+}
+
+#cip-genpw-quality {
+    text-align: center;
 }
 
 .b2c-modal-backdrop {

--- a/keepassxc-browser/keepassxc-browser.css
+++ b/keepassxc-browser/keepassxc-browser.css
@@ -18,6 +18,7 @@
 .kpxc .ui-dialog {
     font-size: 12px !important;
     box-shadow: 0 4px 6px 0 hsla(0, 0%, 0%, 0.2);
+    z-index: 2147483645;
 }
 
 .kpxc .ui-widget-overlay {
@@ -57,7 +58,7 @@ input.genpw-text {
 }
 
 .genpw-input-group-addon {
-    font-size: inherit !important;
+    font-size: .9em !important;
     background-color: #eee;
     border: 1px solid #ccc;
     padding: .2em;

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -231,7 +231,7 @@ cipPassword.createDialog = function() {
         .addClass('genpw-input-group-addon')
         .addClass('b2c-add-on')
         .attr('id', 'cip-genpw-quality')
-        .text('123 Bits');
+        .text('??? Bits');
     $inputGroup.append($textfieldPassword).append($quality);
 
     const $checkGroup = jQuery('<div>').addClass('genpw-input-group');


### PR DESCRIPTION
Multiple small fixes to the password generator:
- Center the `Bits` text and adjust the font to the input font size
- Modify z-index to the maximum so the password generator is always on top
- Change default `123 Bits` to `??? Bits`

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/87 and https://github.com/keepassxreboot/keepassxc-browser/issues/107.