### PR TITLE
Clearer error messages

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -52,16 +52,16 @@
         "description": "Cannot decrypt message."
     },
     "errorMessageTimeout": {
-        "message": "Timeout or not connected to KeePassXC.",
-        "description": "Timeout or not connected to KeePassXC."
+        "message": "Cannot connect to KeePassXC. Check that browser integration is enabled in KeePassXC settings.",
+        "description": "Cannot connect to KeePassXC. Check that browser integration is enabled in KeePassXC settings."
     },
     "errorMessageCanceled": {
         "message": "Action canceled or denied.",
         "description": "Action canceled or denied."
     },
     "errorMessageEncrypt": {
-        "message": "Cannot encrypt message or public key not found. Is native messaging or support for your browser enabled in KeePassXC?",
-        "description": "Cannot encrypt message or public key not found. Is native messaging or support for your browser enabled in KeePassXC?"
+        "message": "Message encryption failed. Is KeePassXC running?",
+        "description": "Message encryption failed. Is KeePassXC running?"
     },
     "errorMessageAssociate": {
         "message": "KeePassXC association failed, try again.",

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -52,7 +52,7 @@
       </div>
 
       <div id="configured-and-associated" style="display: none">
-        <span data-i18n="popupConfiguredAndAssociated" i18n-placeholder="<span class='bg-success' id='associated-identifier'></span>"></span>
+        <p data-i18n="popupConfiguredAndAssociated" i18n-placeholder="<span class='bg-success' id='associated-identifier'></span>"></p>
         <div style="text-align: right">
           <button id="redetect-fields-button" class="btn btn-sm btn-primary"><span class="glyphicon glyphicon-list-alt"></span> <span data-i18n="popupRedetectButton"/></button>
         </div>


### PR DESCRIPTION
Modify the error messages to be a little more clearer.  The previous error messages are not clear enough to describe the error situation.

Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/2622

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/261.
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/312.