### PR TITLE
[WIP] Automatic reconnect

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -451,6 +451,10 @@
         "message": "Automatically retrieve credentials.",
         "description": "Automatically retrieve credentials checkbox text."
     },
+    "optionsCheckboxAutomaticReconnect": {
+        "message": "Automatically reconnect to KeePassXC.",
+        "description": "Auto-reconnect checkbox text."
+    },
     "optionsCheckboxAutoFillSingleEntry": {
         "message": "Automatically fill in single-credential entries.",
         "description": "Automatically fill-in single credential entry checkbox text."
@@ -526,6 +530,10 @@
     "optionsAutoRetrieveCredentialsHelpText": {
         "message": "KeePassXC-Browser will immediately retrieve credentials when a tab is activated.",
         "description": "Auto-Retrive Credentials option help text."
+    },
+    "optionsAutomaticReconnectHelpText": {
+        "message": "Reconnects automatically to KeePassXC when it is detected.",
+        "description": "Auto-reconnect option help text."
     },
     "optionsAutoFillSingleEntryHelpText": {
         "message": "Let KeePassXC-Browser automatically fill in credentials if it receives only a single entry.",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -285,6 +285,8 @@ kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
     'associate': keepass.associate,
     'check_update_keepassxc': kpxcEvent.onCheckUpdateKeePassXC,
+    'enable_automatic_reconnect': keepass.enableAutomaticReconnect,
+    'disable_automatic_reconnect': keepass.disableAutomaticReconnect,
     'generate_password': keepass.generatePassword,
     'get_connected_database': kpxcEvent.onGetConnectedDatabase,
     'get_keepassxc_versions': kpxcEvent.onGetKeePassXCVersions,

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -7,6 +7,7 @@ keepass.migrateKeyRing().then(() => {
             keepass.connectToNative();
             keepass.generateNewKeyPair();
             keepass.changePublicKeys(null).then((pkRes) => {
+                keepass.enableAutomaticReconnect();
                 keepass.getDatabaseHash((gdRes) => {}, null);
             });
         });

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -9,7 +9,8 @@ const defaultSettings = {
     autoRetrieveCredentials: true,
     showNotifications: true,
     showLoginNotifications: true,
-    saveDomainOnly: true
+    saveDomainOnly: true,
+    automaticReconnect: true
 };
 
 var page = {};
@@ -48,6 +49,9 @@ page.initSettings = function() {
             }
             if (!('saveDomainOnly' in page.settings)) {
                 page.settings.saveDomainOnly = defaultSettings.saveDomainOnly;
+            }
+            if (!('automaticReconnect' in page.settings)) {
+                page.settings.automaticReconnect = defaultSettings.automaticReconnect;
             }
             browser.storage.local.set({'settings': page.settings});
             resolve(page.settings);

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -111,6 +111,15 @@
         <p>
           <div class="checkbox">
             <label class="checkbox">
+              <input type="checkbox" name="automaticReconnect" value="true" /><span data-i18n="optionsCheckboxAutomaticReconnect"/>
+            </label>
+            <span class="help-block" data-i18n="optionsAutomaticReconnectHelpText"></span>
+          </div>
+        </p>
+        <hr />
+        <p>
+          <div class="checkbox">
+            <label class="checkbox">
               <input type="checkbox" name="autoFillSingleEntry" value="false" /><span data-i18n="optionsCheckboxAutoFillSingleEntry"/>
             </label>
             <span class="help-block" data-i18n="optionsAutoFillSingleEntryHelpText"></span>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -84,9 +84,12 @@ options.initGeneralSettings = function() {
     $('#tab-general-settings input[type=checkbox]').change(function() {
         const name = $(this).attr('name');
         options.settings[name] = $(this).is(':checked');
-        options.saveSettingsPromise().then((x) => {
+        options.saveSettingsPromise().then((updated) => {
             if (name === 'autoFillAndSend') {
                 browser.runtime.sendMessage({action: 'init_http_auth'});
+            } else if (name == 'automaticReconnect') {
+                const message = updated.automaticReconnect ? 'enable_automatic_reconnect' : 'disable_automatic_reconnect';
+                browser.runtime.sendMessage({action: message});
             }
         });
     });


### PR DESCRIPTION
Automatic reconnect reimplemented. Added an option which is enabled by default. Enabling or disabling it affects directly to the automatic reconnect mechanism.

It is disabled for Windows if KeePassXC is older than 2.3.4. This is because of the process spawning behaviour in Chromium-based browsers which needed a special handling to the KeePassXC side.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/264.
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/422.