### PR TITLE
Fix handling multiple icons

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -60,7 +60,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             kpxc.settings = response;
             kpxc.initCredentialFields(true);
         } else if (req.action === 'show_password_generator') {
-            kpxcPassword.trigger();
+            kpxcPasswordDialog.trigger();
         } else if (req.action === 'add_username_only_option') {
             kpxc.addToSitePreferences();
         }
@@ -448,7 +448,7 @@ kpxcFields.getUsernameField = function(passwordId, checkDisabled) {
             }
 
             if (kpxc.settings.showLoginFormIcon) {
-                kpxcUsernameField.initField(usernameField);
+                kpxcUsernameFields.newIcon(usernameField);
             }
             usernameField = i;
         }
@@ -506,8 +506,7 @@ kpxcFields.getPasswordField = function(usernameId, checkDisabled) {
             passwordField = null;
         }
 
-        kpxcPassword.init(kpxc.settings.usePasswordGeneratorIcons);
-        kpxcPassword.initField(passwordField);
+        kpxcPasswordIcons.newIcon(kpxc.settings.usePasswordGeneratorIcons, passwordField);
     } else {
         // Search all inputs on page
         const inputs = kpxcFields.getAllFields();
@@ -564,7 +563,7 @@ kpxcFields.prepareCombinations = async function(combinations) {
         });
 
         if (kpxc.settings.showLoginFormIcon) {
-            kpxcUsernameField.initField(usernameField, res.databaseClosed);
+            kpxcUsernameFields.newIcon(usernameField, res.databaseClosed);
         }
 
         // Initialize form-submit for remembering credentials
