### PR TITLE
Add support for ignored sites

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -30,48 +30,41 @@ browser.runtime.onMessage.addListener(function(req, sender, callback) {
                     cipForm.destroy(false, {'password': list.list[0], 'username': list.list[1]});
                 }
             }
-        }
-        else if (req.action === 'fill_user_pass') {
+        } else if (req.action === 'fill_user_pass') {
             _called.manualFillRequested = 'both';
             cip.receiveCredentialsIfNecessary().then((response) => {
                 cip.fillInFromActiveElement(false);
             });
-        }
-        else if (req.action === 'fill_pass_only') {
+        } else if (req.action === 'fill_pass_only') {
             _called.manualFillRequested = 'pass';
             cip.receiveCredentialsIfNecessary().then((response) => {
                 cip.fillInFromActiveElement(false, true); // passOnly to true
             });
-        }
-        else if (req.action === 'fill_totp') {
+        } else if (req.action === 'fill_totp') {
             cip.receiveCredentialsIfNecessary().then((response) => {
                 cip.fillInFromActiveElementTOTPOnly(false);
             });
-        }
-        else if (req.action === 'activate_password_generator') {
+        } else if (req.action === 'activate_password_generator') {
             cip.initPasswordGenerator(cipFields.getAllFields());
-        }
-        else if (req.action === 'remember_credentials') {
+        } else if (req.action === 'remember_credentials') {
             cip.contextMenuRememberCredentials();
-        }
-        else if (req.action === 'choose_credential_fields') {
+        } else if (req.action === 'choose_credential_fields') {
             cipDefine.init();
-        }
-        else if (req.action === 'clear_credentials') {
+        } else if (req.action === 'clear_credentials') {
             cipEvents.clearCredentials();
             callback();
-        }
-        else if (req.action === 'activated_tab') {
+        } else if (req.action === 'activated_tab') {
             cipEvents.triggerActivatedTab();
             callback();
-        }
-        else if (req.action === 'redetect_fields') {
+        } else if (req.action === 'redetect_fields') {
             browser.runtime.sendMessage({
                 action: 'load_settings',
             }).then((response) => {
                 cip.settings = response;
                 cip.initCredentialFields(true);
             });
+        } else if (req.action === 'ignore-site') {
+            cip.ignoreSite(req.args);
         }
     }
 });
@@ -1827,6 +1820,25 @@ cip.rememberCredentials = function(usernameValue, passwordValue) {
     return false;
 };
 
+cip.ignoreSite = function(sites) {
+    if (!sites || sites.length === 0) {
+        return;
+    }
+
+    const site = sites[0];
+    if (!cip.settings['ignoredSites']) {
+        cip.settings['ignoredSites'] = {};
+    }
+
+    cip.settings['ignoredSites'][site] = {
+        url: site
+    };
+
+    browser.runtime.sendMessage({
+        action: 'save_settings',
+        args: [cip.settings]
+    });
+};
 
 
 var cipEvents = {};

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -20,6 +20,7 @@
           <li class="active"><a href="#general-settings">General</a></li>
           <li><a href="#connected-databases">Connected Databases</a></li>
           <li><a href="#specified-fields">Specified credential fields</a></li>
+          <li><a href="#ignored-sites">Ignored sites</a></li>
           <li><a href="#about">About</a></li>
         </ul>
       </nav>
@@ -278,6 +279,52 @@
               <div class="modal-body">
                 <p>Do you really want to remove the specified credential fields on the page <strong></strong>?</p>
                 <p class="help-block">KeePassXC-Browser will automatically detect the credential fields the next time you visit this page.</p>
+              </div>
+              <div class="modal-footer">
+                <button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+                <button class="btn yes btn-primary">Yes, remove now</button>
+              </div>
+            </div>
+          </div>
+       </div>
+      </div>
+
+      <!-- Ignored sites -->
+      <div class="tab" id="tab-ignored-sites">
+        <h2>Ignored sites</h2>
+        <hr />
+        <p>
+          Sites in this list are ignored when new credentials are detected.
+          <br />
+          Go to the page with new credentials, click the blinking KeePassXC-Browser icon or the notification and select <em>Never ask for this page</em>.
+        </p>
+        <table class="table table-striped table-bordered table-hover">
+          <thead>
+            <tr>
+              <th>Page URL</th>
+              <th>Delete</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="empty">
+              <td colspan="2">No ignored sites found.</td>
+            </tr>
+            <tr class="clone">
+              <td></td>
+              <td><button class="btn delete btn-danger btn"><span class="glyphicon glyphicon-remove-sign"></span> Remove</button></td>
+            </tr>
+          </tbody>
+        </table>
+        <div id="dialogDeleteIgnoredSite" class="modal fade" tabindex="-1" role="dialog">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <h3 id="myModalLabel">Remove site?</h3>
+              </div>
+              <div class="modal-body">
+                <p>Do you really want to remove the specified site from the ignore list?</p>
+                <p class="help-block">KeePassXC-Browser will detect new credentials the next time you visit this page.</p>
               </div>
               <div class="modal-footer">
                 <button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -17,6 +17,7 @@ $(function() {
             options.initGeneralSettings();
             options.initConnectedDatabases();
             options.initSpecifiedCredentialFields();
+            options.initIgnoredSites();
             options.initAbout();
         });
     });
