### PR TITLE
Move DOM elements to Shadow DOM

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -81,5 +81,14 @@ TOTPFieldIcon.prototype.createIcon = function(field) {
 
     kpxcUI.setIconPosition(icon, field);
     this.icon = icon;
-    document.body.appendChild(icon);
+
+    const styleSheet = document.createElement('link');
+    styleSheet.setAttribute('rel', 'stylesheet');
+    styleSheet.setAttribute('href', browser.runtime.getURL('css/totp.css'));
+
+    const wrapper = document.createElement('div');
+    this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
+    this.shadowRoot.append(styleSheet);
+    this.shadowRoot.append(icon);
+    document.body.append(wrapper);
 };

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -166,6 +166,13 @@ const initColorTheme = function(elem) {
     }
 };
 
+const createStylesheet = function(file) {
+    const stylesheet = document.createElement('link');
+    stylesheet.setAttribute('rel', 'stylesheet');
+    stylesheet.setAttribute('href', browser.runtime.getURL(file));
+    return stylesheet;
+};
+
 // Enables dragging
 document.addEventListener('mousemove', function(e) {
     if (!kpxcUI.mouseDown) {
@@ -211,4 +218,17 @@ HTMLDivElement.prototype.appendMultiple = function(...args) {
 
 Element.prototype.getLowerCaseAttribute = function(attr) {
     return this.getAttribute(attr) ? this.getAttribute(attr).toLowerCase() : undefined;
+};
+
+Element.prototype._attachShadow = Element.prototype.attachShadow;
+Element.prototype.attachShadow = function () {
+    return this._attachShadow( { mode: 'closed' } );
+};
+
+Object.prototype.shadowSelector = function(value) {
+    return this.shadowRoot ? this.shadowRoot.querySelector(value) : undefined;
+};
+
+Object.prototype.shadowSelectorAll = function(value) {
+    return this.shadowRoot ? this.shadowRoot.querySelectorAll(value) : undefined;
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -100,7 +100,16 @@ UsernameFieldIcon.prototype.createIcon = function(target) {
 
     kpxcUI.setIconPosition(icon, field);
     this.icon = icon;
-    document.body.appendChild(icon);
+
+    const styleSheet = document.createElement('link');
+    styleSheet.setAttribute('rel', 'stylesheet');
+    styleSheet.setAttribute('href', browser.runtime.getURL('css/username.css'));
+
+    const wrapper = document.createElement('div');
+    this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
+    this.shadowRoot.append(styleSheet);
+    this.shadowRoot.append(icon);
+    document.body.append(wrapper);
 };
 
 const iconClicked = async function(field, icon) {

--- a/keepassxc-browser/css/pwgen.css
+++ b/keepassxc-browser/css/pwgen.css
@@ -65,11 +65,6 @@
     width: 100% !important;
 }
 
-.kpxc-pwgen-checkbox-label {
-    font-style: normal !important;
-    font-weight: normal !important;
-}
-
 .kpxc #kpxc-pwgen-error {
     color: var(--text-color);
     font-size: 12px !important;

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -110,7 +110,14 @@
         "icons/keepassxc.svg",
         "icons/key.svg",
         "icons/locked.svg",
-        "icons/otp.svg"
+        "icons/otp.svg",
+        "css/autocomplete.css",
+        "css/banner.css",
+        "css/button.css",
+        "css/colors.css",
+        "css/pwgen.css",
+        "css/username.css",
+        "css/totp.css"
     ],
     "permissions": [
         "activeTab",


### PR DESCRIPTION
Moves all DOM elements to Shadow DOM.

Not originally meant as a security feature, but it adds a little more protection to the DOM elements extension is using. `Element.prototype.attachShadow` is overridden by the extension, so a page or a script cannot override it and make Shadow DOM visible. This makes receiving any usernames or other possibly sensitive information more difficult by malicious extensions or scripts.

Also, pages will no longer override CSS styles defined by the extension.

The downsides of this feature is that all CSS files must be included to the content scripts, and minimum Firefox version must be increased from 52 to 63. However, even the ESR release of Firefox is now at version 68.

Fixes #600.
Fixes #717.