### PR TITLE
Make input field type detection case insensitive

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -1260,7 +1260,12 @@ cipObserverHelper.getInputs = function(target) {
     // Only include input fields that match with cipObserverHelper.inputTypes
     let inputs = [];
     for (const i of inputFields) {
-        if (cipObserverHelper.inputTypes.includes(i.getAttribute('type'))) {
+        let type = i.getAttribute('type');
+        if (type) {
+            type = type.toLowerCase();
+        }
+
+        if (cipObserverHelper.inputTypes.includes(type)) {
             inputs.push(i);
         }
     }


### PR DESCRIPTION
Allows `type="TEXT"` and other not-so-standard cases.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/313.
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/331.