### PR TITLE
Tiny fix for autocomplete.css

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -1,6 +1,5 @@
 .kpxcAutocomplete-items {
     position: absolute !important;
-    border: 1px solid #d4d4d4;
 }
 
 .kpxcAutocomplete-items div {
@@ -8,6 +7,8 @@
     cursor: pointer;
     background-color: #fff; 
     border-bottom: 1px solid #d4d4d4;
+    border-left: 1px solid #d4d4d4;
+    border-right: 1px solid #d4d4d4;
     width: auto;
     color: #000;
     font-size: .9em !important;
@@ -16,4 +17,5 @@
 .kpxcAutocomplete-active {
     background-color: #6cac4d !important; 
     color: #ffffff !important;
+    border: 0px !important;
 }


### PR DESCRIPTION
Remove borders from autocomplete menu. It's a bit easier for the eye.

Before:
![Screen Shot 2019-04-21 at 9 44 51](https://user-images.githubusercontent.com/24570482/56466529-1ecb1b80-641c-11e9-8e17-d4be2859a322.png)

After:
![Screen Shot 2019-04-21 at 9 56 50](https://user-images.githubusercontent.com/24570482/56466531-24286600-641c-11e9-9965-ef3ddc319a00.png)
