### PR TITLE
Support for displaying expired credentials

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -239,6 +239,10 @@
         "message": "Error: No credentials for the given username found.",
         "description": "Alert message when no credentials are found for the given username."
     },
+    "credentialExpired": {
+        "message": "Expired",
+        "description": "If a credential is expired, this is appended to the title label."
+    },
     "fieldsFill": {
         "message": "Error: Cannot find fields to fill in.",
         "description": "Alert message when no fields are found to fill in."

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -10,7 +10,7 @@ kpxcAutocomplete.input = undefined;
 kpxcAutocomplete.create = function(input, showListInstantly = false, autoSubmit = false) {
     kpxcAutocomplete.autoSubmit = autoSubmit;
     kpxcAutocomplete.input = input;
-    kpxcAutocomplete.started = true
+    kpxcAutocomplete.started = true;
 
     input.addEventListener('click', function(e) {
         if (!e.isTrusted) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -941,7 +941,7 @@ kpxc.prepareFieldsForCredentials = function(autoFillInForSingle) {
         // Generate popup-list of usernames + descriptions
         browser.runtime.sendMessage({
             action: 'popup_login',
-            args: [ [ kpxc.credentials[0].login + ' (' + kpxc.credentials[0].name + ')' ] ]
+            args: [ [ `${kpxc.credentials[0].login} (${kpxc.credentials[0].name})` ] ]
         });
     } else if (kpxc.credentials.length > 1 || (kpxc.credentials.length > 0 && (!kpxc.settings.autoFillSingleEntry || !autoFillInForSingle))) {
         kpxc.preparePageForMultipleCredentials(kpxc.credentials);
@@ -949,15 +949,23 @@ kpxc.prepareFieldsForCredentials = function(autoFillInForSingle) {
 };
 
 kpxc.preparePageForMultipleCredentials = function(credentials) {
+    function getLoginText(credential) {
+        const visibleLogin = (credential.login.length > 0) ? credential.login : tr('credentialsNoUsername');
+        if (credential.expired && credential.expired === 'true') {
+            return `${visibleLogin} (${credential.name}) [${tr('credentialExpired')}]`;
+        }
+        return `${visibleLogin} (${credential.name})`;
+    }
+
     // Add usernames + descriptions to autocomplete-list and popup-list
     const usernames = [];
     kpxcAutocomplete.elements = [];
-    let visibleLogin;
     for (let i = 0; i < credentials.length; i++) {
-        visibleLogin = (credentials[i].login.length > 0) ? credentials[i].login : tr('credentialsNoUsername');
-        usernames.push(visibleLogin + ' (' + credentials[i].name + ')');
+        const loginText = getLoginText(credentials[i]);
+        usernames.push(loginText);
+
         const item = {
-            label: visibleLogin + ' (' + credentials[i].name + ')',
+            label: loginText,
             value: credentials[i].login,
             loginId: i
         };

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -204,7 +204,8 @@ Response message data (success, decrypted):
     {
         "login": "user2",
         "name": "user2",
-        "password": "passwd2"
+        "password": "passwd2",
+        "expired": "true"
     }],
     "nonce": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q",
     "success": "true",


### PR DESCRIPTION
Adds support for "expired" field in the protocol. If an entry has that property set, an extra string "[Expired]" is shown at the end of the entry title in the popup and autocomplete menu to inform the user.

KeePassXC side PR: https://github.com/keepassxreboot/keepassxc/pull/3134.

Screenshot:
![Screen Shot 2019-05-09 at 8 44 24](https://user-images.githubusercontent.com/24570482/57430391-38e86480-7238-11e9-9db7-05e9d4bcee4f.png)
