### PR TITLE
Fix race conditions

### DIFF
--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -18,74 +18,6 @@ var _observerIds = [];
 // Document URL
 let _documentURL = document.location.href;
 
-browser.runtime.onMessage.addListener(function(req, sender, callback) {
-    if ('action' in req) {
-        if (req.action === 'fill_user_pass_with_specific_login') {
-            if (cip.credentials[req.id]) {
-                let combination = null;
-                if (cip.u) {
-                    cip.setValueWithChange(cip.u, cip.credentials[req.id].login);
-                    combination = cipFields.getCombination('username', cip.u);
-                    browser.runtime.sendMessage({
-                        action: 'page_set_login_id', args: [req.id]
-                    });
-                    cip.u.focus();
-                }
-                if (cip.p) {
-                    cip.setValueWithChange(cip.p, cip.credentials[req.id].password);
-                    browser.runtime.sendMessage({
-                        action: 'page_set_login_id', args: [req.id]
-                    });
-                    combination = cipFields.getCombination('password', cip.p);
-                }
-
-                let list = [];
-                if (cip.fillInStringFields(combination.fields, cip.credentials[req.id].stringFields, list)) {
-                    cipForm.destroy(false, {'password': list.list[0], 'username': list.list[1]});
-                }
-            }
-        } else if (req.action === 'fill_user_pass') {
-            _called.manualFillRequested = 'both';
-            cip.receiveCredentialsIfNecessary().then((response) => {
-                cip.fillInFromActiveElement(false);
-            });
-        } else if (req.action === 'fill_pass_only') {
-            _called.manualFillRequested = 'pass';
-            cip.receiveCredentialsIfNecessary().then((response) => {
-                cip.fillInFromActiveElement(false, true); // passOnly to true
-            });
-        } else if (req.action === 'fill_totp') {
-            cip.receiveCredentialsIfNecessary().then((response) => {
-                cip.fillInFromActiveElementTOTPOnly(false);
-            });
-        } else if (req.action === 'activate_password_generator') {
-            cip.initPasswordGenerator(cipFields.getAllFields());
-        } else if (req.action === 'remember_credentials') {
-            cip.contextMenuRememberCredentials();
-        } else if (req.action === 'choose_credential_fields') {
-            cipDefine.init();
-        } else if (req.action === 'clear_credentials') {
-            cipEvents.clearCredentials();
-            return Promise.resolve();
-        } else if (req.action === 'activated_tab') {
-            cipEvents.triggerActivatedTab();
-            return Promise.resolve();
-        } else if (req.action === 'redetect_fields') {
-            browser.runtime.sendMessage({
-                action: 'load_settings',
-            }).then((response) => {
-                cip.settings = response;
-                cip.initCredentialFields(true);
-            });
-        } else if (req.action === 'ignore-site') {
-            cip.ignoreSite(req.args);
-        }
-        else if (req.action === 'check_database_hash' && 'hash' in req) {
-            cip.detectDatabaseChange(req.hash);
-        }
-    }
-});
-
 function _f(fieldId) {
     const field = (fieldId) ? jQuery('input[data-cip-id=\''+fieldId+'\']:first') : [];
     return (field.length > 0) ? field : null;
@@ -1501,6 +1433,7 @@ cip.initCredentialFields = function(forceCall) {
         }
 
         if (cip.settings.autoRetrieveCredentials && _called.retrieveCredentials === false && (cip.url && cip.submitUrl)) {
+            _called.retrieveCredentials = true;
             browser.runtime.sendMessage({
                 action: 'retrieve_credentials',
                 args: [ cip.url, cip.submitUrl ]

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -58,6 +58,16 @@
             ],
             "run_at": "document_idle",
             "all_frames": true
+        },
+        {
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": [
+                "requests.js"
+            ],
+            "run_at": "document_idle",
+            "all_frames": false
         }
     ],
     "commands": {

--- a/keepassxc-browser/requests.js
+++ b/keepassxc-browser/requests.js
@@ -1,0 +1,69 @@
+'use strict';
+
+browser.runtime.onMessage.addListener(function(req, sender) {
+    if ('action' in req) {
+        if (req.action === 'fill_user_pass_with_specific_login') {
+            if (cip.credentials[req.id]) {
+                let combination = null;
+                if (cip.u) {
+                    cip.setValueWithChange(cip.u, cip.credentials[req.id].login);
+                    combination = cipFields.getCombination('username', cip.u);
+                    browser.runtime.sendMessage({
+                        action: 'page_set_login_id', args: [req.id]
+                    });
+                    cip.u.focus();
+                }
+                if (cip.p) {
+                    cip.setValueWithChange(cip.p, cip.credentials[req.id].password);
+                    browser.runtime.sendMessage({
+                        action: 'page_set_login_id', args: [req.id]
+                    });
+                    combination = cipFields.getCombination('password', cip.p);
+                }
+
+                let list = [];
+                if (cip.fillInStringFields(combination.fields, cip.credentials[req.id].stringFields, list)) {
+                    cipForm.destroy(false, {'password': list.list[0], 'username': list.list[1]});
+                }
+            }
+        } else if (req.action === 'fill_user_pass') {
+            _called.manualFillRequested = 'both';
+            cip.receiveCredentialsIfNecessary().then((response) => {
+                cip.fillInFromActiveElement(false);
+            });
+        } else if (req.action === 'fill_pass_only') {
+            _called.manualFillRequested = 'pass';
+            cip.receiveCredentialsIfNecessary().then((response) => {
+                cip.fillInFromActiveElement(false, true); // passOnly to true
+            });
+        } else if (req.action === 'fill_totp') {
+            cip.receiveCredentialsIfNecessary().then((response) => {
+                cip.fillInFromActiveElementTOTPOnly(false);
+            });
+        } else if (req.action === 'activate_password_generator') {
+            cip.initPasswordGenerator(cipFields.getAllFields());
+        } else if (req.action === 'remember_credentials') {
+            cip.contextMenuRememberCredentials();
+        } else if (req.action === 'choose_credential_fields') {
+            cipDefine.init();
+        } else if (req.action === 'clear_credentials') {
+            cipEvents.clearCredentials();
+            return Promise.resolve();
+        } else if (req.action === 'activated_tab') {
+            cipEvents.triggerActivatedTab();
+            return Promise.resolve();
+        } else if (req.action === 'redetect_fields') {
+            browser.runtime.sendMessage({
+                action: 'load_settings',
+            }).then((response) => {
+                cip.settings = response;
+                cip.initCredentialFields(true);
+            });
+        } else if (req.action === 'ignore-site') {
+            cip.ignoreSite(req.args);
+        }
+        else if (req.action === 'check_database_hash' && 'hash' in req) {
+            cip.detectDatabaseChange(req.hash);
+        }
+    }
+});


### PR DESCRIPTION
Moves the `browser.runtime.onMessage` listener to a separate file that is loaded to content scripts with setting `all_frames=false`. Previously all keyboard and context menu shortcuts were executed in all frames. If the web page has several frames, the message listener is loaded several times, causing simultanous requests to KeePassXC (e.g. `retrieve_credentials`) which can cause race conditions.

Using the context menu or keyboards shortcuts must be handled only **once**.

A good example for this is the website [www.kayak.com](https://www.kayak.com). Previously, if the user wants to fill the username and password from the context menu, three simultaneous requests (one by each frame) will be made. Two of those are identical. The requests are:
- `https://staticxx.facebook.com`
- `https://www.kayak.com`
- `https://www.kayak.com`

With this PR this is eliminated, and the request are only made once with the correct URL.