### PR TITLE
Stop querying changed text nodes for children elements

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1143,6 +1143,11 @@ let observer = new MutationObserver(function(mutations, observer) {
     }
 
     for (const mut of mutations) {
+        // skip text nodes
+        if (mut.target.nodeType === Node.TEXT_NODE) {
+            continue;
+        }
+
         // Check if the added element has any inputs
         const inputs = mut.target.querySelectorAll(cipFields.inputQueryPattern);
 


### PR DESCRIPTION
Currently, this plugin produces quite a few exceptions in the browser's console when the observed list of changed nodes contains text nodes:

```
keepassxc-browser.js:1147 Uncaught TypeError: mut.target.querySelectorAll is not a function
    at MutationObserver.<anonymous> (keepassxc-browser.js:1147)
(anonymous) @ keepassxc-browser.js:1147
```

This pull request fixes the issue by filtering out texts nodes from the list of mutated nodes.