### PR TITLE
Remove popup reconnect

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -531,6 +531,10 @@
         "message": "Automatically reconnect to KeePassXC.",
         "description": "Auto-reconnect checkbox text."
     },
+    "optionsAutomaticReconnectWarning": {
+        "message": "Warning! This feature is experimental. Use at your own risk.",
+        "description": "Auto-reconnect warning message."
+    },
     "optionsCheckboxAutoFillSingleEntry": {
         "message": "Automatically fill in single-credential entries.",
         "description": "Automatically fill-in single credential entry checkbox text."

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -154,9 +154,13 @@ kpxcEvent.onGetStatus = function(callback, tab, internalPoll = false, triggerUnl
 
 kpxcEvent.onReconnect = async function(callback, tab) {
     const configured = await keepass.reconnect(callback, tab);
-    browser.tabs.sendMessage(tab.id, {
-        action: 'redetect_fields'
-    });
+    if (configured) {
+        browser.tabs.sendMessage(tab.id, {
+            action: 'redetect_fields'
+        }).catch((err) => {
+            console.log(err);
+        });
+    }
     kpxcEvent.showStatus(configured, tab, callback);
 };
 

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -4,10 +4,9 @@ keepass.migrateKeyRing().then(() => {
     page.initSettings().then(() => {
         page.initOpenedTabs().then(() => {
             httpAuth.init();
-            keepass.enableAutomaticReconnect();
-            keepass.changePublicKeys(null).then((pkRes) => {
-                keepass.getDatabaseHash((gdRes) => {}, null);
-            }).catch((e) => {});
+            keepass.reconnect().then(() => {
+                keepass.enableAutomaticReconnect();
+            });
         });
     });
 });

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -419,16 +419,6 @@ keepass.testAssociation = async function(callback, tab, enableTimeout = false, t
         page.tabs[tab.id].errorMessage = null;
     }
 
-    if (!keepass.isKeePassXCAvailable && !page.settings.automaticReconnect) {
-        try {
-            await keepass.reconnect();
-        } catch (err) {
-            keepass.handleError(tab, kpErrors.PUBLIC_KEY_NOT_FOUND);
-            callback(false);
-            return false;
-        }
-    }
-
     keepass.getDatabaseHash((dbHash) => {
         if (!dbHash) {
             callback(false);
@@ -1133,7 +1123,7 @@ keepass.decrypt = function(input, nonce) {
 
 keepass.enableAutomaticReconnect = function() {
     // Disable for Windows if KeePassXC is older than 2.3.4
-    if (!page.settings.automaticReconnect ||
+    if (!page.settings.autoReconnect ||
         (navigator.platform.toLowerCase().includes('win') && !keepass.compareVersion('2.3.4', keepass.currentKeePassXC))) {
         return;
     }
@@ -1198,6 +1188,8 @@ keepass.updateDatabaseHashToContent = function() {
             browser.tabs.sendMessage(tabs[0].id, {
                 action: 'check_database_hash',
                 hash: { old: keepass.previousDatabaseHash, new: keepass.databaseHash }
+            }).catch((err) => {
+                console.log(err);
             });
             keepass.previousDatabaseHash = keepass.databaseHash;
         }

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -11,7 +11,7 @@ const defaultSettings = {
     showNotifications: true,
     showLoginNotifications: true,
     saveDomainOnly: true,
-    automaticReconnect: true,
+    autoReconnect: false,
     defaultGroup: '',
     defaultGroupAlwaysAsk: false
 };
@@ -56,8 +56,8 @@ page.initSettings = function() {
             if (!('saveDomainOnly' in page.settings)) {
                 page.settings.saveDomainOnly = defaultSettings.saveDomainOnly;
             }
-            if (!('automaticReconnect' in page.settings)) {
-                page.settings.automaticReconnect = defaultSettings.automaticReconnect;
+            if (!('autoReconnect' in page.settings)) {
+                page.settings.autoReconnect = defaultSettings.autoReconnect;
             }
             if (!('defaultGroup' in page.settings)) {
                 page.settings.defaultGroup = defaultSettings.defaultGroup;

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -137,9 +137,10 @@
         <p>
           <div class="checkbox">
             <label class="checkbox">
-              <input type="checkbox" name="automaticReconnect" value="true" /><span data-i18n="optionsCheckboxAutomaticReconnect"/>
+              <input type="checkbox" name="autoReconnect" value="false" /><span data-i18n="optionsCheckboxAutomaticReconnect"/>
             </label>
             <span class="help-block" data-i18n="optionsAutomaticReconnectHelpText"></span>
+            <span class="bg-danger" data-i18n="optionsAutomaticReconnectWarning"></span>
           </div>
         </p>
         <hr />

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -107,8 +107,8 @@ options.initGeneralSettings = function() {
                     $('#defaultGroupButton').prop('disabled', false);
                     $('#defaultGroupButtonReset').prop('disabled', false);
                 }
-            } else if (name === 'automaticReconnect') {
-                const message = updated.automaticReconnect ? 'enable_automatic_reconnect' : 'disable_automatic_reconnect';
+            } else if (name === 'autoReconnect') {
+                const message = updated.autoReconnect ? 'enable_automatic_reconnect' : 'disable_automatic_reconnect';
                 browser.runtime.sendMessage({ action: message });
             }
         });


### PR DESCRIPTION
- Removes reconnect from the popup (causes more problems than any good)
- Sets Auto-Reconnect to disabed as default
- Add a warning message to Settings page
- Fixes a connecting issue with KeePassXC versions earlier than 2.4.0

Fixes #562.