### PR TITLE
Disable browserAction update loop

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -13,9 +13,6 @@ keepass.migrateKeyRing().then(() => {
     });
 });
 
-// Milliseconds for intervall (e.g. to update browserAction)
-const _interval = 250;
-
 /**
  * Generate information structure for created tab and invoke all needed
  * functions if tab is created in foreground
@@ -136,8 +133,3 @@ browser.commands.onCommand.addListener((command) => {
         });
     }
 });
-
-// Interval which updates the browserAction (e.g. blinking icon)
-window.setInterval(function() {
-    browserAction.update(_interval);
-}, _interval);


### PR DESCRIPTION
Disables an unnecessary loop from `init.js` that is only used for blinking the extension popup icon. This caused constant CPU usage. It is moved to `browserAction.js` instead, and it's only used when needed.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/348.