### PR TITLE
Remove whitespaces from translation file

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -220,31 +220,31 @@
         "description": "Popup window title."
     },
     "popupSettingsText": {
-        "message": " Settings",
+        "message": "Settings",
         "description": "Popup Settings button text."
     },
     "popupChooseCredentialsText": {
-        "message": " Choose custom login fields for this page",
+        "message": "Choose custom login fields for this page",
         "description": "Popup credential choosing button text."
     },
     "popupConnectButton": {
-        "message": " Connect",
+        "message": "Connect",
         "description": "Popup Connect button text."
     },
     "popupReconnectButton": {
-        "message": " Reconnect",
+        "message": "Reconnect",
         "description": "Popup Reconnect button text."
     },
     "popupRedetectButton": {
-        "message": " Redetect login fields",
+        "message": "Redetect login fields",
         "description": "Popup Redetect login fields button text."
     },
     "popupReloadButton": {
-        "message": " Reload",
+        "message": "Reload",
         "description": "Popup Reload button text."
     },
     "popupReopenButton": {
-        "message": " Reopen database",
+        "message": "Reopen database",
         "description": "Popup reopen database button text."
     },
     "popupErrorEncountered": {
@@ -260,7 +260,7 @@
         "description": "Popup warning message link when KeePassXC version is not up-to-date."
     },
     "popupCheckingStatus": {
-        "message": " Checking status...",
+        "message": "Checking status...",
         "description": "Checking status message in popup."
     },
     "popupNotConfigured": {
@@ -328,15 +328,15 @@
         "description": "A username field name shown on credential update."
     },
     "popupButtonNew": {
-        "message": " New",
+        "message": "New",
         "description": "New button text in popup when updating credentials."
     },
     "popupButtonUpdate": {
-        "message": " Update",
+        "message": "Update",
         "description": "Update button text in popup when updating credentials."
     },
     "popupButtonDismiss": {
-        "message": " Dismiss",
+        "message": "Dismiss",
         "description": "Dismiss button text in popup when updating credentials."
     },
     "popupButtonIgnore": {
@@ -348,7 +348,7 @@
         "description": "Close button text in popup or in notification."
     },
     "popupButtonDismissHttpAuth": {
-        "message": " Dismiss and show the default authentication dialog",
+        "message": "Dismiss and show the default authentication dialog",
         "description": "Dismiss button text when in HTTP Authentication popup."
     },
     "optionsTitle": {
@@ -396,35 +396,35 @@
         "description": "About page header."
     },
     "optionsButtonConfigureShortcuts": {
-        "message": " Configure shortcuts",
+        "message": "Configure shortcuts",
         "description": "Keyboard shortcut button text."
     },
     "optionsButtonSave": {
-        "message": " Save",
+        "message": "Save",
         "description": "Save button text."
     },
     "optionsButtonConnect": {
-        "message": " Connect",
+        "message": "Connect",
         "description": "Connect button text."
     },
     "optionsButtonRemove": {
-        "message": " Remove",
+        "message": "Remove",
         "description": "Remove button text."
     },
     "optionsButtonAdd": {
-        "message": " Add",
+        "message": "Add",
         "description": "Add button text."
     },
     "optionsButtonUpdate": {
-        "message": " Check for updates",
+        "message": "Check for updates",
         "description": "Check for updates button text."
     },
     "optionsButtonRemoveNow": {
-        "message": " Yes, remove now",
+        "message": "Yes, remove now",
         "description": "Confirm button text when removing database key or custom login fields."
     },
     "optionsButtonCancel": {
-        "message": " Cancel",
+        "message": "Cancel",
         "description": "Cancel button text when removing database key or custom login fields."
     },
     "optionsLabelBlinkTime": {
@@ -476,19 +476,19 @@
         "description": "Text above radio buttons in the settings page."
     },
     "optionsRadioThreeDays": {
-        "message": " every 3 days",
+        "message": "every 3 days",
         "description": "Radio button text."
     },
     "optionsRadioWeek": {
-        "message": " every week",
+        "message": "every week",
         "description": "Radio button text."
     },
     "optionsRadioMonth": {
-        "message": " every month",
+        "message": "every month",
         "description": "Radio button text."
     },
     "optionsRadioNever": {
-        "message": " never",
+        "message": "never",
         "description": "Radio button text."
     },
     "optionsKeyboardShortcutsHeader": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -35,14 +35,14 @@
           <span data-i18n="contextMenuFillPassword"></span>: <span id="fill-password-shortcut">error</span><br />
           <span data-i18n="contextMenuFillTOTP"></span>: <span id="fill-totp-shortcut">error</span>
         </p>
