### PR TITLE
Add Save Domain Only option when saving new credentials

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -691,6 +691,10 @@
         "message": "When saving new credentials, save only the domain instead of full URL.",
         "description": "Save domain only option help text."
     },
+    "optionsSaveDomainOnlyCustomLoginHelpText": {
+        "message": "When saving new custom login fields, save only the domain instead of full URL.",
+        "description": "Save domain only option help text."
+    },
     "optionsAutoFillAndSendHelpText": {
         "message": "If credentials are found for a page and the login-type is an HTTP Basic Auth request, KeePassXC-Browser tries to login with the first given credentials.",
         "description": "Auto-Fill And Send option help text."

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -13,6 +13,7 @@ const defaultSettings = {
     showLoginFormIcon: true,
     showOTPIcon: true,
     saveDomainOnly: true,
+    saveDomainOnlyNewCreds: false,
     autoReconnect: false,
     defaultGroup: '',
     defaultGroupAlwaysAsk: false
@@ -68,6 +69,9 @@ page.initSettings = async function() {
         }
         if (!('saveDomainOnly' in page.settings)) {
             page.settings.saveDomainOnly = defaultSettings.saveDomainOnly;
+        }
+        if (!('saveDomainOnlyNewCreds' in page.settings)) {
+            page.settings.saveDomainOnlyNewCreds = defaultSettings.saveDomainOnlyNewCreds;
         }
         if (!('autoReconnect' in page.settings)) {
             page.settings.autoReconnect = defaultSettings.autoReconnect;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1654,7 +1654,7 @@ kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue
 
         let url = this.action;
         if (!url) {
-            url = kpxc.getDocumentLocation();
+            url = kpxc.settings.saveDomainOnlyNewCreds ? document.location.origin : document.location.href;
             if (url.indexOf('?') > 0) {
                 url = url.substring(0, url.indexOf('?'));
                 if (url.length < document.location.origin.length) {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -161,6 +161,12 @@
               <input type="checkbox" name="showLoginNotifications" value="true" /><span data-i18n="optionsCheckboxShowLoginNotifications"></span>
             </label>
           </div>
+          <div class="checkbox">
+            <label class="checkbox">
+              <input type="checkbox" name="saveDomainOnlyNewCreds" value="true" /><span data-i18n="optionsSaveDomainOnly"></span>
+            </label>
+            <span class="help-block" data-i18n="optionsSaveDomainOnlyHelpText"></span>
+          </div>
         </p>
         <hr />
         <p>
@@ -168,7 +174,7 @@
             <label class="checkbox">
               <input type="checkbox" name="saveDomainOnly" value="true" /><span data-i18n="optionsSaveDomainOnly"></span>
             </label>
-            <span class="help-block" data-i18n="optionsSaveDomainOnlyHelpText"></span>
+            <span class="help-block" data-i18n="optionsSaveDomainOnlyCustomLoginHelpText"></span>
           </div>
         </p>
         <hr />


### PR DESCRIPTION
- Fixes the incorrect text in the settings that only applies to Custom Login fields
- Adds a new option under credential saving that allows saving domain only (subdomains are included) instead of full URL

Fixes #736.