### PR TITLE
Don't show remember popup if database is closed

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -217,7 +217,17 @@ kpxcEvent.onRemoveCredentialsFromTabInformation = function(callback, tab) {
 };
 
 kpxcEvent.onSetRememberPopup = function(callback, tab, username, password, url, usernameExists, credentialsList) {
-    browserAction.setRememberPopup(tab.id, username, password, url, usernameExists, credentialsList);
+    keepass.testAssociation((response) => {
+        if (response) {
+            keepass.isConfigured().then((configured) => {
+                if (configured) {
+                    browserAction.setRememberPopup(tab.id, username, password, url, usernameExists, credentialsList);
+                }
+            }).catch((e) => {
+                console.log(e);
+            });
+        }
+    }, tab);
 };
 
 kpxcEvent.onLoginPopup = function(callback, tab, logins) {


### PR DESCRIPTION
If database is closed, remember popup or notification(s) are not shown when requesting new credentials.

Solves https://github.com/keepassxreboot/keepassxc-browser/issues/112.