-        <p id="chrome-only"><button class="btn btn-sm btn-primary" id="configureCommands" type="button"><span class="glyphicon glyphicon-cog"></span><span data-i18n="optionsButtonConfigureShortcuts"/></button></p>
+        <p id="chrome-only"><button class="btn btn-sm btn-primary" id="configureCommands" type="button"><span class="glyphicon glyphicon-cog"></span> <span data-i18n="optionsButtonConfigureShortcuts"/></button></p>
         <p>
           <div class="form-group">
             <label for="blinkTimeout" data-i18n="optionsLabelBlinkTime"></label>
             <div class="control-group">
               <div class="input-append">
                 <input type="number" id="blinkTimeout" placeholder="7500" value="7500" min="-1"/>
-                <button class="btn btn-sm btn-primary" id="blinkTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span><span data-i18n="optionsButtonSave"/></button>
+                <button class="btn btn-sm btn-primary" id="blinkTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> <span data-i18n="optionsButtonSave"/></button>
               </div>
             </div>
             <span class="help-inline">
@@ -58,7 +58,7 @@
             <div class="control-group">
               <div class="input-append">
                 <input type="number" id="blinkMinTimeout" placeholder="2000" value="2000" min="-1"/>
-                <button class="btn btn-sm btn-primary" id="blinkMinTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span><span data-i18n="optionsButtonSave"/></button>
+                <button class="btn btn-sm btn-primary" id="blinkMinTimeoutButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> <span data-i18n="optionsButtonSave"/></button>
               </div>
             </div>
             <span class="help-inline">
@@ -76,7 +76,7 @@
             <div class="control-group">
               <div class="input-append">
                 <input type="number" id="allowedRedirect" placeholder="1" value="1" min="1"/>
-                <button class="btn btn-sm btn-primary" id="allowedRedirectButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span><span data-i18n="optionsButtonSave"/></button>
+                <button class="btn btn-sm btn-primary" id="allowedRedirectButton" type="button"><span class="glyphicon glyphicon-floppy-disk"></span> <span data-i18n="optionsButtonSave"/></button>
               </div>
             </div>
             <span class="help-inline">
@@ -168,7 +168,7 @@
           </div>
           <div>
             <span data-i18n="optionsLatestVersion" i18n-placeholder="<em class='latestVersion'></em>"></span>
-            <button class="btn btn-sm btn-primary checkUpdateKeePassXC"><span class="glyphicon glyphicon-refresh"></span><span data-i18n="optionsButtonUpdate"/></button>
+            <button class="btn btn-sm btn-primary checkUpdateKeePassXC"><span class="glyphicon glyphicon-refresh"></span> <span data-i18n="optionsButtonUpdate"/></button>
           </div>
         </div>
         <hr />
@@ -211,12 +211,12 @@
               <td></td>
               <td class="last-used"></td>
               <td class="created"></td>
-              <td><button class="btn delete btn-danger"><span class="glyphicon glyphicon-remove-sign"></span><span data-i18n="optionsButtonRemove"></span></button></td>
+              <td><button class="btn delete btn-danger"><span class="glyphicon glyphicon-remove-sign"></span> <span data-i18n="optionsButtonRemove"></span></button></td>
             </tr>
           </tbody>
         </table>
         <div style="text-align: right">
-          <button id="connect-button" class="btn btn-primary"><span class="glyphicon glyphicon-link"></span><span data-i18n="optionsButtonConnect"></span></button>
+          <button id="connect-button" class="btn btn-primary"><span class="glyphicon glyphicon-link"></span> <span data-i18n="optionsButtonConnect"></span></button>
         </div>
 
         <div id="dialogDeleteConnectedDatabase" class="modal fade" tabindex="-1" role="dialog">
@@ -232,8 +232,8 @@
                 <p class="help-block" data-i18n="optionsDatabasesRemoveIdentifierConfirmSecond"></p>
               </div>
               <div class="modal-footer">
-                <button class="btn" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span><span data-i18n="optionsButtonCancel"></span></button>
-                <button class="btn yes btn-primary"><span class="glyphicon glyphicon-ok"></span><span data-i18n="optionsButtonRemoveNow"></span></button>
+                <button class="btn" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="optionsButtonCancel"></span></button>
+                <button class="btn yes btn-primary"><span class="glyphicon glyphicon-ok"></span> <span data-i18n="optionsButtonRemoveNow"></span></button>
               </div>
             </div>
           </div>
