### PR TITLE
Fix filling password from context menu

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -33,6 +33,7 @@ kpxcAutocomplete.create = function(input, showListInstantly = false, autoSubmit 
 
 kpxcAutocomplete.showList = function(inputField) {
     kpxcAutocomplete.closeList();
+    kpxcAutocomplete.input = inputField;
     const div = kpxcUI.createElement('div', 'kpxcAutocomplete-items', { 'id': 'kpxcAutocomplete-list' });
 
     // Element position
@@ -191,7 +192,7 @@ kpxcAutocomplete.fillPassword = function(value, index) {
     const combination = kpxcFields.getCombination(givenType, fieldId);
     combination.loginId = index;
 
-    kpxc.fillInCredentials(combination, false, false);
+    kpxc.fillInCredentials(combination, givenType === 'password', false);
     kpxcAutocomplete.input.setAttribute('fetched', true);
 };
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1240,7 +1240,7 @@ kpxc.fillIn = function(combination, onlyPassword, suppressWarnings) {
     } else if (combination.loginId !== undefined && kpxc.credentials[combination.loginId]) {
         // Specific login ID given
         let filledIn = false;
-        if (uField) {
+        if (uField && (!onlyPassword || _singleInputEnabledForPage)) {
             kpxc.setValueWithChange(uField, kpxc.credentials[combination.loginId].login);
             browser.runtime.sendMessage({
                 action: 'page_set_login_id', args: [ combination.loginId ]


### PR DESCRIPTION
Previous versions made changes to autocomplete that it is not always created, but a previously created autocomplete is reused. In some cases (for example Protonmail's mailbox password page) the input field inside autocomplete was still pointing to the previous page's username input field and caused invalid values filled to the password field.

Also in some cases username was filled along with the password, which not should happen.