### PR TITLE
Fix auto-submit

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1328,12 +1328,26 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
         }
     }
 
+    // Get the form submit button instead if action URL is same as the page itself
+    function getSubmitButton(form) {
+        if (kpxc.submitUrl === document.location.origin + document.location.pathname) {
+            for (const i of form.elements) {
+                if (i.type === 'submit') {
+                    return i;
+                }
+            }
+        }
+        return undefined;
+    }
+
     // Auto-submit
     if (kpxc.settings.autoSubmit) {
-        if (kpxc.u.form) {
-            kpxc.u.form.submit();
-        } else if (kpxc.p.form) {
-            kpxc.u.form.submit();
+        const form = kpxc.u.form || kpxc.p.form;
+        const submitButton = getSubmitButton(form);
+        if (submitButton !== undefined) {
+            submitButton.click();
+        } else {
+            form.submit();
         }
     }
 };


### PR DESCRIPTION
Some forms can be without an action URL. In these cases the `submitURL` is set same as the page URL and the `form.submit()` won't work correctly. If this kind of situation is regognized use the submit button instead.

Fixes #532.