### PR TITLE
Reset password filled boolean state on page reload

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -138,6 +138,7 @@ page.clearLogins = function(tabId) {
     }
 
     page.tabs[tabId].loginList = [];
+    page.passwordFilled = false;
 };
 
 page.setSubmittedCredentials = function(submitted, username, password, url, oldCredentials) {


### PR DESCRIPTION
Resets password filled state after page reload. This bug causes the icons not to show after a fill.

How to reproduce:
- Open any site you have credentials to with current `develop` branch.
- Fill any login
- Reload the page. Icons are no longer shown.

Related to changes made with https://github.com/keepassxreboot/keepassxc-browser/pull/625.