### PR TITLE
Add option for auto-submit

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -535,6 +535,14 @@
         "message": "Activate autocomplete for username fields.",
         "description": "Activate autocomplete for username fields checkbox text."
     },
+    "optionsCheckboxAutoSubmit": {
+        "message": "Auto-submit login forms",
+        "description": "Auto-submit checkbox text."
+    },
+    "optionsAutoSubmitHelpText": {
+        "message": "Automatically submits selected credentials. This is disabled for single entry auto-fill.",
+        "description": "Auto-submit help text."
+    },
     "optionsCheckboxShowNotifications": {
         "message": "Show notifications.",
         "description": "Show notifications checkbox text."
@@ -878,5 +886,9 @@
     "httpAuthDialog": {
         "message": "HTTP Basic Authentication dialog",
         "description": "Options page HTTP Basic Auth dialog text"
+    },
+    "autocompleteSubmitMessage": {
+        "message": "Your selection will be auto-submitted",
+        "description": "Message shown at the bottom of autocomplete menu."
     }
 }

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -6,6 +6,7 @@ const defaultSettings = {
     autoFillAndSend: false,
     usePasswordGenerator: true,
     autoFillSingleEntry: false,
+    autoSubmit: false,
     autoRetrieveCredentials: true,
     showNotifications: true,
     showLoginNotifications: true,
@@ -39,6 +40,9 @@ page.initSettings = function() {
             }
             if (!('autoFillSingleEntry' in page.settings)) {
                 page.settings.autoFillSingleEntry = defaultSettings.autoFillSingleEntry;
+            }
+            if (!('autoSubmit' in page.settings)) {
+                page.settings.autoSubmit = defaultSettings.autoSubmit;
             }
             if (!('autoRetrieveCredentials' in page.settings)) {
                 page.settings.autoRetrieveCredentials = defaultSettings.autoRetrieveCredentials;

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -3,7 +3,7 @@
 var kpxcAutocomplete = {};
 kpxcAutocomplete.elements = [];
 
-kpxcAutocomplete.create = function(input, showListInstantly = false) {
+kpxcAutocomplete.create = function(input, showListInstantly = false, autoSubmit = false) {
     let _index = -1;
 
     input.addEventListener('click', function(e) {
@@ -65,6 +65,12 @@ kpxcAutocomplete.create = function(input, showListInstantly = false) {
             });
 
             div.appendChild(item);
+        }
+
+        // Add a footer message for auto-submit
+        if (autoSubmit) {
+            const footer = kpxcUI.createElement('footer', '', {}, tr('autocompleteSubmitMessage'));
+            div.appendChild(footer);
         }
 
         // Activate the first item automatically

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -942,9 +942,6 @@ kpxc.prepareFieldsForCredentials = function(autoFillInForSingle) {
             action: 'popup_login',
             args: [ [ kpxc.credentials[0].login + ' (' + kpxc.credentials[0].name + ')' ] ]
         });
-
-        // Auto-submit
-        kpxc.p.form.submit();
     } else if (kpxc.credentials.length > 1 || (kpxc.credentials.length > 0 && (!kpxc.settings.autoFillSingleEntry || !autoFillInForSingle))) {
         kpxc.preparePageForMultipleCredentials(kpxc.credentials);
     }
@@ -978,14 +975,14 @@ kpxc.preparePageForMultipleCredentials = function(credentials) {
             // Both username and password fields are visible
             if (_detectedFields >= 2) {
                 if (_f(i.username)) {
-                    kpxcAutocomplete.create(_f(i.username));
+                    kpxcAutocomplete.create(_f(i.username), false, kpxc.settings.autoSubmit);
                 }
             } else if (_detectedFields === 1) {
                 if (_f(i.username)) {
-                    kpxcAutocomplete.create(_f(i.username));
+                    kpxcAutocomplete.create(_f(i.username), false, kpxc.settings.autoSubmit);
                 }
                 if (_f(i.password)) {
-                    kpxcAutocomplete.create(_f(i.password));
+                    kpxcAutocomplete.create(_f(i.password), false, kpxc.settings.autoSubmit);
                 }
             }
         }
@@ -1225,6 +1222,7 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
                     args: [ message ]
                 });
             }
+            return;
         }
     } else if (combination.loginId !== undefined && kpxc.credentials[combination.loginId]) {
         // Specific login ID given
@@ -1260,6 +1258,7 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
                     args: [ message ]
                 });
             }
+            return;
         }
     } else { // Multiple credentials available
         // Check if only one password for given username exists
@@ -1307,7 +1306,7 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
             if (countPasswords > 1) {
                 if (!suppressWarnings) {
                     const target = onlyPassword ? pField : uField;
-                    kpxcAutocomplete.create(target, true);
+                    kpxcAutocomplete.create(target, true, kpxc.settings.autoSubmit);
                     target.focus();
                 }
             } else if (countPasswords < 1) {
@@ -1322,9 +1321,18 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
         } else {
             if (!suppressWarnings) {
                 const target = onlyPassword ? pField : uField;
-                kpxcAutocomplete.create(target, true);
+                kpxcAutocomplete.create(target, true, kpxc.settings.autoSubmit);
                 target.focus();
             }
+        }
+    }
+
+    // Auto-submit
+    if (kpxc.settings.autoSubmit) {
+        if (kpxc.u.form) {
+            kpxc.u.form.submit();
+        } else if (kpxc.p.form) {
+            kpxc.u.form.submit();
         }
     }
 };

--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -14,6 +14,16 @@
     font-size: .9em !important;
 }
 
+.kpxcAutocomplete-items footer {
+    padding: 5px;
+    background-color: #ddd;
+    border: 1px solid #d4d4d4 !important;
+    width: auto;
+    color: #000;
+    font-size: .8em !important;
+    font-style: italic;
+}
+
 .kpxcAutocomplete-active {
     background-color: #6cac4d !important; 
     color: #ffffff !important;

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -163,6 +163,15 @@
         </p>
         <hr />
         <p>
+            <div class="checkbox">
+              <label class="checkbox">
+                <input type="checkbox" name="autoSubmit" value="false" /><span data-i18n="optionsCheckboxAutoSubmit"></span>
+              </label>
+              <span class="help-block" data-i18n="optionsAutoSubmitHelpText"></span>
+            </div>
+          </p>
+          <hr />
+        <p>
           <div class="checkbox">
             <label class="checkbox">
               <input type="checkbox" name="showNotifications" value="true" /><span data-i18n="optionsCheckboxShowNotifications"></span>


### PR DESCRIPTION
Adds option for Auto-submit when multiple credentials are present. It is **disabled** by default and ignored when auto-filling for single entry is enabled.

When the option is enabled, autocomplete menu shows the following:
![Screen Shot 2019-04-22 at 10 01 43](https://user-images.githubusercontent.com/24570482/56488395-ef351580-64e6-11e9-9872-73b2c6dc9f1d.png)

Still. It's not guaranteed this works with every site.

Fixes #216.
Fixes #479.