### PR TITLE
Shortcut improvements

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -12,7 +12,7 @@
         "description": "Context menu item for filling password."
     },
     "contextMenuFillTOTP": {
-        "message": "Insert TOTP",
+        "message": "Fill TOTP",
         "description": "Context menu item for filling Time-based One Time Password."
     },
     "contextMenuShowPasswordGeneratorIcons": {
@@ -395,6 +395,10 @@
         "message": "About",
         "description": "About page header."
     },
+    "optionsButtonConfigureShortcuts": {
+        "message": " Configure shortcuts",
+        "description": "Keyboard shortcut button text."
+    },
     "optionsButtonSave": {
         "message": " Save",
         "description": "Save button text."
@@ -487,17 +491,9 @@
         "message": " never",
         "description": "Radio button text."
     },
-    "optionsGeneralHelpText": {
-        "message": "If you just want to insert username and password into the fields where your focus is, press $1",
-        "description": "Context menu help text."
-    },
-    "optionsGeneralHelpTextSecond": {
-        "message": "If you only want to insert the password, just press $1",
-        "description": "Context menu help text."
-    },
-    "optionsCustomizeCommandsHelpText": {
-        "message": "You can customize these shortcuts on page $1",
-        "descriptions": "Shortcut customize help text."
+    "optionsKeyboardShortcutsHeader": {
+        "message": "Keyboard shortcuts",
+        "description": "Keyboard shortcut header text."
     },
     "optionsBlinkTimeHelpText": {
         "message": "Maximum time (ms) the icon should blink after detecting new credentials",

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -29,13 +29,13 @@
       <div class="tab" id="tab-general-settings">
         <h2 data-i18n="optionsGeneralSettingsTab"></h2>
         <hr />
+        <h3 data-i18n="optionsKeyboardShortcutsHeader"></h3>
         <p>
-          <span data-i18n="optionsGeneralHelpText" i18n-placeholder="<code><span id='mac-user-shortcut'>Ctrl + Shift + U</span><span id='default-user-shortcut'>Alt + Shift + U</span></code>"></span>.
-          <br />
-          <span data-i18n="optionsGeneralHelpTextSecond" i18n-placeholder="<code><span id='mac-pass-shortcut'>Ctrl + Shift + I</span><span id='default-pass-shortcut'>Alt + Shift + I</span></code>"></span>.
-          <br />
-          <span id="chrome-only"><span data-i18n="optionsCustomizeCommandsHelpText" i18n-placeholder="<code>chrome://extensions/configureCommands</code>"></span></span>
+          <span data-i18n="contextMenuFillUsernameAndPassword"></span>: <span id="fill-username-password-shortcut">error</span><br />
+          <span data-i18n="contextMenuFillPassword"></span>: <span id="fill-password-shortcut">error</span><br />
+          <span data-i18n="contextMenuFillTOTP"></span>: <span id="fill-totp-shortcut">error</span>
         </p>
+        <p id="chrome-only"><button class="btn btn-sm btn-primary" id="configureCommands" type="button"><span class="glyphicon glyphicon-cog"></span><span data-i18n="optionsButtonConfigureShortcuts"/></button></p>
         <p>
           <div class="form-group">
             <label for="blinkTimeout" data-i18n="optionsLabelBlinkTime"></label>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -118,6 +118,18 @@ options.initGeneralSettings = function() {
     $('#blinkMinTimeout').val(options.settings['blinkMinTimeout']);
     $('#allowedRedirect').val(options.settings['allowedRedirect']);
 
+    browser.commands.getAll().then(function(commands) {
+        commands.forEach(function(command) {
+            var shortcut = document.getElementById(`${command.name}-shortcut`);
+            if (!shortcut) return;
+            shortcut.textContent = command.shortcut || 'not configured';
+        });
+    });
+
+    $('#configureCommands').click(function(){
+        browser.tabs.create({ url: 'chrome://extensions/configureCommands' });
+    });
+
     $('#blinkTimeoutButton').click(function(){
         const blinkTimeout = $.trim($('#blinkTimeout').val());
         const blinkTimeoutval = blinkTimeout !== '' ? Number(blinkTimeout) : defaultSettings.blinkTimeout;
@@ -370,7 +382,7 @@ options.initSitePreferences = function() {
             $('#tab-site-preferences table tbody:first').append(tr);
         }
     }
-    
+
     if ($('#tab-site-preferences table tbody:first tr').length > 2) {
         $('#tab-site-preferences table tbody:first tr.empty:first').hide();
     } else {
@@ -382,17 +394,5 @@ options.initAbout = function() {
     $('#tab-about em.versionCIP').text(browser.runtime.getManifest().version);
     if (isFirefox()) {
         $('#chrome-only').remove();
-    }
-
-    if (navigator.platform === 'MacIntel') {
-        $('#default-user-shortcut').hide();
-        $('#default-pass-shortcut').hide();
-        $('#mac-user-shortcut').show();
-        $('#mac-pass-shortcut').show();
-    } else {
-        $('#mac-user-shortcut').hide();
-        $('#mac-pass-shortcut').hide();
-        $('#default-user-shortcut').show();
-        $('#default-pass-shortcut').show();
     }
 };


### PR DESCRIPTION
- Get current shortcut keys.
- Add button that opens shortcut page, it can be opened by using `chrome.tabs.create()`.

Hi everyone. Thanks for a great tool and extension. I decided to make some small improvements to the explanations for the shortcuts and also a button that opens the page in Chrome where you can configure the shortcuts.

Although `chrome://extensions/configureCommands` now redirects to `chrome://extensions/shortcuts`, I left it as the old URL to be more backwards compatible.

I tested this in Firefox, and getting the shortcut keys work as expected. It is now possible to customize the shortcut keys in recent Firefox versions, but it is not as easy as in Chrome, since the extension must provide an input field and then trigger the update.

Hope you like it!