### PR TITLE
Ignore update icon if update check is set to never

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -881,9 +881,11 @@ keepass.keePassXCUpdateAvailable = function() {
         if (daysSinceLastCheck >= page.settings.checkUpdateKeePassXC) {
             keepass.checkForNewKeePassXCVersion();
         }
+
+        return keepass.compareVersion(keepass.currentKeePassXC, keepass.latestKeePassXC.version, false);
     }
 
-    return keepass.compareVersion(keepass.currentKeePassXC, keepass.latestKeePassXC.version, false);
+    return false;
 };
 
 keepass.checkForNewKeePassXCVersion = function() {

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -111,7 +111,7 @@ options.initGeneralSettings = function() {
     $('#tab-general-settings input#defaultGroup').val(options.settings['defaultGroup']);
 
     $('#tab-general-settings input[type=radio]').each(function() {
-        if ($(this).val() === options.settings[$(this).attr('name')]) {
+        if ($(this).val() === String(options.settings[$(this).attr('name')])) {
             $(this).attr('checked', options.settings[$(this).attr('name')]);
         }
     });


### PR DESCRIPTION
Update icon shows a little green star for a newer version of KeePassXC even if the settings is set to "Never". Also, the Settings page doesn't update the radio button value correctly.