@@ -173,8 +174,7 @@ options.initConnectedDatabases = function() {
 
         if ($('#tab-connected-databases table tbody:first tr').length > 2) {
             $('#tab-connected-databases table tbody:first tr.empty:first').hide();
-        }
-        else {
+        } else {
             $('#tab-connected-databases table tbody:first tr.empty:first').show();
         }
     });
@@ -201,8 +201,7 @@ options.initConnectedDatabases = function() {
 
     if ($('#tab-connected-databases table tbody:first tr').length > 2) {
         $('#tab-connected-databases table tbody:first tr.empty:first').hide();
-    }
-    else {
+    } else {
         $('#tab-connected-databases table tbody:first tr.empty:first').show();
     }
 
@@ -235,8 +234,7 @@ options.initSpecifiedCredentialFields = function() {
 
         if ($('#tab-specified-fields table tbody:first tr').length > 2) {
             $('#tab-specified-fields table tbody:first tr.empty:first').hide();
-        }
-        else {
+        } else {
             $('#tab-specified-fields table tbody:first tr.empty:first').show();
         }
     });
@@ -248,7 +246,7 @@ options.initSpecifiedCredentialFields = function() {
         const $tr = $trClone.clone(true);
         $tr.data('url', url);
         $tr.attr('id', 'tr-scf' + counter);
-        counter += 1;
+        ++counter;
 
         $tr.children('td:first').text(url);
         $('#tab-specified-fields table tbody:first').append($tr);
@@ -256,9 +254,55 @@ options.initSpecifiedCredentialFields = function() {
 
     if ($('#tab-specified-fields table tbody:first tr').length > 2) {
         $('#tab-specified-fields table tbody:first tr.empty:first').hide();
-    }
-    else {
+    } else {
         $('#tab-specified-fields table tbody:first tr.empty:first').show();
+    }
+};
+
+options.initIgnoredSites = function() {
+    $('#dialogDeleteIgnoredSite').modal({keyboard: true, show: false, backdrop: true});
+    $('#tab-ignored-sites tr.clone:first button.delete:first').click(function(e) {
+        e.preventDefault();
+        $('#dialogDeleteIgnoredSite').data('url', $(this).closest('tr').data('url'));
+        $('#dialogDeleteIgnoredSite').data('tr-id', $(this).closest('tr').attr('id'));
+        $('#dialogDeleteIgnoredSite .modal-body:first strong:first').text($(this).closest('tr').children('td:first').text());
+        $('#dialogDeleteIgnoredSite').modal('show');
+    });
+
+    $('#dialogDeleteIgnoredSite .modal-footer:first button.yes:first').click(function(e) {
+        $('#dialogDeleteIgnoredSite').modal('hide');
+
+        const $url = $('#dialogDeleteIgnoredSite').data('url');
+        const $trId = $('#dialogDeleteIgnoredSite').data('tr-id');
+        $('#tab-ignored-sites #' + $trId).remove();
+
+        delete options.settings['ignoredSites'][$url];
+        options.saveSettings();
+
+        if ($('#tab-ignored-sites table tbody:first tr').length > 2) {
+            $('#tab-ignored-sites table tbody:first tr.empty:first').hide();
+        } else {
+            $('#tab-ignored-sites table tbody:first tr.empty:first').show();
+        }
+    });
+
+    const $trClone = $('#tab-ignored-sites table tr.clone:first').clone(true);
+    $trClone.removeClass('clone');
+    let counter = 1;
+    for (let url in options.settings['ignoredSites']) {
+        const $tr = $trClone.clone(true);
+        $tr.data('url', url);
+        $tr.attr('id', 'tr-scf' + counter);
+        ++counter;
+
+        $tr.children('td:first').text(url);
+        $('#tab-ignored-sites table tbody:first').append($tr);
+    }
+
+    if ($('#tab-ignored-sites table tbody:first tr').length > 2) {
+        $('#tab-ignored-sites table tbody:first tr.empty:first').hide();
+    } else {
+        $('#tab-ignored-sites table tbody:first tr.empty:first').show();
     }
 };
 

--- a/keepassxc-browser/popups/popup_remember.html
+++ b/keepassxc-browser/popups/popup_remember.html
@@ -32,6 +32,7 @@
         <button id="btn-new" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-pencil"></span> New</button>
         <button id="btn-update" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-refresh"></span> Update</button>
         <button id="btn-dismiss" class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-remove"></span> Dismiss</button>
+        <button id="btn-ignore" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-remove"></span> Never ask for this page</button>
       </p>
     </div>
 

--- a/keepassxc-browser/popups/popup_remember.js
+++ b/keepassxc-browser/popups/popup_remember.js
@@ -78,6 +78,21 @@ function _initialize(tab) {
         e.preventDefault();
         _close();
     });
+
+    $('#btn-ignore').click(function(e) {
+        browser.windows.getCurrent().then((win) => {
+            browser.tabs.query({ 'active': true, 'currentWindow': true }).then((tabs) => {
+                const tab = tabs[0];
+                browser.runtime.getBackgroundPage().then((global) => {
+                    browser.tabs.sendMessage(tab.id, {
+                        action: 'ignore-site',
+                        args: [_tab.credentials.url]
+                    });
+                    _close();
+                });
+            });
+        });
+    });
 }
 
 function _connected_database(db) {


### PR DESCRIPTION
Settings page has a new tab `Ignored sites`. User has a possibility to add a certain site to this list from the popup icon or from the notification. When site is in the ignore list the credentials are still received but no notifications are shown for saving new credentials or modifying existing ones.

Closes the wishlist item https://github.com/keepassxreboot/keepassxc-browser/issues/95.