### PR TITLE
Fix password fill

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -88,12 +88,12 @@ browser.runtime.onMessage.addListener(function(req, sender) {
 });
 
 function _f(fieldId) {
-    const inputs = document.querySelectorAll('input[data-kpxc-id=\'' + fieldId + '\']');
+    const inputs = document.querySelectorAll(`input[data-kpxc-id='${fieldId}']`);
     return inputs.length > 0 ? inputs[0] : null;
 }
 
 function _fs(fieldId) {
-    const inputs = document.querySelectorAll('input[data-kpxc-id=\'' + fieldId + '\'], select[data-kpxc-id=\'' + fieldId + '\']');
+    const inputs = document.querySelectorAll(`input[data-kpxc-id='${fieldId}'], select[data-kpxc-id='${fieldId}']`);
     return inputs.length > 0 ? inputs[0] : null;
 }
 

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -267,15 +267,8 @@ kpxcPassword.copy = function(e) {
 kpxcPassword.fill = function(e) {
     e.preventDefault();
 
-    let field = null;
-    const inputs = document.querySelectorAll('input[type=\'password\']');
-    for (const i of inputs) {
-        if (i.getAttribute('data-kpxc-id')) {
-            field = i;
-            break;
-        }
-    }
-
+    // Use the active input field
+    const field = _f(kpxcPassword.dialog.getAttribute('kpxc-pwgen-field-id'));
     if (field) {
         const password = $('.kpxc-pwgen-input');
         if (field.getAttribute('maxlength')) {


### PR DESCRIPTION
Fix password fill when updating passwords with three different input fields (Current, New, Repeat new).

#### Current implementation
All password input fields are used in order, no matter which password generator icon is pressed. The fields are also filled in that order.

#### Fixed implementation
Fill uses the input field which icon has been clicked as active field. The next input field of the current one is always filled.

Fixes #575.