### PR TITLE
Fix reconnect issues

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -152,16 +152,12 @@ kpxcEvent.onGetStatus = function(callback, tab, internalPoll = false, triggerUnl
     }
 };
 
-kpxcEvent.onReconnect = function(callback, tab) {
-    // Add a small timeout after reconnecting. Just to make sure. It's not pretty, I know :(
-    setTimeout(() => {
-        keepass.reconnect(callback, tab).then((configured) => {
-            browser.tabs.sendMessage(tab.id, {
-                action: 'redetect_fields'
-            });
-            kpxcEvent.showStatus(configured, tab, callback);
-        });
-    }, 500);
+kpxcEvent.onReconnect = async function(callback, tab) {
+    const configured = await keepass.reconnect(callback, tab);
+    browser.tabs.sendMessage(tab.id, {
+        action: 'redetect_fields'
+    });
+    kpxcEvent.showStatus(configured, tab, callback);
 };
 
 kpxcEvent.lockDatabase = function(callback, tab) {

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -4,12 +4,10 @@ keepass.migrateKeyRing().then(() => {
     page.initSettings().then(() => {
         page.initOpenedTabs().then(() => {
             httpAuth.init();
-            keepass.connectToNative();
-            keepass.generateNewKeyPair();
+            keepass.enableAutomaticReconnect();
             keepass.changePublicKeys(null).then((pkRes) => {
-                keepass.enableAutomaticReconnect();
                 keepass.getDatabaseHash((gdRes) => {}, null);
-            });
+            }).catch((e) => {});
         });
     });
 });

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -1152,10 +1152,25 @@ keepass.disableAutomaticReconnect = function() {
     keepass.reconnectLoop = null;
 };
 
-keepass.reconnect = async function(callback, tab) {
-    keepass.connectToNative();
-    keepass.generateNewKeyPair();
-    keepass.changePublicKeys(tab, true).then(r => true).catch(e => false);
+keepass.reconnect = function(callback, tab) {
+    return new Promise((resolve) => {
+        keepass.connectToNative();
+        keepass.generateNewKeyPair();
+        keepass.changePublicKeys(tab, true).then((r) => {
+            keepass.getDatabaseHash((gdRes) => {
+                if (gdRes !== '' && tab && page.tabs[tab.id]) {
+                    delete page.tabs[tab.id].errorMessage;
+                }
+                keepass.testAssociation((associationResponse) => {
+                    keepass.isConfigured().then((configured) => {
+                        resolve(true);
+                    });
+                });
+            }, tab);
+        }).catch((e) => {
+            resolve(false); 
+        });
+    });
 };
 
 keepass.updatePopup = function(iconType) {


### PR DESCRIPTION
Fixes the following reconnect issues:
- Reconnect didn't work if KeePassXC was started after the browser
- Clicking the popup was not reconnecting the extension properly
- Error message was shown if reconnected database was already open

FYI: When reconnect is active the extension consumes memory, but the garbage collector will clean it when the reconnect happens.

Fixes #523.
Fixes #544.