### PR TITLE
Fix update button from Credential Banner

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1573,7 +1573,7 @@ kpxc.contextMenuRememberCredentials = async function() {
  * @param {Array} oldCredentials    Credentials saved from the password change page, if available
  */
 kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue, oldCredentials) {
-    const credentials = kpxc.credentials || oldCredentials;
+    const credentials = (oldCredentials !== undefined && oldCredentials.length > 0) ? oldCredentials : kpxc.credentials;
 
     // No password given or field cleaned by a site-running script
     // --> no password to save


### PR DESCRIPTION
Fixes the Update button disabling from Credential Banner.

Previously, after a page submit, even if `oldCredentials` had the credentials `kpxc.credentials` were used instead because it existed, but was an empty Array. Now `oldCredentials` are always used instead if it's defined.

Fixes #619.