### PR TITLE
Show Credential banner only in the main page

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -118,7 +118,11 @@ kpxcBanner.create = async function(credentials = {}) {
     banner.appendMultiple(bannerInfo, bannerButtons);
 
     initColorTheme(banner);
-    window.parent.document.body.appendChild(banner);
+
+    const existingBanner = window.parent.document.body.querySelector('.kpxc-banner');
+    if (existingBanner === null) {
+        window.parent.document.body.appendChild(banner);
+    }
 };
 
 kpxcBanner.saveNewCredentials = async function(credentials = {}) {

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -118,7 +118,7 @@ kpxcBanner.create = async function(credentials = {}) {
     banner.appendMultiple(bannerInfo, bannerButtons);
 
     initColorTheme(banner);
-    document.body.appendChild(banner);
+    window.parent.document.body.appendChild(banner);
 };
 
 kpxcBanner.saveNewCredentials = async function(credentials = {}) {


### PR DESCRIPTION
Appends the Credential banner only to the main page instead of any iframes.

Fixes #695.