### PR TITLE
Match patterns fix

### DIFF
--- a/keepassxc-browser/global.js
+++ b/keepassxc-browser/global.js
@@ -4,6 +4,10 @@ const IGNORE_NOTHING = 'ignoreNothing';
 const IGNORE_NORMAL = 'ignoreNormal';
 const IGNORE_FULL = 'ignoreFull';
 
+var schemeSegment = '(\\*|http|https|ws|wss|file|ftp)';
+var hostSegment = '(\\*|(?:\\*\\.)?(?:[^/*]+))?';
+var pathSegment = '(.*)';
+
 var isFirefox = function() {
     if (!(/Chrome/.test(navigator.userAgent) && /Google/.test(navigator.vendor))) {
         return true;
@@ -35,21 +39,18 @@ var matchPatternToRegExp = function(pattern) {
         return (/^(?:http|https|file|ftp|app):\/\//);
     }
 
-    const schemeSegment = '(\\*|http|https|ws|wss|file|ftp)';
-    const hostSegment = '(\\*|(?:\\*\\.)?(?:[^/*]+))?';
-    const pathSegment = '(.*)';
     const matchPatternRegExp = new RegExp(
         `^${schemeSegment}://${hostSegment}/${pathSegment}$`
     );
 
     let match = matchPatternRegExp.exec(pattern);
     if (!match) {
-         throw new TypeError('"${pattern}" is not a valid MatchPattern');
+        throw new TypeError(pattern + ' is not a valid MatchPattern');
     }
 
     let [, scheme, host, path] = match;
     if (!host) {
-        throw new TypeError('"${pattern}" does not have a valid host');
+        throw new TypeError(pattern + ' does not have a valid host');
     }
 
     let regex = '^';

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -299,7 +299,7 @@ options.initSitePreferences = function() {
 
     $('#sitePreferencesManualAdd').click(function(e) {
         e.preventDefault();
-        const value = $('#manualUrl').val();
+        let value = $('#manualUrl').val();
         if (value.length > 10 && value.length <= 2000) {
             if (options.settings['sitePreferences'] === undefined) {
                 options.settings['sitePreferences'] = [];
@@ -308,6 +308,11 @@ options.initSitePreferences = function() {
             const newValue = options.settings['sitePreferences'].length + 1;
             const trClone = $('#tab-site-preferences table tr.clone:first').clone(true);
             trClone.removeClass('clone');
+
+            // Fills the last / char if needed. This ensures the compatibility with Match Patterns
+            if (options.slashNeededForUrl(value)) {
+                value += '/';
+            }
 
             const tr = trClone.clone(true);
             tr.data('url', value);
@@ -386,4 +391,10 @@ options.initAbout = function() {
         $('#default-user-shortcut').show();
         $('#default-pass-shortcut').show();
     }
+};
+
+// Checks if URL has only scheme and host without the last / char.
+options.slashNeededForUrl = function(pattern) {
+    const matchPattern = new RegExp(`^${schemeSegment}://${hostSegment}$`);
+    return matchPattern.exec(pattern);
 };


### PR DESCRIPTION
Previously if manually added URL was in a form scheme://host and the last `/` was missing, the match pattern throws an error. This fix ensures that manually added URL's will be compatible.

Extends #208.