### PR TITLE
Do not overwrite keyRing element with itself

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -851,7 +851,7 @@ keepass.updateLastUsed = function(hash) {
 };
 // Update the databaseHash from legacy hash
 keepass.updateDatabaseHash = function(oldHash, newHash) {
-    if (!oldHash || !newHash) {
+    if (!oldHash || !newHash || oldHash === newHash) {
         return;
     }
 


### PR DESCRIPTION
Using KeePassXC 2.5.0 with a database created with KeePassXC 2.5.0, decrypted messages from keepassxc-proxy contain an 'oldHash' and a 'hash' value that are equal. In that case, we must not try to replace the database hash ID in the keyRing, as it effectively leads to the keyRing entry to be destroyed without replacement.

This is a "regression" introduced with https://github.com/keepassxreboot/keepassxc-browser/commit/a2a7c20885f74d504e21f2850816d7fd31be8bff and only occurs when using KeePassXC 2.5.0 (currently in development) and a database which was created with KeePassXC 2.5.0 (2.4.3 binaries and database created with 2.4.3 even when used with 2.5.0 do have this problem). Only in that case the decoded proxy response contains the 'oldHash' value.

I don't know why that is the case. But independently of this, I think my change is reasonable as it adds robustness (the function does not work as intended if the two parameters are equal despite of version/protocol).