### PR TITLE
Allow filling username only from keyboard shortcut

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -818,12 +818,16 @@ kpxc.initCredentialFields = function(forceCall) {
         kpxc.initializeSitePreferences();
         if (kpxc.settings.sitePreferences) {
             for (const site of kpxc.settings.sitePreferences) {
-                if (site.url === window.top.location.href || siteMatch(site.url, window.top.location.href)) {
-                    if (site.ignore === IGNORE_FULL) {
-                        return;
-                    }
+                try {
+                    if (siteMatch(site.url, window.top.location.href) || site.url === window.top.location.href) {
+                        if (site.ignore === IGNORE_FULL) {
+                            return;
+                        }
 
-                    _singleInputEnabledForPage = site.usernameOnly;
+                        _singleInputEnabledForPage = site.usernameOnly;
+                    }
+                } catch (err) {
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Allow filling username using a keyboard shortcut when username field is the only visible one in the page.

For the Google page the DOMException was not handled correctly which caused the content script to fail.

Please note that if the page has scripts that include unhandled exceptions, keyboard shortcuts are only handled after those are thrown. This may require multiple uses of the shortcut, or wait till the page has loaded completely. Also, the input field must have focus.

Examples:
- https://accounts.google.com
- https://id.atlassian.com/login

Fixes solution 2. in https://github.com/keepassxreboot/keepassxc-browser/pull/520.