### PR TITLE
Modify shortcuts

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -72,8 +72,8 @@
 		"fill-password": {
 			"description": "Insert a password",
 			"suggested_key": {
-				"default": "Alt+Shift+P",
-				"mac": "MacCtrl+Shift+P"
+				"default": "Alt+Shift+I",
+				"mac": "MacCtrl+Shift+I"
 			}
 		},
         "fill-totp": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -29,9 +29,9 @@
         <h2>General Settings</h2>
         <hr />
         <p>
-          If you just want to insert username + password into the fields where your focus is, press <code>Alt + Shift + U</code>.
+          If you just want to insert username + password into the fields where your focus is, press <code><span id="mac-user-shortcut">Ctrl + Shift + U</span><span id="default-user-shortcut">Alt + Shift + U</span></code>.
           <br />
-          If you only want to insert the password, just press <code>Alt + Shift + P</code>.
+          If you only want to insert the password, just press <code><span id="mac-pass-shortcut">Ctrl + Shift + I</span><span id="default-pass-shortcut">Alt + Shift + I</span></code>.
           <span id="chrome-only">You can customize these shortcuts on <code>chrome://extensions/configureCommands</code> page</span>
         </p>
         <p>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -261,4 +261,16 @@ options.initAbout = function() {
     if (isFirefox()) {
         $('#chrome-only').remove();
     }
+
+    if (navigator.platform === 'MacIntel') {
+        $('#default-user-shortcut').hide();
+        $('#default-pass-shortcut').hide();
+        $('#mac-user-shortcut').show();
+        $('#mac-pass-shortcut').show();
+    } else {
+        $('#mac-user-shortcut').hide();
+        $('#mac-pass-shortcut').hide();
+        $('#default-user-shortcut').show();
+        $('#default-pass-shortcut').show();
+    }
 };


### PR DESCRIPTION
Alt+Shift+P doesn't work with Firefox. Changed the shortcut to Alt+Shift+I. Also show correct shortcuts for macOS in the settings page.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/72.