### PR TITLE
Fix for hiding update message

### DIFF
--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -64,6 +64,7 @@ body {
     padding-bottom: 0px;
     margin-bottom: 0px;
     text-align: left;
+    display: none;
 }
 #update-available a:hover,
 #update-available a:active {

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -18,7 +18,7 @@
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> Choose own credential fields for this page</button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
-        <div id="update-available" class="alert alert-danger" style="display: none">
+        <div id="update-available" class="alert alert-danger">
           You use an old version of KeePassXC.
           <br />
           <a target="_blank" class="alert-link" href="https://keepassxc.org/download">Please download the latest version from keepassxc.org</a>.


### PR DESCRIPTION
Fixes hiding the KeePassXC update message from all popups by default.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/140.