### PR TITLE
[WIP] Allow filling attributes to fields from context menu

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -11,6 +11,10 @@
         "message": "Fill Password Only",
         "description": "Context menu item for filling password."
     },
+    "contextMenuFillAttribute": {
+        "message": "Fill attribute…",
+        "description": "Context menu parent item for filling a custom attribute"
+    },
     "contextMenuFillTOTP": {
         "message": "Fill TOTP",
         "description": "Context menu item for filling Time-based One Time Password."

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -47,6 +47,9 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             _called.manualFillRequested = ManualFill.PASS;
             await kpxc.receiveCredentialsIfNecessary();
             kpxc.fillInFromActiveElement(false, true); // passOnly to true
+        } else if (req.action === 'fill_attribute' && 'args' in req && 'attribute' in req.args) {
+            await kpxc.receiveCredentialsIfNecessary();
+            kpxc.fillInFromActiveElementAttribute(null, req.args.attribute);
         } else if (req.action === 'fill_totp') {
             await kpxc.receiveCredentialsIfNecessary();
             kpxc.fillInFromActiveElementTOTPOnly();
@@ -1272,6 +1275,18 @@ kpxc.fillInFromActiveElement = function(suppressWarnings, passOnly = false) {
     delete combination.loginId;
 
     kpxc.fillInCredentials(combination, passOnly, suppressWarnings);
+};
+
+kpxc.fillInFromActiveElementAttribute = async function(target, attribute) {
+    const el = target || document.activeElement;
+
+    const allStringFields = kpxc.credentials[0].stringFields.reduce((acc, obj) => ({
+        ...acc,
+        ...obj,
+    }), {});
+
+    const value = allStringFields[`KPH: ${attribute}`];
+    kpxc.setValueWithChange(el, value);
 };
 
 kpxc.fillInFromActiveElementTOTPOnly = async function(target) {


### PR DESCRIPTION
I decided to have a shot at implementing #390.

This is tested so far only in Firefox.

I request feedback, please.

I reworked how the context menu is built slightly, to allow arbitrary context menu item options to be passed in, and to allow arbitrary arguments to be sent along with the action, and to allow reuse of the logic which converts from the terse form of an item to the options object passed to the browser.

Questions:

1. How are other languages usually populated? Should I start off by just grabbing translations from Google Translate?
2. How should I be handling multiple sets of credentials here? I'm currently assuming there's exactly one set, and so grabbing the first one. Please give some guidance.
3. Am I running the credentials retrieval and context menu rebuilding code correctly and at the right time? See `background/init.js`.
4. Right now it's using the `KPH` attributes, since these are the only ones I seem to be able to get from Keepassxc. Am I right in saying a change to Keepassxc is needed to get others? I personally would like it to offer me *all* the attributes in this context menu; I'd rather not have to prefix them to appear here, I think. If a change is necessary, can you help guide me on that, please? My C++ is beginner-level.
5. Am I handling the attributes correctly? I don't understand why they're retrieved as an array of objects, each with one key in it. It necessitates a pretty ugly reduce call to get them all into one object so I can get the one I'm looking for or loop through them conveniently.
6. Any thoughts about what the menu structure should be?
7. What does KPH stand for? I'm guessing the KP is Keepass...

To do:

- ~Add "Fill attribute…" message in locales other than English~
- [ ] Properly handle multiple sets of credentials
- [ ] Ensure I'm running the credentials retrieval and context menu rebuilding code correctly and at the right time
- ~Get *all* attributes, or ones with a special new prefix other than `KPH: `, since this isn't what those are for~
- [x] Ensure I'm handling the attributes correctly
- [x] Finalize menu structure
- [ ] Test in Chrome