### PR TITLE
Hide the connected key(s) partially in the settings tab

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -156,6 +156,10 @@ options.showKeePassXCVersions = function(response) {
     $('#tab-general-settings button.checkUpdateKeePassXC:first').attr('disabled', false);
 };
 
+options.getPartiallyHiddenKey = function(key) {
+    return !key ? 'Error' : (key.substr(0, 8) + '*'.repeat(10));
+};
+
 options.initConnectedDatabases = function() {
     $('#dialogDeleteConnectedDatabase').modal({keyboard: true, show: false, backdrop: true});
     $('#tab-connected-databases tr.clone:first button.delete:first').click(function(e) {
@@ -193,7 +197,7 @@ options.initConnectedDatabases = function() {
         $('a.dropdown-toggle:first img:first', tr).attr('src', '/icons/19x19/icon_normal_19x19.png');
 
         tr.children('td:first').text(options.keyRing[hash].id);
-        tr.children('td:eq(1)').text(options.keyRing[hash].key);
+        tr.children('td:eq(1)').text(options.getPartiallyHiddenKey(options.keyRing[hash].key));
         const lastUsed = (options.keyRing[hash].lastUsed) ? new Date(options.keyRing[hash].lastUsed).toLocaleString() : 'unknown';
         tr.children('td:eq(2)').text(lastUsed);
         const date = (options.keyRing[hash].created) ? new Date(options.keyRing[hash].created).toLocaleDateString() : 'unknown';


### PR DESCRIPTION
Hides the connected key(s) partially in the Connected databases settings tab.
The first eight characters are shown. This enables the comparison with the key saved in KeePassXC without revealing it totally.