### PR TITLE
Remove automatic username field add

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -894,15 +894,6 @@ cipFields.getAllCombinations = function(inputs) {
         }
     }
 
-    // If only username field found, add it to the array
-    if (fields.length === 0 && uField) {
-        const combination = {
-            username: uField[0].getAttribute('data-cip-id'),
-            password: null
-        };
-        fields.push(combination);
-    }
-
     return fields;
 };
 


### PR DESCRIPTION
Automatic addon of any username field caused unnecessary credential retrievals. Pages with a single username field it's preferred to use a manually choosed credential field.

Fixes #139.