### PR TITLE
refactor: return a promise instead of using a callback function

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -15,7 +15,7 @@ var _detectedFields = 0;
 // Element id's containing input fields detected by MutationObserver
 var _observerIds = [];
 
-browser.runtime.onMessage.addListener(function(req, sender, callback) {
+browser.runtime.onMessage.addListener(function(req, sender) {
     if ('action' in req) {
         if (req.action === 'fill_user_pass_with_specific_login') {
             if (cip.credentials[req.id]) {
@@ -63,10 +63,10 @@ browser.runtime.onMessage.addListener(function(req, sender, callback) {
             cipDefine.init();
         } else if (req.action === 'clear_credentials') {
             cipEvents.clearCredentials();
-            callback();
+            return Promise.resolve();
         } else if (req.action === 'activated_tab') {
             cipEvents.triggerActivatedTab();
-            callback();
+            return Promise.resolve();
         } else if (req.action === 'redetect_fields') {
             browser.runtime.sendMessage({
                 action: 'load_settings',


### PR DESCRIPTION
The callback-based api will soon be removed. `webextension-polyfill` logs a warning in the console:

> Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)

