### PR TITLE
Respect Site Preferences settings with the banner

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -44,12 +44,8 @@ kpxcBanner.create = async function(credentials = {}) {
     }
 
     // Don't show anything if the site is in the ignore
-    if (kpxc.settings.sitePreferences !== undefined) {
-        for (const site of kpxc.settings.sitePreferences) {
-            if (site.ignore !== IGNORE_NOTHING && (site.url === credentials.url || siteMatch(site.url, credentials.url))) {
-                return;
-            }
-        }
+    if (kpxc.siteIgnored(IGNORE_NORMAL)) {
+        return;
     }
 
     kpxcBanner.created = true;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -885,7 +885,7 @@ kpxc.detectDatabaseChange = async function(response) {
 };
 
 // Checks if the site has been ignored using Site Preferences
-kpxc.siteIgnored = function() {
+kpxc.siteIgnored = function(condition) {
     kpxc.initializeSitePreferences();
     if (kpxc.settings.sitePreferences) {
         let currentLocation;
@@ -897,9 +897,10 @@ kpxc.siteIgnored = function() {
             currentLocation = window.self.location.href;
         } 
 
+        const currentSetting = condition || IGNORE_FULL;
         for (const site of kpxc.settings.sitePreferences) {
             if (siteMatch(site.url, currentLocation) || site.url === currentLocation) {
-                if (site.ignore === IGNORE_FULL) {
+                if (site.ignore === currentSetting) {
                     return true;
                 }
 


### PR DESCRIPTION
When showing the new Credential Banner, checking the Site Preferences was able to return too soon and not check all the settings.

Instead, it's using the same `kpxc.siteIgnored()` that was implemented recently for another fix.

Fixes #626.