### PR TITLE
Fix using tab with autocomplete

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -167,7 +167,7 @@ kpxcAutocomplete.keyPress = function(e) {
         }
     } else if (e.key === 'Tab') {
         // Return if value is not in the list
-        if (kpxcAutocomplete.input.value !== '' && kpxcAutocomplete.elements.some(c => c.value !== kpxcAutocomplete.input.value)) {
+        if (kpxcAutocomplete.input.value !== '' && !kpxcAutocomplete.elements.some(c => c.value === kpxcAutocomplete.input.value)) {
             kpxcAutocomplete.closeList();
             return;
         }


### PR DESCRIPTION
Fix using <kbd>Tab</kbd> with autocomplete menu.

The expected behaviour is that when you enter a username manually to the input field, using <kdb>Tab</kbd> will autocomplete the password when focusing away from the username field. Previously this didn't work correctly.