### PR TITLE
Added save domain only option

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -6,7 +6,8 @@ const defaultSettings = {
     autoFillSingleEntry: false,
     autoRetrieveCredentials: true,
     showNotifications: true,
-    showLoginNotifications: true
+    showLoginNotifications: true,
+    saveDomainOnly: true
 };
 
 var page = {};
@@ -41,6 +42,9 @@ page.initSettings = function() {
             }
             if (!('showLoginNotifications' in page.settings)) {
                 page.settings.showLoginNotifications = defaultSettings.showLoginNotifications;
+            }
+            if (!('saveDomainOnly' in page.settings)) {
+                page.settings.saveDomainOnly = defaultSettings.saveDomainOnly;
             }
             browser.storage.local.set({'settings': page.settings});
             resolve(page.settings);

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1762,7 +1762,7 @@ cip.rememberCredentials = function(usernameValue, passwordValue) {
 
         let url = jQuery(this)[0].action;
         if (!url) {
-            url = document.location.href;
+            url = cip.settings.saveDomainOnly ? document.location.origin : document.location.href;
             if (url.indexOf('?') > 0) {
                 url = url.substring(0, url.indexOf('?'));
                 if (url.length < document.location.origin.length) {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -140,6 +140,15 @@
         </p>
         <hr />
         <p>
+          <div class="checkbox">
+            <label class="checkbox">
+              <input type="checkbox" name="saveDomainOnly" value="true" /> Save domain only.
+            </label>
+            <span class="help-block">When saving new credentials save only the domain instead of full URL.</span>
+          </div>
+        </p>
+        <hr />
+        <p>
           Check for updates of KeePassXC:
           <br />
           <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="3" /> every 3 days</label>


### PR DESCRIPTION
Adds a new option `Save domain only` when saving new credentials. It is enabled by default.

Solves wishlist item https://github.com/keepassxreboot/keepassxc-browser/issues/85.