### PR TITLE
Use the autocomplete attribute as a hint

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -300,11 +300,16 @@ kpxcFields.isVisible = function(field) {
     return true;
 };
 
+kpxcFields.isAutocompleteAppropriate = function(field) {
+    const autocomplete = field.getLowerCaseAttribute('autocomplete');
+    return !(autocomplete === 'off' || autocomplete === 'new-password');
+};
+
 kpxcFields.getAllFields = function() {
     const fields = [];
     const inputs = kpxcObserverHelper.getInputs(document);
     for (const i of inputs) {
-        if (kpxcFields.isVisible(i) && !kpxcFields.isSearchField(i)) {
+        if (kpxcFields.isVisible(i) && !kpxcFields.isSearchField(i) && kpxcFields.isAutocompleteAppropriate(i)) {
             kpxcFields.setUniqueId(i);
             fields.push(i);
         }
@@ -992,8 +997,9 @@ kpxc.initOTPFields = function(inputs, databaseClosed) {
     for (const i of inputs) {
         const id = i.getLowerCaseAttribute('id');
         const name = i.getLowerCaseAttribute('name');
+        const autocomplete = i.getLowerCaseAttribute('autocomplete');
 
-        if (acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f)))) {
+        if (autocomplete === 'one-time-code' || acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f)))) {
             kpxcTOTPIcons.newIcon(i, _databaseClosed);
         }
     }


### PR DESCRIPTION
The change: Do not add helpers on fields that have `autocomplete="off"` or `autocomplete="new-password"`. Identify fields with `autocomplete="one-time-code"` as TOTP fields.

Feel free to change things such as function naming, etc. I hope this PR is a good demonstration of what I am looking for. I used this MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

I think it would also be good to somehow be able to configure how aggressive the extension should be in trying to identify things. Sometimes I see the helpers on way too many fields and it would be nice to maybe have a "strict" mode option? Remember how browsers used to have (or still have?) a Quirks mode and Strict mode.

Anyhow, I hope you consider this. Thanks!