@@ -264,7 +264,7 @@
             </tr>
             <tr class="clone">
               <td></td>
-              <td><button class="btn delete btn-danger btn"><span class="glyphicon glyphicon-remove-sign"></span><span data-i18n="optionsButtonRemove"></span></button></td>
+              <td><button class="btn delete btn-danger btn"><span class="glyphicon glyphicon-remove-sign"></span> <span data-i18n="optionsButtonRemove"></span></button></td>
             </tr>
           </tbody>
         </table>
@@ -280,8 +280,8 @@
                 <p class="help-block" data-i18n="optionsCustomFieldsConfirmationHelpText"></p>
               </div>
               <div class="modal-footer">
-                <button class="btn" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span><span data-i18n="optionsButtonCancel"></span></button>
-                <button class="btn yes btn-primary"><span class="glyphicon glyphicon-ok"></span><span data-i18n="optionsButtonRemoveNow"></span></button>
+                <button class="btn" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="optionsButtonCancel"></span></button>
+                <button class="btn yes btn-primary"><span class="glyphicon glyphicon-ok"></span> <span data-i18n="optionsButtonRemoveNow"></span></button>
               </div>
             </div>
           </div>
@@ -307,7 +307,7 @@
           <div class="control-group">
             <div class="input-append">
               <input type="url" id="manualUrl"/>
-              <button class="btn btn-sm btn-primary" id="sitePreferencesManualAdd" type="button"><span class="glyphicon glyphicon-plus-sign"></span><span data-i18n="optionsButtonAdd"></span></button>
+              <button class="btn btn-sm btn-primary" id="sitePreferencesManualAdd" type="button"><span class="glyphicon glyphicon-plus-sign"></span> <span data-i18n="optionsButtonAdd"></span></button>
             </div>
           </div>
         </div>
@@ -335,7 +335,7 @@
                 </select>
               </td>
               <td><input type="checkbox" name="usernameOnly" value="false" /></td>
-              <td><button class="btn delete btn-danger btn"><span class="glyphicon glyphicon-remove-sign"></span><span data-i18n="optionsButtonRemove"></span></button></td>
+              <td><button class="btn delete btn-danger btn"><span class="glyphicon glyphicon-remove-sign"></span> <span data-i18n="optionsButtonRemove"></span></button></td>
             </tr>
           </tbody>
         </table>
@@ -351,8 +351,8 @@
                 <p class="help-block" data-i18n="optionsSitePreferencesConfirmationHelpText"></p>
               </div>
               <div class="modal-footer">
-                <button class="btn" data-dismiss="modal" aria-hidden="true"><span data-i18n="optionsButtonCancel"></span></button>
-                <button class="btn yes btn-primary"><span data-i18n="optionsButtonRemoveNow"></span></button>
+                <button class="btn" data-dismiss="modal" aria-hidden="true"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="optionsButtonCancel"></span></button>
+                <button class="btn yes btn-primary"><span class="glyphicon glyphicon-ok"></span> <span data-i18n="optionsButtonRemoveNow"></span></button>
               </div>
             </div>
           </div>

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -14,8 +14,8 @@
   <body>
     <div class="container">
       <div id="settings" class="settings">
-        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span><span data-i18n="popupSettingsText"/></button>
-        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span><span data-i18n="popupChooseCredentialsText"/></button>
+        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span> <span data-i18n="popupSettingsText"/></button>
+        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupChooseCredentialsText"/></button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
         <div id="update-available" class="alert alert-danger">
@@ -26,13 +26,13 @@
       </div>
 
       <div id="initial-state">
-        <p><img style="margin-right: 1em" src="throbber.gif"/><span data-i18n="popupCheckingStatus"/></p>
+        <p><img style="margin-right: 1em" src="throbber.gif"/> <span data-i18n="popupCheckingStatus"/></p>
       </div>
 
       <div id="not-configured" style="display: none">
         <p data-i18n="popupNotConfigured"/>
         <div style="text-align: right">
-          <button id="connect-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-link"></span><span data-i18n="popupConnectButton"/></button>
+          <button id="connect-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-link"></span> <span data-i18n="popupConnectButton"/></button>
         </div>
       </div>
 
@@ -43,7 +43,7 @@
         </p>
         <p data-i18n="popupNeedReconfigureMessage"/>
         <div style="text-align: right">
-          <button id="reconnect-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-refresh"></span><span data-i18n="popupReconnectButton"/></button>
+          <button id="reconnect-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-refresh"></span> <span data-i18n="popupReconnectButton"/></button>
         </div>
       </div>
 
