### PR TITLE
Save to Root group if defined without default group

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -128,9 +128,16 @@ kpxcBanner.saveNewCredentials = async function(credentials = {}) {
     // Or when default group is not set and defaultGroupAskAlways is disabled -> save to default
     if ((result.groups === undefined || (result.groups.length > 0 && result.groups[0].children.length === 0)) ||
         (!result.defaultGroupAlwaysAsk && (result.defaultGroup === '' || result.defaultGroup === DEFAULT_BROWSER_GROUP))) {
+        let args = [ credentials.username, credentials.password, credentials.url ];
+
+        // If root group is defined by the user, and there's no default browser group, save the credentials to the root group
+        if (result.groups[0].children.length === 0 && result.defaultGroup.toLowerCase() === 'root') {
+            args.push(result.groups[0].name, result.groups[0].uuid);
+        }
+
         const res = await browser.runtime.sendMessage({
             action: 'add_credentials',
-            args: [ credentials.username, credentials.password, credentials.url ]
+            args: args
         });
         kpxcBanner.verifyResult(res);
         return;


### PR DESCRIPTION
If user has defined the Root group for saving new credentials, and the default group KeePassXC-Browser Passwords doesn't exists, the default group is created.

This respects the user's choice and doesn't create the default group if there's no subgroups at all under Root. This bug was not visible if one or more subgroups existed.

Fixes #730.