### PR TITLE
Improve detection of username fields

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -897,6 +897,14 @@ cipFields.getAllCombinations = function(inputs) {
         }
     }
 
+    if (fields.length === 0 && uField) {
+        const combination = {
+            username: uField[0].getAttribute('data-cip-id'),
+            password: null
+        };
+        fields.push(combination);
+    }
+
     return fields;
 };
 
@@ -1156,7 +1164,13 @@ let observer = new MutationObserver(function(mutations, observer) {
         if (inputs.length > neededLength && !_observerIds.includes(mut.target.id)) {
             // Save target element id for preventing multiple calls to initCredentialsFields()
             _observerIds.push(mut.target.id);
-            cip.initCredentialFields(true);
+            
+            // Sometimes the settings haven't been loaded before new input fields are detected
+            if (Object.keys(cip.settings).length === 0) {
+                cip.init();
+            } else {
+                cip.initCredentialFields(true);
+            }
         }
     }
 });
@@ -1269,6 +1283,8 @@ cip.initCredentialFields = function(forceCall) {
             }).then(cip.retrieveCredentialsCallback).catch((e) => {
                 console.log(e);
             });
+        } else {
+            cip.preparePageForMultipleCredentials(cip.credentials);
         }
     });
 };


### PR DESCRIPTION
With some pages MutationObserver tries to detect fields before browser extension settings are loaded. This fixes username field detection (e.g.) for pages: [https://accounts.google.com](https://accounts.google.com) and [https://login.live.com/](https://login.live.com/).