### PR TITLE
Credential retrieval fix

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -159,6 +159,9 @@ kpxcEvent.onReconnect = function(callback, tab) {
     // Add a small timeout after reconnecting. Just to make sure. It's not pretty, I know :(
     setTimeout(() => {
         keepass.reconnect(callback, tab).then((configured) => {
+            browser.tabs.sendMessage(tab.id, {
+                action: 'redetect_fields'
+            });
             kpxcEvent.showStatus(configured, tab, callback);
         });
     }, 500);

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -839,6 +839,17 @@ keepass.onNativeMessage = function(response) {
         keepass.testAssociation((associationResponse) => {
             keepass.isConfigured().then((configured) => {
                 keepass.updatePopup(configured ? 'normal' : 'cross');
+
+                // Send message to content script
+                browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+                    if (tabs.length) {
+                        browser.tabs.sendMessage(tabs[0].id, {
+                            action: 'check_database_hash',
+                            hash: {old: keepass.previousDatabaseHash, new: keepass.databaseHash}
+                        });
+                        keepass.previousDatabaseHash = keepass.databaseHash;
+                    }
+                });
             });
         }, null);
     }

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1202,6 +1202,7 @@ cip.detectDatabaseChange = function(response) {
                 args: [ true ]    // Set polling to true, this is an internal function call
             });
         } else if (response.new !== 'no-hash' && response.new !== response.old) {
+            _called.retrieveCredentials = false;
             browser.runtime.sendMessage({
                 action: 'load_settings',
             }).then((response) => {
@@ -1257,7 +1258,6 @@ cip.initCredentialFields = function(forceCall) {
         } 
 
         if (cip.settings.autoRetrieveCredentials && _called.retrieveCredentials === false && (cip.url && cip.submitUrl)) {
-            _called.retrieveCredentials = true;
             browser.runtime.sendMessage({
                 action: 'retrieve_credentials',
                 args: [ cip.url, cip.submitUrl ]


### PR DESCRIPTION
Performs redetect credential fields on reconnect and does a database hash check when it has been changed or locked/unlocked.

Fixes #150.