### PR TITLE
Check document.dir to determine the position of the icon.

### DIFF
--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -26,7 +26,7 @@ class Icon {
         if (!this.icon) {
             return;
         }
-    
+
         if (locked) {
            this.icon.style.filter = 'saturate(0%)';
         } else {
@@ -85,7 +85,12 @@ kpxcUI.setIconPosition = function(icon, field) {
     const size = Number(icon.getAttribute('size'));
 
     icon.style.top = Pixels((rect.top + document.scrollingElement.scrollTop) + offset + 1);
-    icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + field.offsetWidth - size - offset);
+    if (document.dir == 'rtl') {
+        icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + offset);
+    }
+    else {
+        icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + field.offsetWidth - size - offset);
+    }
 };
 
 /**

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -85,7 +85,7 @@ kpxcUI.setIconPosition = function(icon, field) {
     const size = Number(icon.getAttribute('size'));
 
     icon.style.top = Pixels((rect.top + document.scrollingElement.scrollTop) + offset + 1);
-    if (document.dir == 'rtl') {
+    if (document.dir === 'rtl') {
         icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + offset);
     }
     else {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -87,8 +87,7 @@ kpxcUI.setIconPosition = function(icon, field) {
     icon.style.top = Pixels((rect.top + document.scrollingElement.scrollTop) + offset + 1);
     if (document.dir === 'rtl') {
         icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + offset);
-    }
-    else {
+    } else {
         icon.style.left = Pixels((rect.left + document.scrollingElement.scrollLeft) + field.offsetWidth - size - offset);
     }
 };


### PR DESCRIPTION
Function `kpxcUI.setIconPosition` doesn't take into consideration the direction of the page's direction. In RTL(right to left) websites, the icon is displayed on top of the text instead of the opposite side(left).
Fixes #701 .