### PR TITLE
Add undefined type to the input field list

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -615,7 +615,8 @@ kpxcObserverHelper.inputTypes = [
     'tel',
     'number',
     'username', // Note: Not a standard
-    null // Input field can be without any type. Include these to the list.
+    undefined, // Input field can be without any type. Include this and null to the list.
+    null 
 ];
 
 // Ignores all nodes that doesn't contain elements


### PR DESCRIPTION
Adds `undefined` type to the accepted input field type's list. Extension's own `Element.prototype.getLowerCaseAttribute()` returns this instead of null.

Fixes #636.