### PR TITLE
Revert to default values when saving empty input field

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -39,7 +39,7 @@
             <label for="blinkTimeout">Blink Time:</label>
             <div class="control-group">
               <div class="input-append">
-                <input type="number" id="blinkTimeout" placeholder="7500" value="7500" />
+                <input type="number" id="blinkTimeout" placeholder="7500" value="7500" min="0"/>
                 <button class="btn btn-sm btn-primary" id="blinkTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> Save</button>
               </div>
             </div>
@@ -55,7 +55,7 @@
             <label for="blinkMinTimeout">Redirect Offset:</label>
             <div class="control-group">
               <div class="input-append">
-                <input type="number" id="blinkMinTimeout" placeholder="2000" value="2000" />
+                <input type="number" id="blinkMinTimeout" placeholder="2000" value="2000" min="-1"/>
                 <button class="btn btn-sm btn-primary" id="blinkMinTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> Save</button>
               </div>
             </div>
@@ -73,7 +73,7 @@
             <label for="allowedRedirect">Redirect Allowance:</label>
             <div class="control-group">
               <div class="input-append">
-                <input type="number" id="allowedRedirect" placeholder="1" value="1" />
+                <input type="number" id="allowedRedirect" placeholder="1" value="1" min="1"/>
                 <button class="btn btn-sm btn-primary" id="allowedRedirectButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> Save</button>
               </div>
             </div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -2,6 +2,12 @@ if (jQuery) {
     var $ = jQuery.noConflict(true);
 }
 
+const defaultSettings = {
+    blinkTimeout: 7500,
+    redirectOffset: -1,
+    redirectAllowance: 1
+};
+
 $(function() {
     browser.runtime.sendMessage({ action: 'load_settings' }).then((settings) => {
         options.settings = settings;
@@ -111,7 +117,7 @@ options.initGeneralSettings = function() {
 
     $('#blinkTimeoutButton').click(function(){
         const blinkTimeout = $.trim($('#blinkTimeout').val());
-        const blinkTimeoutval = Number(blinkTimeout);
+        const blinkTimeoutval = blinkTimeout !== '' ? Number(blinkTimeout) : defaultSettings.blinkTimeout;
 
         options.settings['blinkTimeout'] = String(blinkTimeoutval);
         options.saveSetting('blinkTimeout');
@@ -119,7 +125,7 @@ options.initGeneralSettings = function() {
 
     $('#blinkMinTimeoutButton').click(function(){
         const blinkMinTimeout = $.trim($('#blinkMinTimeout').val());
-        const blinkMinTimeoutval = Number(blinkMinTimeout);
+        const blinkMinTimeoutval = blinkMinTimeout !== '' ? Number(blinkMinTimeout) : defaultSettings.redirectOffset;
 
         options.settings['blinkMinTimeout'] = String(blinkMinTimeoutval);
         options.saveSetting('blinkMinTimeout');
@@ -127,7 +133,7 @@ options.initGeneralSettings = function() {
 
     $('#allowedRedirectButton').click(function(){
         const allowedRedirect = $.trim($('#allowedRedirect').val());
-        const allowedRedirectval = Number(allowedRedirect);
+        const allowedRedirectval = allowedRedirect !== '' ? Number(allowedRedirect) : defaultSettings.redirectAllowance;
 
         options.settings['allowedRedirect'] = String(allowedRedirectval);
         options.saveSetting('allowedRedirect');


### PR DESCRIPTION
When deleting the input field and pressing Save the default value is not saved. This ensures that in these cases the default value will be saved. Also a minimum values has been added to the input fields.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/106.