### PR TITLE
Handle single field login forms without error

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1809,7 +1809,7 @@ cip.fillIn = function(combination, onlyPassword, suppressWarnings) {
     // exactly one pair of credentials available
     if (cip.credentials.length === 1) {
         let filledIn = false;
-        if (uField && !onlyPassword) {
+        if (uField && (!onlyPassword || _singleInputEnabledForPage)) {
             cip.setValueWithChange(uField, cip.credentials[0].login);
             browser.runtime.sendMessage({
                 action: 'page_set_login_id', args: [0]


### PR DESCRIPTION
Hides `Cannot find fields to fill in` error on username-only pages.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/290.