### PR TITLE
Enable all features when adding site manually to Site Preferences

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -334,11 +334,11 @@ options.initSitePreferences = function() {
             tr.data('url', value);
             tr.attr('id', 'tr-scf' + newValue);
             tr.children('td:first').text(value);
-            tr.children('td:nth-child(2)').children('select').val(IGNORE_NORMAL);
+            tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
             $('#tab-site-preferences table tbody:first').append(tr);
             $('#tab-site-preferences table tbody:first tr.empty:first').hide();
 
-            options.settings['sitePreferences'].push({url: value, ignore: IGNORE_NORMAL, usernameOnly: false});
+            options.settings['sitePreferences'].push({url: value, ignore: IGNORE_NOTHING, usernameOnly: false});
             options.saveSettings();
 
             $('#manualUrl').val('');


### PR DESCRIPTION
There's no need to disable new/modified logins when adding the site manually from extension settings. Modify the value to `Enable all features`.