@@ -54,7 +54,7 @@
       <div id="configured-and-associated" style="display: none">
         <span data-i18n="popupConfiguredAndAssociated" i18n-placeholder="<span class='bg-success' id='associated-identifier'></span>"></span>
         <div style="text-align: right">
-          <button id="redetect-fields-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-list-alt"></span><span data-i18n="popupRedetectButton"/></button>
+          <button id="redetect-fields-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupRedetectButton"/></button>
         </div>
       </div>
 
@@ -64,7 +64,7 @@
           <code id="error-message"></code>
         </p>
         <div style="text-align: right">
-          <button id="reload-status-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-refresh"></span><span data-i18n="popupReloadButton"/></button>
+          <button id="reload-status-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-refresh"></span> <span data-i18n="popupReloadButton"/></button>
         </div>
       </div>
 
@@ -74,7 +74,7 @@
           <code id="database-error-message"></code>
         </p>
         <div style="text-align: right">
-          <button id="reopen-database-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-lock"></span><span data-i18n="popupReopenButton"/></button>
+          <button id="reopen-database-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-lock"></span> <span data-i18n="popupReopenButton"/></button>
         </div>
       </div>
     </div>

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -14,8 +14,8 @@
   <body>
     <div class="container">
       <div id="settings" class="settings">
-        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span><span data-i18n="popupSettingsText"/></button>
-        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span><span data-i18n="popupChooseCredentialsText"/></button>
+        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span> <span data-i18n="popupSettingsText"/></button>
+        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupChooseCredentialsText"/></button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
         <div id="update-available" class="alert alert-danger">
@@ -29,7 +29,7 @@
         <p data-i18n="popupAuthText"></p>
         <div id="login-list" class="list-group"></div>
         <p>
-          <button id="btn-dismiss" class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-remove"></span><span data-i18n="popupButtonDismissHttpAuth"/></button>
+          <button id="btn-dismiss" class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="popupButtonDismissHttpAuth"/></button>
         </p>
       </div>
     </div>

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -14,8 +14,8 @@
   <body>
     <div class="container">
       <div id="settings" class="settings">
-        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span><span data-i18n="popupSettingsText"/></button>
-        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span><span data-i18n="popupChooseCredentialsText"/></button>
+        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span> <span data-i18n="popupSettingsText"/></button>
+        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupChooseCredentialsText"/></button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
         <div id="update-available" class="alert alert-danger">

--- a/keepassxc-browser/popups/popup_multiple-fields.html
+++ b/keepassxc-browser/popups/popup_multiple-fields.html
@@ -13,8 +13,8 @@
   <body>
     <div class="container">
       <div id="settings" class="settings">
-        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span><span data-i18n="popupSettingsText"/></button>
-        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span><span data-i18n="popupChooseCredentialsText"/></button>
+        <button id="btn-options" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-cog"></span> <span data-i18n="popupSettingsText"/></button>
+        <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupChooseCredentialsText"/></button>
         <button id="lock-database-button" class="btn btn-danger" title="Lock database"><span class="glyphicon glyphicon-lock"></span></button>
 
         <div id="update-available" class="alert alert-danger">

--- a/keepassxc-browser/popups/popup_remember.html
+++ b/keepassxc-browser/popups/popup_remember.html
@@ -30,10 +30,10 @@
         <span class="small" data-i18n="popupUsername"></span><span class="small info information-username"></span>
       </p>
       <p>
-        <button id="btn-new" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-pencil"></span><span data-i18n="popupButtonNew"></span></button>
-        <button id="btn-update" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-refresh"></span><span data-i18n="popupButtonUpdate"></span></button>
-        <button id="btn-dismiss" class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-remove"></span><span data-i18n="popupButtonDismiss"></span></button>
-        <button id="btn-ignore" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-remove"></span><span data-i18n="popupButtonIgnore"></span></button> <!--missing-->
+        <button id="btn-new" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-pencil"></span> <span data-i18n="popupButtonNew"></span></button>
+        <button id="btn-update" class="btn btn-sm btn-warning"><span class="glyphicon glyphicon-refresh"></span> <span data-i18n="popupButtonUpdate"></span></button>
+        <button id="btn-dismiss" class="btn btn-sm btn-danger"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="popupButtonDismiss"></span></button>
+        <button id="btn-ignore" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-remove"></span> <span data-i18n="popupButtonIgnore"></span></button>
       </p>
     </div>
 


### PR DESCRIPTION
Removes the unnecessary whitespaces from translation file and inserts them in the HTML files instead. Glyphicons with appended text need an extra space inside buttons.