### PR TITLE
New values for element minimum size with isVisible()

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -902,7 +902,7 @@ cipFields.isVisible = function(field) {
     }
 
     // Check element position and size
-    if (rect.x < 0 || rect.y < 0 || rect.width < 16 || rect.height < 16) {
+    if (rect.x < 0 || rect.y < 0 || rect.width < 8 || rect.height < 8) {
         return false;
     }
 


### PR DESCRIPTION
`isVisible()` checks if element is in the page. Previously the input field minimum size was 16 pixels, which is still quite large. This PR halves the value.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/262.