### PR TITLE
Allows a separate ID key for association

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -371,10 +371,13 @@ keepass.associate = function(callback, tab) {
         const key = nacl.util.encodeBase64(keepass.keyPair.publicKey);
         const nonce = keepass.getNonce();
         const incrementedNonce = keepass.incrementedNonce(nonce);
+        const idKeyPair = nacl.box.keyPair();
+        const idKey = nacl.util.encodeBase64(idKeyPair.publicKey);
 
         const messageData = {
             action: kpAction,
-            key: key
+            key: key,
+            idKey: idKey
         };
 
         const request = {
@@ -402,7 +405,7 @@ keepass.associate = function(callback, tab) {
                     keepass.handleError(tab, kpErrors.ASSOCIATION_FAILED);
                 }
                 else {
-                    keepass.setCryptoKey(id, key);    // Save the current public key as id key for the database
+                    keepass.setCryptoKey(id, idKey);    // Save the new identification public key as id key for the database
                     keepass.associated.value = true;
                     keepass.associated.hash = parsed.hash || 0;
                 }

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -8,7 +8,7 @@ Now the requests are encrypted by [TweetNaCl.js](https://github.com/dchest/tweet
 3. All messages between the browser extension and KeePassXC are now encrypted.
 4. When keepassxc-browser sends a message it is encrypted with KeePassXC's public key, a random generated nonce and keepassxc-browser's secret key.
 5. When KeePassXC sends a message it is encrypted with keepassxc-browser's public key and an incremented nonce.
-6. Databases are stored based on the current public key used with `associate`. A new key pair for data transfer is generated each time keepassxc-browser is launched. This saved key is not used again, as it's only used for identification.
+6. Databases are stored with newly created public key used with `associate`. A new key pair for data transfer is generated each time keepassxc-browser is launched. This saved key is not used again, as it's only used for identification.
 
 Encrypted messages are built with these JSON parameters:
 - action - `test-associate`, `associate`, `get-logins`, `get-logins-count`, `set-login`...
@@ -71,7 +71,8 @@ Unencrypted message:
 ```javascript
 {
 	"action": "associate",
-	"key": "<current public key>"
+	"key": "<current public key>",
+	"idKey": "<a new identification key>"
 }
 ```
 


### PR DESCRIPTION
When doing associations to multiple databases within the same session, the same public key is used as an identification key. This causes the connections to use identical keys.

This PR solves it by modifying the keepassxc-protocol to allow a separate `idKey` used for association.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/257.

Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/2185.