### PR TITLE
Fix autocomplete password fill

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -169,7 +169,8 @@ kpxcAutocomplete.create = function(input, showListInstantly = false, autoSubmit 
     function fillPassword(value, index) {
         const fieldId = input.getAttribute('data-kpxc-id');
         kpxcFields.prepareId(fieldId);
-        const combination = kpxcFields.getCombination('username', fieldId);
+        const givenType = input.type === 'password' ? 'password' : 'username';
+        const combination = kpxcFields.getCombination(givenType, fieldId);
         combination.loginId = index;
 
         kpxc.fillInCredentials(combination, false, false);


### PR DESCRIPTION
Fills only the password if autocomplete menu was used from a password field.

Previously with only-password pages it detected the password field as username and password field in the combination. That caused the extension to fill first the username, and the password only after that.