### PR TITLE
Add default value for update checking on settings page

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -152,7 +152,7 @@
         <p>
           Check for updates of KeePassXC:
           <br />
-          <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="3" /> every 3 days</label>
+          <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="3" checked="true"/> every 3 days</label>
           <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="7" /> every week</label>
           <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="30" /> every month</label>
           <label class="radio-inline"><input type="radio" name="checkUpdateKeePassXC" value="0" /> never</label>


### PR DESCRIPTION
Sets default value to three days. The same is the default value in the extension settings.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/238.