### PR TITLE
Remove XML exclude from the manifest

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -48,10 +48,6 @@
             "matches": [
                 "<all_urls>"
             ],
-            "exclude_matches": [
-                "*://*/*.xml",
-                "*://*/*.xsd"
-            ],
             "js": [
                 "browser-polyfill.min.js",
                 "content/banner.js",


### PR DESCRIPTION
Removes the exclude for XML in the extension manifest. This was needed before when we were still using jQuery with content scripts (see #50). Current version is no longer affected by the issue.

Fixes #665.