### PR TITLE
Retrieve credentials with HTTP Basic Auth option added

### DIFF
--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -51,7 +51,7 @@ httpAuth.retrieveCredentials = function(tabId, url, submitUrl, forceCallback) {
     return new Promise((resolve, reject) => {
         keepass.retrieveCredentials((logins) => {
             resolve(logins);
-        }, tabId, url, submitUrl, forceCallback);
+        }, tabId, url, submitUrl, forceCallback, false, true);
     });
 };
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -194,7 +194,7 @@ keepass.updateCredentials = function(callback, tab, entryId, username, password,
     });
 };
 
-keepass.retrieveCredentials = function(callback, tab, url, submiturl, forceCallback, triggerUnlock = false) {
+keepass.retrieveCredentials = function(callback, tab, url, submiturl, forceCallback, triggerUnlock = false, httpAuth = false) {
     page.debug('keepass.retrieveCredentials(callback, {1}, {2}, {3}, {4})', tab.id, url, submiturl, forceCallback);
 
     keepass.testAssociation((response) => {
@@ -238,6 +238,10 @@ keepass.retrieveCredentials = function(callback, tab, url, submiturl, forceCallb
 
         if (submiturl) {
             messageData.submitUrl = submiturl;
+        }
+
+        if (httpAuth) {
+            messageData.httpAuth = 'true';
         }
 
         const request = {

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -160,6 +160,7 @@ Unencrypted message:
 	"action": "get-logins",
 	"url": "<snip>",
 	"submitUrl": optional,
+	"httpAuth": optional,
 	"keys": [
 		{
 			"id": <connected_id>,


### PR DESCRIPTION
When retrieving credentials from HTTP Basic Auth dialogs, an additional option is added to the request. KeePassXC side handles the permissions for HTTP Basic Auth separetely. If an older KeePassXC version is used, this extra parameter has no affect.

Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/2542

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/273.
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/342.

This requires KeePassXC 2.4.0 so merging this will have to wait.