### PR TITLE
Fix #196 regression: input field detection broken

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -2023,7 +2023,7 @@ cip.ignoreSite = function(sites) {
 
  // Delete previously created Object if it exists. It will be replaced by an Array
 cip.initializeIgnoredSites = function() {
-    if (cip.settings['ignoredSites'] !== null && cip.settings['ignoredSites'].constructor === Object) {
+    if (cip.settings['ignoredSites'] !== undefined && cip.settings['ignoredSites'].constructor === Object) {
         delete cip.settings['ignoredSites'];
     }
 


### PR DESCRIPTION
Fixes a regression introduced by #196.

Field detection stopped working for me entirely, since the `ignoredSites` setting is `undefined` and not `null`. Strangely enough, I cannot reproduce the original issue #192, which #196 was supposed to fix. So from my standpoint, #196 actually introduced the issue, causing the universe to implode in an endless loop of cause and effect.