### PR TITLE
Fixed updating credentials from the context menu

### DIFF
--- a/keepassxc-browser/popups/popup_remember.js
+++ b/keepassxc-browser/popups/popup_remember.js
@@ -5,15 +5,20 @@ var _tab;
 function _initialize(tab) {
     _tab = tab;
 
-    // no credentials set or credentials already cleared
-    if (!_tab.credentials.username) {
+    // No credentials set or credentials already cleared
+    if (!_tab.credentials.username && !_tab.credentials.password) {
         _close();
         return;
     }
 
-    // no existing credentials to update --> disable update-button
+    // No existing credentials to update --> disable Update button
     if (_tab.credentials.list.length === 0) {
         $('#btn-update').attr('disabled', true).removeClass('btn-warning');
+    }
+
+    // No username available. This might be because of trigger from context menu --> disable New button
+    if (!_tab.credentials.username && _tab.credentials.password) {
+        $('#btn-new').attr('disabled', true).removeClass('btn-success');
     }
 
     let url = _tab.credentials.url;
@@ -31,8 +36,13 @@ function _initialize(tab) {
     $('#btn-update').click(function(e) {
         e.preventDefault();
 
-        //  only one entry which could be updated
+        //  Only one entry which could be updated
         if(_tab.credentials.list.length === 1) {
+            // Use the current username if it's empty
+            if (!_tab.credentials.username) {
+                _tab.credentials.username = _tab.credentials.list[0].login;
+            }
+
             browser.runtime.sendMessage({
                 action: 'update_credentials',
                 args: [_tab.credentials.list[0].uuid, _tab.credentials.username, _tab.credentials.password, _tab.credentials.url]
@@ -58,10 +68,35 @@ function _initialize(tab) {
                     .data('entryId', i)
                     .click(function(e) {
                         e.preventDefault();
+                        const entryId = $(this).data('entryId');
+
+                        // Use the current username if it's empty
+                        if (!_tab.credentials.username) {
+                            _tab.credentials.username = _tab.credentials.list[entryId].login;
+                        }
+
+                        // Check if the password has changed for the updated credentials
                         browser.runtime.sendMessage({
-                            action: 'update_credentials',
-                            args: [_tab.credentials.list[$(this).data('entryId')].uuid, _tab.credentials.username, _tab.credentials.password, _tab.credentials.url]
-                        }).then(_verifyResult);
+                            action: 'retrieve_credentials',
+                            args: [ url, '', false, true ]
+                        }).then((credentials) => {
+                            if (!credentials || credentials.length !== _tab.credentials.list.length) {
+                                _verifyResult('error');
+                                return;
+                            }
+                            
+                            // Show a notification if the user tries to update credentials using the old password
+                            if (credentials[entryId].password === _tab.credentials.password) {
+                                showNotification('Error: Credentials not updated. The password has not been changed.');
+                                _close();
+                                return;
+                            }
+
+                            browser.runtime.sendMessage({
+                                action: 'update_credentials',
+                                args: [_tab.credentials.list[entryId].uuid, _tab.credentials.username, _tab.credentials.password, _tab.credentials.url]
+                            }).then(_verifyResult);
+                        });
                     });
 
                 if (_tab.credentials.usernameExists && _tab.credentials.username === _tab.credentials.list[i].login) {


### PR DESCRIPTION
When using context menu to save changed password the popup dialog is closed if no username is available.

This fix enables to use the username of the selected entry in the popup, and also disables the New button when no username is used for credential saving.

If user tries to update an old password (using the context menu from the old password's input field), a notification will be displayed and the popup is closed.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/211.