### PR TITLE
Add TOTP icon filling and improve icon handling

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -167,6 +167,14 @@
         "message": "Username field icon",
         "description": "Username field icon text."
     },
+    "totpFieldText": {
+        "message": "Fill TOTP from KeePassXC",
+        "description": "OTP field icon hover text."
+    },
+    "totpFieldIcon": {
+        "message": "TOTP field icon",
+        "description": "OTP field icon text."
+    },
     "defineDismiss": {
         "message": "Dismiss",
         "description": "Dismiss button text when choosing custom login fields."
@@ -567,6 +575,10 @@
         "message": "Activate username field icons.",
         "description": "Activate username field icons textbox text."
     },
+    "optionsCheckboxOTPIcons": {
+        "message": "Activate 2FA/OTP field icons.",
+        "description": "Activate OTP field icons textbox text."
+    },
     "optionsCheckboxAutoRetrieveCredentials": {
         "message": "Automatically retrieve credentials.",
         "description": "Automatically retrieve credentials checkbox text."
@@ -646,6 +658,10 @@
     "optionsShowLoginFormIconHelpText": {
         "message": "Adds an icon to username fields for filling credentials with a single mouse click.",
         "description": "Username field icon option help text."
+    },
+    "optionsShowOTPIconHelpText": {
+        "message": "Adds an icon to input fields that are recognized as OTP/2FA.",
+        "description": "OTP field icon option help text."
     },
     "optionsAutoRetrieveCredentialsHelpText": {
         "message": "KeePassXC-Browser will immediately retrieve credentials when a tab is activated.",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -228,6 +228,15 @@ kpxcEvent.onUsernameFieldDetected = function(tab, detected) {
     page.usernameFieldDetected = detected;
 };
 
+kpxcEvent.passwordGetFilled = async function() {
+    return page.passwordFilled;
+}
+
+kpxcEvent.passwordSetFilled = function(tab, state) {
+    page.passwordFilled = state;
+    return Promise.resolve();
+}
+
 // All methods named in this object have to be declared BEFORE this!
 kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
@@ -255,6 +264,8 @@ kpxcEvent.messageHandlers = {
     'page_get_submitted': kpxcEvent.pageGetSubmitted,
     'page_set_login_id': kpxcEvent.pageSetLoginId,
     'page_set_submitted': kpxcEvent.pageSetSubmitted,
+    'password_get_filled': kpxcEvent.passwordGetFilled,
+    'password_set_filled': kpxcEvent.passwordSetFilled,
     'pop_stack': kpxcEvent.onPopStack,
     'popup_login': kpxcEvent.onLoginPopup,
     'popup_multiple-fields': kpxcEvent.onMultipleFieldsPopup,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -11,6 +11,7 @@ const defaultSettings = {
     showNotifications: true,
     showLoginNotifications: true,
     showLoginFormIcon: true,
+    showOTPIcon: true,
     saveDomainOnly: true,
     autoReconnect: false,
     defaultGroup: '',
@@ -21,6 +22,7 @@ var page = {};
 page.blockedTabs = [];
 page.currentTabId = -1;
 page.loginId = -1;
+page.passwordFilled = false;
 page.submitted = false;
 page.submittedCredentials = {};
 page.tabs = [];
@@ -60,6 +62,9 @@ page.initSettings = async function() {
         }
         if (!('showLoginFormIcon' in page.settings)) {
             page.settings.showLoginFormIcon = defaultSettings.showLoginFormIcon;
+        }
+        if (!('showOTPIcon' in page.settings)) {
+            page.settings.showOTPIcon = defaultSettings.showOTPIcon;
         }
         if (!('saveDomainOnly' in page.settings)) {
             page.settings.saveDomainOnly = defaultSettings.saveDomainOnly;
@@ -114,6 +119,7 @@ page.clearCredentials = function(tabId, complete) {
     }
 
     page.usernameFieldDetected = false;
+    page.passwordFilled = false;
     page.tabs[tabId].credentials = [];
     delete page.tabs[tabId].credentials;
 

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -3,15 +3,20 @@
 const kpxcPasswordIcons = {};
 kpxcPasswordIcons.icons = [];
 
-kpxcPasswordIcons.newIcon = function(field, databaseClosed = true) {
-    kpxcPasswordIcons.icons.push(new PasswordIcon(field, databaseClosed));
+kpxcPasswordIcons.newIcon = function(useIcons, field, inputs, pos, databaseClosed = true) {
+    kpxcPasswordIcons.icons.push(new PasswordIcon(useIcons, field, inputs, pos, databaseClosed));
+};
+
+kpxcPasswordIcons.switchIcon = function(locked) {
+    kpxcPasswordIcons.icons.forEach(u => u.switchIcon(locked));
 };
 
 
 class PasswordIcon extends Icon {
-    constructor(useIcons, field, inputs, pos) {
+    constructor(useIcons, field, inputs, pos, databaseClosed) {
         super();
         this.useIcons = useIcons;
+        this.databaseClosed = databaseClosed;
 
         this.initField(field, inputs, pos);
         kpxcUI.monitorIconPosition(this);
@@ -71,6 +76,10 @@ PasswordIcon.prototype.createIcon = function(field) {
     icon.style.zIndex = '10000000';
     icon.style.width = Pixels(size);
     icon.style.height = Pixels(size);
+
+    if (this.databaseClosed) {
+        icon.style.filter = 'saturate(0%)';
+    }
 
     icon.addEventListener('click', function(e) {
         if (!e.isTrusted) {

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var kpxcTOTPIcons = {};
+kpxcTOTPIcons.icons = [];
+
+kpxcTOTPIcons.newIcon = function(field, databaseClosed = true) {
+    kpxcTOTPIcons.icons.push(new TOTPFieldIcon(field, databaseClosed));
+};
+
+kpxcTOTPIcons.switchIcon = function(locked) {
+    kpxcTOTPIcons.icons.forEach(u => u.switchIcon(locked));
+};
+
+
+class TOTPFieldIcon extends Icon {
+    constructor(field, databaseClosed = true) {
+        super();
+        this.icon = null;
+        this.inputField = null;
+        this.databaseClosed = databaseClosed;
+
+        this.initField(field);
+        kpxcUI.monitorIconPosition(this);
+    }
+};
+
+TOTPFieldIcon.prototype.initField = function(field) {
+    if (!field || field.getAttribute('kpxc-totp-field') === 'true') {
+        return;
+    }
+
+    field.setAttribute('kpxc-totp-field', 'true');
+
+    // Observer the visibility
+    if (this.observer) {
+        this.observer.observe(field);
+    }
+
+    this.createIcon(field);
+    this.inputField = field;
+};
+
+TOTPFieldIcon.prototype.createIcon = function(field) {
+    const className = (isFirefox() ? 'moz' : 'default');
+
+    // Size the icon dynamically, but not greater than 24 or smaller than 14
+    const size = Math.max(Math.min(24, field.offsetHeight - 4), 14);
+    let offset = Math.floor((field.offsetHeight - size) / 3);
+    offset = (offset < 0) ? 0 : offset;
+
+    const icon = kpxcUI.createElement('div', 'kpxc kpxc-totp-icon ' + className,
+        {
+            'title': tr('totpFieldText'),
+            'alt': tr('totpFieldIcon'),
+            'size': size,
+            'offset': offset
+        });
+    icon.style.zIndex = '10000000';
+    icon.style.width = Pixels(size);
+    icon.style.height = Pixels(size);
+
+    if (this.databaseClosed) {
+        icon.style.filter = 'saturate(0%)';
+    }
+
+    icon.addEventListener('click', async function(e) {
+        if (!e.isTrusted) {
+            return;
+        }
+
+        e.preventDefault();
+        await kpxc.receiveCredentialsIfNecessary();
+        kpxc.fillInFromActiveElementTOTPOnly(field);
+    });
+
+    kpxcUI.setIconPosition(icon, field);
+    this.icon = icon;
+    document.body.appendChild(icon);
+};

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -21,6 +21,18 @@ class Icon {
             console.log(err);
         }
     }
+
+    switchIcon(locked) {
+        if (!this.icon) {
+            return;
+        }
+    
+        if (locked) {
+           this.icon.style.filter = 'saturate(0%)';
+        } else {
+            this.icon.style.filter = 'saturate(100%)';
+        }
+    }
 };
 
 const kpxcUI = {};

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -1,24 +1,25 @@
 'use strict';
 
-const kpxcUsernameFields = {};
-kpxcUsernameFields.icons = [];
+const kpxcUsernameIcons = {};
+kpxcUsernameIcons.icons = [];
 
-kpxcUsernameFields.newIcon = function(field, databaseClosed = true) {
-    kpxcUsernameFields.icons.push(new UsernameFieldIcon(field, databaseClosed));
+kpxcUsernameIcons.newIcon = function(field, databaseClosed = true) {
+    kpxcUsernameIcons.icons.push(new UsernameFieldIcon(field, databaseClosed));
 };
 
-kpxcUsernameFields.switchIcon = function(locked) {
-    kpxcUsernameFields.icons.forEach(u => u.switchIcon(locked));
+kpxcUsernameIcons.switchIcon = function(locked) {
+    kpxcUsernameIcons.icons.forEach(u => u.switchIcon(locked));
 };
 
 
 class UsernameFieldIcon extends Icon {
     constructor(field, databaseClosed = true) {
         super();
+        this.databaseClosed = databaseClosed;
         this.icon = null;
         this.inputField = null;
 
-        this.initField(field, databaseClosed);
+        this.initField(field,);
         kpxcUI.monitorIconPosition(this);
     }
 
@@ -39,7 +40,7 @@ class UsernameFieldIcon extends Icon {
     }
 };
 
-UsernameFieldIcon.prototype.initField = function(field, databaseClosed = true) {
+UsernameFieldIcon.prototype.initField = function(field) {
     if (!field || field.getAttribute('kpxc-username-field') === 'true') {
         return;
     }
@@ -51,18 +52,18 @@ UsernameFieldIcon.prototype.initField = function(field, databaseClosed = true) {
         this.observer.observe(field);
     }
 
-    this.createIcon(field, databaseClosed);
+    this.createIcon(field);
     this.inputField = field;
 };
 
-UsernameFieldIcon.prototype.createIcon = function(target, databaseClosed) {
+UsernameFieldIcon.prototype.createIcon = function(target) {
     // Remove any existing password generator icons from the input field
     if (target.getAttribute('kpxc-password-generator')) {
         kpxcPasswordDialog.removeIcon(target);
     }
 
     const field = target;
-    const className = getIconClassName(databaseClosed);
+    const className = getIconClassName(this.databaseClosed);
 
     // Size the icon dynamically, but not greater than 24 or smaller than 14
     const size = Math.max(Math.min(24, field.offsetHeight - 4), 14);
@@ -78,7 +79,7 @@ UsernameFieldIcon.prototype.createIcon = function(target, databaseClosed) {
 
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-username-icon ' + className,
         {
-            'title': databaseClosed ? tr('usernameLockedFieldText') : tr('usernameFieldText'),
+            'title': this.databaseClosed ? tr('usernameLockedFieldText') : tr('usernameFieldText'),
             'alt': tr('usernameFieldIcon'),
             'size': size,
             'offset': offset,

--- a/keepassxc-browser/css/totp.css
+++ b/keepassxc-browser/css/totp.css
@@ -1,0 +1,14 @@
+.kpxc-totp-icon {
+    position: absolute;
+    cursor: pointer;
+}
+
+.kpxc-totp-icon.default {
+    background: url('chrome-extension://__MSG_@@extension_id__/icons/otp.svg') right no-repeat;
+    background-size: contain;
+}
+
+.kpxc-totp-icon.moz {
+    background: url('moz-extension://__MSG_@@extension_id__/icons/otp.svg') right no-repeat;
+    background-size: contain;
+}

--- a/keepassxc-browser/icons/otp.svg
+++ b/keepassxc-browser/icons/otp.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 99.999997 100"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="otp.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <title
+     id="title836">OTP icon</title>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1402"
+     inkscape:window-height="1053"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="4.72"
+     inkscape:cx="19.20533"
+     inkscape:cy="22.698472"
+     inkscape:window-x="867"
+     inkscape:window-y="158"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4257">
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="0"
+         id="stop4259" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop4261" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-3-6">
+      <stop
+         style="stop-color:#226e23;stop-opacity:1"
+         offset="0"
+         id="stop4173" />
+      <stop
+         style="stop-color:#63ab3a;stop-opacity:1"
+         offset="1"
+         id="stop4175" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316-3">
+      <stop
+         id="stop4167"
+         offset="0"
+         style="stop-color:#226e23;stop-opacity:1" />
+      <stop
+         id="stop4169"
+         offset="1"
+         style="stop-color:#63ab3a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4316">
+      <stop
+         style="stop-color:#226e23;stop-opacity:1"
+         offset="0"
+         id="stop4318" />
+      <stop
+         style="stop-color:#63ab3a;stop-opacity:1"
+         offset="1"
+         id="stop4320" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4153"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#b3b3b3;stop-opacity:1;"
+         offset="0"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4316"
+       id="linearGradient4324"
+       x1="50.757614"
+       y1="964.83679"
+       x2="50.757614"
+       y2="1042.2632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0561225,0,0,1.0561225,-2.8061215,-1008.6172)" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="43.571938"
+       fy="41.189114"
+       fx="-82.91127"
+       cy="41.189114"
+       cx="-82.91127"
+       id="radialGradient5106"
+       xlink:href="#linearGradient4316" />
+    <linearGradient
+       xlink:href="#linearGradient4316"
+       id="linearGradient4324-3"
+       x1="50.757614"
+       y1="964.83679"
+       x2="50.757614"
+       y2="1042.2632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0561225,0,0,1.0561225,118.96071,-1109.1994)" />
+    <linearGradient
+       xlink:href="#linearGradient4316"
+       id="linearGradient4324-3-6"
+       x1="50.757614"
+       y1="964.83679"
+       x2="50.757614"
+       y2="1042.2632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0561225,0,0,1.0561225,-2.8061235,-1008.6171)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="86.356995"
+       x2="53.238865"
+       y1="12.753036"
+       x1="53.238865"
+       id="linearGradient5199"
+       xlink:href="#linearGradient4316-3-6" />
+    <linearGradient
+       xlink:href="#linearGradient4257"
+       id="linearGradient4263"
+       x1="50.09866"
+       y1="86.831215"
+       x2="49.526104"
+       y2="8.6772995"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>OTP icon</dc:title>
+        <cc:license
+           rdf:resource="http://scripts.sil.org/OFL" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>KeePassXC Team</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>KeePassXC Team</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>otp</rdf:li>
+            <rdf:li>totp</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:date>2019</dc:date>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://scripts.sil.org/OFL">
+        <cc:permits
+           rdf:resource="http://scripts.sil.org/pub/OFL/Reproduction" />
+        <cc:permits
+           rdf:resource="http://scripts.sil.org/pub/OFL/Distribution" />
+        <cc:permits
+           rdf:resource="http://scripts.sil.org/pub/OFL/Embedding" />
+        <cc:permits
+           rdf:resource="http://scripts.sil.org/pub/OFL/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://scripts.sil.org/pub/OFL/Notice" />
+        <cc:requires
+           rdf:resource="http://scripts.sil.org/pub/OFL/Attribution" />
+        <cc:requires
+           rdf:resource="http://scripts.sil.org/pub/OFL/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://scripts.sil.org/pub/OFL/DerivativeRenaming" />
+        <cc:requires
+           rdf:resource="http://scripts.sil.org/pub/OFL/BundlingWhenSelling" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="fill:#6cac4d;fill-opacity:1;stroke:#467720;stroke-width:3.28421712;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     d="m 17.573148,24.970678 h 64.853704 c 4.426642,0 7.990329,4.214625 7.990329,9.449831 v 27.398502 c 0,5.235207 -3.563687,9.449832 -7.990329,9.449832 H 78.373496 74.320139 L 74.28734,83.531602 64.520559,71.268843 H 62.160069 58.106713 54.053356 50 45.946644 41.893287 37.839931 33.786574 29.733218 25.679861 21.626504 17.573148 c -4.426642,0 -7.9903288,-4.214625 -7.9903288,-9.449832 V 34.420509 c 0,-5.235206 3.5636868,-9.449831 7.9903288,-9.449831 z"
+     id="rect872"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssscccccccccccccccssss" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     x="20"
+     y="69.295219"
+     id="text868"><tspan
+       sodipodi:role="line"
+       id="tspan866"
+       x="26"
+       y="69.295219">***</tspan></text>
+</svg>

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -58,6 +58,7 @@
                 "content/keepassxc-browser.js",
                 "content/pwgen.js",
                 "content/sites.js",
+                "content/totp-field.js",
                 "content/username-field.js"
             ],
             "css": [
@@ -67,6 +68,7 @@
                 "css/define.css",
                 "css/notification.css",
                 "css/pwgen.css",
+                "css/totp.css",
                 "css/username.css"
             ],
             "run_at": "document_idle",
@@ -106,7 +108,8 @@
     "web_accessible_resources": [
         "icons/keepassxc.svg",
         "icons/key.svg",
-        "icons/locked.svg"
+        "icons/locked.svg",
+        "icons/otp.svg"
     ],
     "permissions": [
         "activeTab",

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -70,15 +70,15 @@
         </p>
         <hr />
         <p>
-            <div class="checkbox">
-              <label class="checkbox">
-                <input type="checkbox" name="showLoginFormIcon" value="true"/><span data-i18n="optionsCheckboxUsernameIcons"></span>
-              </label>
-              <span class="help-block">
-                <span data-i18n="optionsShowLoginFormIconHelpText"></span>
-              </span>
-            </div>
-          </p>
+          <div class="checkbox">
+            <label class="checkbox">
+              <input type="checkbox" name="showLoginFormIcon" value="true"/><span data-i18n="optionsCheckboxUsernameIcons"></span>
+            </label>
+            <span class="help-block">
+              <span data-i18n="optionsShowLoginFormIconHelpText"></span>
+            </span>
+          </div>
+        </p>
         <p>
           <div class="checkbox">
             <label class="checkbox">
@@ -87,7 +87,18 @@
             <span class="help-block">
               <span data-i18n="optionsUsePasswordGeneratorHelpText"></span>
               <br />
-              <span data-i18n="optionsUsePasswordGeneratorHelpTextSecond"></span></span>
+              <span data-i18n="optionsUsePasswordGeneratorHelpTextSecond"></span>
+            </span>
+          </div>
+        </p>
+        <p>
+          <div class="checkbox">
+            <label class="checkbox">
+              <input type="checkbox" name="showOTPIcon" value="true"/><span data-i18n="optionsCheckboxOTPIcons"></span>
+            </label>
+            <span class="help-block">
+              <span data-i18n="optionsShowOTPIconHelpText"></span>
+            </span>
           </div>
         </p>
         <hr />


### PR DESCRIPTION
This is an extension to #617.

New features:
- Adds a new OTP icon for filling
- Adjusts icon saturation based on database lock status (password and OTP icons are grey)

When DB is locked:
![closed](https://user-images.githubusercontent.com/24570482/66048758-ce132f00-e532-11e9-8d94-b3caf4a47027.png)

When open:
![open](https://user-images.githubusercontent.com/24570482/66048774-d4091000-e532-11e9-8bc3-7312fca06645.png)
