### PR TITLE
Focus to input field after keyboard fill

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1110,7 +1110,13 @@ kpxc.fillInFromActiveElement = function(suppressWarnings, passOnly = false) {
     const el = document.activeElement;
     if (el.tagName.toLowerCase() !== 'input') {
         if (kpxcFields.combinations.length > 0) {
-            kpxc.fillInCredentials(kpxcFields.combinations[0], false, suppressWarnings);
+            kpxc.fillInCredentials(kpxcFields.combinations[0], passOnly, suppressWarnings);
+
+            // Focus to the input field
+            const field = _f(passOnly ? kpxcFields.combinations[0].password : kpxcFields.combinations[0].username);
+            if (field) {
+                field.focus();
+            }
         }
         return;
     }


### PR DESCRIPTION
After a keyboard fill is made, focus to the input field (to password field if it's filled alone) to enable a form submit.

Fixes #571.