### PR TITLE
Fix entering username manually

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -158,7 +158,12 @@ cipAutocomplete.onBlur = function() {
     else {
         const fieldId = cipFields.prepareId(jQuery(this).attr('data-cip-id'));
         const fields = cipFields.getCombination('username', fieldId);
-        if (_f(fields.password) && _f(fields.password).data('unchanged') !== true && jQuery(this).val() !== '' && _detectedFields > 1) {
+        const fieldValue = jQuery(this).val();
+
+        // Check if the manually inserted value is one of the retrieved credentials
+        let fieldFound = cipAutocomplete.elements.some(e => e.value === fieldValue);
+
+        if (_f(fields.password) && _f(fields.password).data('unchanged') !== true && fieldFound && _detectedFields > 1) {
             cip.fillInCredentials(fields, true, true);
         }
     }


### PR DESCRIPTION
When entering username manually, don't fill it automatically from the first autocomplete entry.
This fix doesn't fill the password field at all if the manually entered username is not one of the retrieved ones.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/288.