### PR TITLE
Hide update message when updates are never checked

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -206,7 +206,7 @@ kpxcEvent.onCheckUpdateKeePassXC = function(callback, tab) {
 };
 
 kpxcEvent.onUpdateAvailableKeePassXC = function(callback, tab) {
-    callback(keepass.keePassXCUpdateAvailable());
+    callback(page.settings.checkUpdateKeePassXC > 0 ? keepass.keePassXCUpdateAvailable() : false);
 };
 
 kpxcEvent.onRemoveCredentialsFromTabInformation = function(callback, tab) {


### PR DESCRIPTION
Hides the update message of KeePassXC if the user has selected option `Never` from the settings.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/234.