### PR TITLE
Add submit button type to query with forms

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1190,7 +1190,7 @@ kpxc.getFormSubmitButton = function(form) {
     }
 
     // Try to find another button. Select the first one.
-    const buttons = Array.from(form.querySelectorAll('button[type=\'button\'], input[type=\'button\'], button:not([type])'));
+    const buttons = Array.from(form.querySelectorAll('button[type=\'button\'], button[type=\'submit\'], input[type=\'button\'], button:not([type])'));
     if (buttons.length > 0) {
         return buttons[0];
     }


### PR DESCRIPTION
In some cases the submit button is not identified in the first round it's checked against `form.action`. This ensures the button will be returned later when inspecting all buttons inside a form.

Fixes #740.