### PR TITLE
Minor fixes for release 1.33

### DIFF
--- a/keepassxc-browser/keepassxc-browser.css
+++ b/keepassxc-browser/keepassxc-browser.css
@@ -7,6 +7,10 @@
     color: #222222 !important;
 }
 
+.kpxc .ui-menu {
+    z-index: 10000;
+}
+
 .ui-helper-hidden-accessible {
     display: none !important;
 }

--- a/keepassxc-browser/keepassxc-browser.js
+++ b/keepassxc-browser/keepassxc-browser.js
@@ -194,7 +194,7 @@ cipAutocomplete.onFocus = function(e) {
 
 // Search for isTrusted from jQuery's originalEvent
 cipAutocomplete.isTrusted = function(e) { 
-    for (let f = e.originalEvent; f !== null; f = f.originalEvent) {
+    for (let f = e.originalEvent; f; f = f.originalEvent) {
         if (f.isTrusted !== undefined) {
             return f.isTrusted;
         }


### PR DESCRIPTION
- Put the password generator icon in the background when autocomplete menu is active
- Simplify the isTrusted() function and prevent use of `undefined`