### PR TITLE
Fix getInputs()

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1203,7 +1203,7 @@ cipObserverHelper.inputTypes = [
     'password',
     'tel',
     'number',
-    ''
+    null    // Input field can be without any type. Include these to the list.
 ];
 
 cipObserverHelper.getInputs = function(target) {


### PR DESCRIPTION
An input field can be without any type. In these cases attributes returns `null`.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/197