### PR TITLE
Ignore TOTP icons if the field is too small

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const MINIMUM_SIZE = 60;
+
 var kpxcTOTPIcons = {};
 kpxcTOTPIcons.icons = [];
 
@@ -25,7 +27,7 @@ class TOTPFieldIcon extends Icon {
 };
 
 TOTPFieldIcon.prototype.initField = function(field) {
-    if (!field || field.getAttribute('kpxc-totp-field') === 'true') {
+    if (!field || field.getAttribute('kpxc-totp-field') === 'true' || field.offsetWidth < MINIMUM_SIZE) {
         return;
     }
 

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -27,7 +27,11 @@ class TOTPFieldIcon extends Icon {
 };
 
 TOTPFieldIcon.prototype.initField = function(field) {
-    if (!field || field.getAttribute('kpxc-totp-field') === 'true' || field.offsetWidth < MINIMUM_SIZE) {
+    if (!field
+        || field.getAttribute('kpxc-totp-field') === 'true' 
+        || field.offsetWidth < MINIMUM_SIZE
+        || field.size < 2
+        || (field.maxLength > 0 && field.maxLength < 4)) {
         return;
     }
 


### PR DESCRIPTION
Fixes #714.