### PR TITLE
Add slash to URL from notification button

### DIFF
--- a/keepassxc-browser/global.js
+++ b/keepassxc-browser/global.js
@@ -91,3 +91,9 @@ var siteMatch = function(site, url) {
     const rx = matchPatternToRegExp(site);
     return url.match(rx);
 };
+
+// Checks if URL has only scheme and host without the last / char.
+var slashNeededForUrl = function(pattern) {
+    const matchPattern = new RegExp(`^${schemeSegment}://${hostSegment}$`);
+    return matchPattern.exec(pattern);
+};

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -2055,8 +2055,12 @@ cip.ignoreSite = function(sites) {
         return;
     }
 
-    const site = sites[0];
+    let site = sites[0];
     cip.initializeSitePreferences();
+
+    if (slashNeededForUrl(site)) {
+        site += '/';
+    }
 
     // Check if the site already exists
     let siteExists = false;

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -310,7 +310,7 @@ options.initSitePreferences = function() {
             trClone.removeClass('clone');
 
             // Fills the last / char if needed. This ensures the compatibility with Match Patterns
-            if (options.slashNeededForUrl(value)) {
+            if (slashNeededForUrl(value)) {
                 value += '/';
             }
 
@@ -391,10 +391,4 @@ options.initAbout = function() {
         $('#default-user-shortcut').show();
         $('#default-pass-shortcut').show();
     }
-};
-
-// Checks if URL has only scheme and host without the last / char.
-options.slashNeededForUrl = function(pattern) {
-    const matchPattern = new RegExp(`^${schemeSegment}://${hostSegment}$`);
-    return matchPattern.exec(pattern);
 };

--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -4,6 +4,9 @@ body {
     background-color: #eee;
     font-size: 15px;
     padding: 8px;
+    min-width: 440px;
+    max-width: 460px;
+    width: auto;
 }
 .container {
     min-width: 440px;


### PR DESCRIPTION
Adding URL to Site Preferences from a notification or from popup doesn't add the slash to the end of the URL if it's missing. Also, the function is moved to global.js because it must be accessed from the popup, options page and from content script.

Some CSS tuning regarding popup_remember.html was also needed.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/249.
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/282.