@@ -856,7 +855,7 @@ kpxc.clearAllFromPage = function() {
 // Switch credentials if database is changed or closed
 kpxc.detectDatabaseChange = async function(response) {
     kpxc.clearAllFromPage();
-    kpxcUsernameField.switchIcon(true);
+    kpxcUsernameFields.switchIcon(true);
 
     if (document.visibilityState !== 'hidden') {
         if (response.new !== '' && response.new !== response.old) {
@@ -866,7 +865,7 @@ kpxc.detectDatabaseChange = async function(response) {
             });
             kpxc.settings = settings;
             await kpxc.initCredentialFields(true);
-            kpxcUsernameField.switchIcon(false); // Unlocked
+            kpxcUsernameFields.switchIcon(false); // Unlocked
 
             // If user has requested a manual fill through context menu the actual credential filling
             // is handled here when the opened database has been regognized. It's not a pretty hack.
@@ -950,11 +949,9 @@ kpxc.initCredentialFields = async function(forceCall) {
 };
 
 kpxc.initPasswordGenerator = function(inputs) {
-    kpxcPassword.init(kpxc.settings.usePasswordGeneratorIcons);
-
     for (let i = 0; i < inputs.length; i++) {
         if (inputs[i] && inputs[i].getLowerCaseAttribute('type') === 'password') {
-            kpxcPassword.initField(inputs[i], inputs, i);
+            kpxcPasswordIcons.newIcon(kpxc.settings.usePasswordGeneratorIcons, inputs[i], inputs, i);
         }
     }
 };
@@ -1772,7 +1769,7 @@ kpxcEvents.triggerActivatedTab = async function() {
 
     // Update username field lock state
     const state = await browser.runtime.sendMessage({ action: 'check_database_hash' });
-    kpxcUsernameField.switchIcon(state === '');
+    kpxcUsernameFields.switchIcon(state === '');
 
     // initCredentialFields calls also "retrieve_credentials", to prevent it
     // check of init() was already called

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -10,6 +10,19 @@ const Pixels = function(value) {
     return String(value) + 'px';
 };
 
+// Basic icon class
+class Icon {
+    constructor() {
+        try {
+            this.observer = new IntersectionObserver((entries) => {
+                kpxcUI.updateFromIntersectionObserver(this, entries);
+            });
+        } catch (err) {
+            console.log(err);
+        }
+    }
+};
+
 const kpxcUI = {};
 
 // Wrapper for creating elements
@@ -34,6 +47,18 @@ kpxcUI.createElement = function(type, classes, attributes, textContent) {
     }
 
     return element;
+};
+
+kpxcUI.monitorIconPosition = function(iconClass) {
+    // Handle icon position on resize
+    window.addEventListener('resize', function(e) {
+        kpxcUI.updateIconPosition(iconClass);
+    });
+
+    // Handle icon position on scroll
+    window.addEventListener('scroll', function(e) {
+        kpxcUI.updateIconPosition(iconClass);
+    });
 };
 
 kpxcUI.updateIconPosition = function(iconClass) {
@@ -62,6 +87,7 @@ kpxcUI.setIconPosition = function(icon, field) {
 kpxcUI.updateFromIntersectionObserver = function(iconClass, entries) {
     for (const entry of entries) {
         const rect = DOMRectToArray(entry.boundingClientRect);
+        const temp = entry.target.closest('.kpxc-username-icon');
 
         if ((entry.intersectionRatio === 0 && !entry.isIntersecting) || (rect.some(x => x < -10))) {
             iconClass.icon.style.display = 'none';
@@ -115,13 +141,13 @@ const DOMRectToArray = function(domRect) {
 
 // Enables dragging
 document.addEventListener('mousemove', function(e) {
-    if (kpxcPassword.selected === kpxcPassword.titleBar) {
-        const xPos = e.clientX - kpxcPassword.diffX;
-        const yPos = e.clientY - kpxcPassword.diffY;
+    if (kpxcPasswordDialog.selected === kpxcPasswordDialog.titleBar) {
+        const xPos = e.clientX - kpxcPasswordDialog.diffX;
+        const yPos = e.clientY - kpxcPasswordDialog.diffY;
 
-        if (kpxcPassword.selected !== null) {
-            kpxcPassword.dialog.style.left = Pixels(xPos);
-            kpxcPassword.dialog.style.top = Pixels(yPos);
+        if (kpxcPasswordDialog.selected !== null) {
+            kpxcPasswordDialog.dialog.style.left = Pixels(xPos);
+            kpxcPasswordDialog.dialog.style.top = Pixels(yPos);
         }
     }
 
@@ -137,7 +163,7 @@ document.addEventListener('mousemove', function(e) {
 });
 
 document.addEventListener('mouseup', function() {
-    kpxcPassword.selected = null;
+    kpxcPasswordDialog.selected = null;
     kpxcDefine.selected = null;
 });
 

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -54,15 +54,15 @@
             ],
             "js": [
                 "browser-polyfill.min.js",
+                "global.js",
+                "content/ui.js",
                 "content/banner.js",
                 "content/autocomplete.js",
                 "content/define.js",
                 "content/keepassxc-browser.js",
                 "content/pwgen.js",
                 "content/sites.js",
-                "content/ui.js",
-                "content/username-field.js",
-                "global.js"
+                "content/username-field.js"
             ],
             "css": [
                 "css/autocomplete.css",


### PR DESCRIPTION
Previously, handling multiple icons on a site was not working correctly. The icon Object(s) always referred to the last icon created, so hiding/showing them would only affect to the last icon.

Improvements:
- All icons are now created dynamically instead of a single Object.
- Added UsernameFieldIcon and PasswordIcon classes.
- Changed `kpxcPassword` to `kpxcPasswordDialog`, removing the icon handling from that Object
- Moved `IntersectionObserver` handling to `kpxcUI` and new `Icon` class instead of copying the same code.

To test this, you can create the following local HTML file:
```HTML
<!DOCTYPE html>
<html>
<head>
</head>
<body>
<button id="nav1">Hide</button>
<button id="nav2">Show</button>
<section id="sec1" style="display:none">
<h1>Hidden</h1>
</section>
<section id="sec2">
<h1>Visible</h1>
<input type="password" />
<input type="password" />
<input type="password" />
</section>
<script>
function fun(e) {
    for (let section of document.getElementsByTagName("section")) {
        if ("nav" + section.id.substring(3) == e.target.id) {
            section.style.display = "block";
        } else {
            section.style.display = "none";
        }
    }
}

document.getElementById("nav1").addEventListener("click", fun);
document.getElementById("nav2").addEventListener("click", fun);
</script>
</body>
</html>
```

Without the fix, only the last icon will hide, and only its state is affected when a database is opened/closed.