### PR TITLE
Ignore comment nodes

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1180,7 +1180,7 @@ cipObserverHelper.inputTypes = [
 ];
 
 cipObserverHelper.getInputs = function(target) {
-    if (target.nodeType === Node.TEXT_NODE) {
+    if (target.nodeType === Node.TEXT_NODE || target.nodeType === Node.COMMENT_NODE) {
         return [];
     }
 


### PR DESCRIPTION
Ignores comment nodes before executing `getElementsByTagName()` to the element.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/183.