### PR TITLE
Fix reseting association state

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -1158,6 +1158,8 @@ keepass.updatePopup = function(iconType) {
 
 // Updates the database hashes to content script
 keepass.updateDatabase = async function() {
+    keepass.associated.value = false;
+    keepass.associated.hash = null;
     await keepass.testAssociation(null);
     const configured = await keepass.isConfigured();
     keepass.updatePopup(configured ? 'normal' : 'cross');


### PR DESCRIPTION
When a database is changed to a non-connected one, the association state is not updated properly. This fix resets the associated values and makes sure the next command (`keepass.testAssociation`) does it job.

Basically, the extension thinks a db has already connected when it's not.

Steps to reproduce without the fix:
1) Activate database tab, open the database and connect it
2) Open a second tab, open the database and try to connect it
3) `keepass.associate()` returns because it thinks the database is already associated

Fixes https://github.com/keepassxreboot/keepassxc/issues/2765.