### PR TITLE
Update hashlist when connecting databases

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -202,6 +202,7 @@ options.initConnectedDatabases = function() {
 
         delete options.keyRing[hash];
         options.saveKeyRing();
+        hashList = options.keyRing;
 
         if ($('#tab-connected-databases table tbody:first tr').length > 2) {
             $('#tab-connected-databases table tbody:first tr.empty:first').hide();
@@ -216,6 +217,7 @@ options.initConnectedDatabases = function() {
     trClone.removeClass('clone');
 
     const addHashToTable = function(hash) {
+        $('#tab-connected-databases table tbody:first tr.empty:first').hide();
         const tr = trClone.clone(true);
         tr.data('hash', hash);
         tr.attr('id', 'tr-cd-' + hash);
@@ -231,7 +233,7 @@ options.initConnectedDatabases = function() {
         $('#tab-connected-databases table tbody:first').append(tr);
     }
 
-    const hashList = options.keyRing;
+    let hashList = options.keyRing;
     for (const hash in hashList) {
         addHashToTable(hash);
     }
@@ -248,6 +250,14 @@ options.initConnectedDatabases = function() {
         if (result === AssociatedAction.NEW_ASSOCIATION) {
             // Update the connection list with the added hash
             options.keyRing = await browser.runtime.sendMessage({ action: 'load_keyring' });
+
+            // This one is the first hash added
+            if (Object.keys(options.keyRing).length === 1) {
+                addHashToTable(Object.keys(options.keyRing)[0]);
+                hashList = options.keyRing;
+                return;
+            }
+
             for (const hash in hashList) {
                 const newHash = Object.keys(options.keyRing).find(h => h !== hash);
                 addHashToTable(newHash);


### PR DESCRIPTION
Internal hashlist in `options.js` was not updated when connecting new databases. For example, if the table was empty, first connected database didn't appear to it correctly.

Also, a new bug was found with the following steps when keeping the Connected Databases page open:
1) Have two databases in KeePassXC, connect the first database
2) Switch to the second database, connect it
3) Remove the first database from the Connected Databases list
4) Switch back to the first database and connect it
5) The database shows an identical ID in the table even when it differs

Both of these are now fixed.