### PR TITLE
Fix unlocking the database

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -87,7 +87,7 @@ kpxcEvent.onShowNotification = function(callback, tab, message) {
 
 kpxcEvent.showStatus = function(configured, tab, callback) {
     let keyId = null;
-    if (configured) {
+    if (configured && keepass.databaseHash !== '') {
         keyId = keepass.keyRing[keepass.databaseHash].id;
     }
 

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1397,7 +1397,7 @@ cip.init = function() {
 // Switch credentials if database is changed or closed
 cip.detectDatabaseChange = function(response) {
     if (document.visibilityState !== 'hidden') {
-        if (response.new === 'no-hash' && response.old !== 'no-hash') {
+        if (response.new === '' && response.old !== '') {
             cipEvents.clearCredentials();
 
             browser.runtime.sendMessage({
@@ -1409,7 +1409,7 @@ cip.detectDatabaseChange = function(response) {
                 action: 'get_status',
                 args: [ true ]    // Set polling to true, this is an internal function call
             });
-        } else if (response.new !== 'no-hash' && response.new !== response.old) {
+        } else if (response.new !== '' && response.new !== response.old) {
             _called.retrieveCredentials = false;
             browser.runtime.sendMessage({
                 action: 'load_settings',

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>KeePassXC-Browser - Popup</title>
+    <title data-i18n="popupTitle"></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css" />
     <link rel="stylesheet" href="../options/bootstrap.min.css" />

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>KeePassXC - Popup</title>
+    <title data-i18n="popupTitle"></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css" />
     <link rel="stylesheet" href="../options/bootstrap.min.css" />
@@ -25,13 +25,23 @@
         </div>
       </div>
 
-      <div class="credentials">
+      <div id="credentialsList" class="credentials">
         <p data-i18n="popupLoginText"></p>
         <div id="filter-block" style="display: none;">
           <label for="login-filter" data-i18n="popupFilterText"></label>
           <input type="text" id="login-filter">
         </div>
         <div id="login-list" class="list-group"></div>
+      </div>
+
+       <div id="database-not-opened" style="display: none">
+        <p data-i18n="popupErrorEncountered"/>
+        <p style="margin-left: 1em">
+          <code id="database-error-message"></code>
+        </p>
+        <div style="text-align: right">
+          <button id="reopen-database-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-lock"></span><span data-i18n="popupReopenButton"/></button>
+        </div>
       </div>
     </div>
     <script type="text/javascript" src="../translate.js"></script>

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -49,5 +49,15 @@ $(function() {
         browser.runtime.sendMessage({
             action: 'lock-database'
         });
+        $('#credentialsList').hide();
+        $('#database-not-opened').show();
+        $('#database-error-message').html(tr('errorMessageDatabaseNotOpened'));
+    });
+
+    $('#reopen-database-button').click(function() {
+        browser.runtime.sendMessage({
+            action: 'get_status',
+            args: [ false, true ]    // Set forcePopup to true
+        });
     });
 });

--- a/keepassxc-browser/popups/popup_multiple-fields.html
+++ b/keepassxc-browser/popups/popup_multiple-fields.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>KeePassXC-Browser - Popup</title>
+    <title data-i18n="popupTitle"></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css" />
     <link rel="stylesheet" href="../options/bootstrap.min.css" />

--- a/keepassxc-browser/popups/popup_remember.html
+++ b/keepassxc-browser/popups/popup_remember.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>KeePassXC-Browser - Popup</title>
+    <title data-i18n="popupTitle"></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css" />
     <link rel="stylesheet" href="../options/bootstrap.min.css" />


### PR DESCRIPTION
When locking the database from the popup lock icon the database hashed are not updated properly to the contect script.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/305.
Fixes https://github.com/keepassxreboot/keepassxc/issues/2480.

Also modifies the login popup to a locked state after clicking the lock icon.