### PR TITLE
Fix filling option value

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1145,7 +1145,7 @@ kpxc.setValue = function(field, value) {
         value = value.toLowerCase().trim();
         const options = field.querySelectorAll('option');
         for (const o of options) {
-            if (o.test().toLowerCase().trim() === value) {
+            if (o.textContent.toLowerCase().trim() === value) {
                 kpxc.setValueWithChange(field, o.value);
                 return false;
             }


### PR DESCRIPTION
Fix a typo in the code (from No jQuery PR) that prevented filling an option type when String Fields are used.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/553.