### PR TITLE
Fix for double reconnect

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -153,8 +153,6 @@ kpxcEvent.onGetStatus = function(callback, tab, internalPoll = false, triggerUnl
 };
 
 kpxcEvent.onReconnect = function(callback, tab) {
-    keepass.connectToNative();
-
     // Add a small timeout after reconnecting. Just to make sure. It's not pretty, I know :(
     setTimeout(() => {
         keepass.reconnect(callback, tab).then((configured) => {

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -1153,9 +1153,7 @@ keepass.disableAutomaticReconnect = function() {
 };
 
 keepass.reconnect = async function(callback, tab) {
-    ////keepass.connectToNative();
-    const port = keepass.nativeConnect();
-    console.log(port);
+    keepass.connectToNative();
     keepass.generateNewKeyPair();
     keepass.changePublicKeys(tab, true).then(r => true).catch(e => false);
 };


### PR DESCRIPTION
Fixes a double reconnect that could cause spawning extra keepassxc-proxy instances.

Fixes #526