### PR TITLE
Removed incorrect function call

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1179,7 +1179,6 @@ cip.credentials = [];
 
 jQuery(function() {
     cip.init();
-    cip.detectDatabaseChange();
 });
 
 cip.init = function() {


### PR DESCRIPTION
Removes one function call that is not used from content script initalization anymore.

Affects to #139 but probably not solves it.