### PR TITLE
Allow label to trigger ignore checkbox

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -69,8 +69,8 @@ kpxcBanner.create = async function(credentials = {}) {
     const dismissButton = kpxcUI.createElement('button', 'kpxc-button kpxc-red-button', { 'id': 'kpxc-banner-btn-dismiss' }, tr('popupButtonDismiss'));
 
     const separator = kpxcUI.createElement('div', 'kpxc-separator');
-    const ignoreCheckbox = kpxcUI.createElement('input', 'kpxc-checkbox', { type: 'checkbox', name: 'ignoreCheckbox' });
-    const checkboxLabel = kpxcUI.createElement('label', 'kpxc-checkbox-label', { for: 'ignoreCheckbox' }, tr('popupButtonIgnore'));
+    const ignoreCheckbox = kpxcUI.createElement('input', 'kpxc-checkbox', { type: 'checkbox', name: 'ignoreCheckbox', id: 'kpxc-banner-ignoreCheckbox' });
+    const checkboxLabel = kpxcUI.createElement('label', 'kpxc-checkbox-label', { for: 'kpxc-banner-ignoreCheckbox' }, tr('popupButtonIgnore'));
 
     // No existing credentials to update --> disable Update button
     if (credentials.list.length === 0) {


### PR DESCRIPTION
It's not possible to click on the ignore label in the banner, the reason is that the input tag of the checkbox doesn't have a id.

This PR adds an unique id and changes the "for" attribute.
