### PR TITLE
Fix #765, always refresh crendentials before inserting them

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1222,20 +1222,17 @@ kpxc.fillInCredentials = async function(combination, onlyPassword, suppressWarni
         kpxc.p = p;
     }
 
-    if (kpxc.url === document.location.origin && kpxc.submitUrl === action && kpxc.credentials.length > 0) {
-        kpxc.fillIn(combination, onlyPassword, suppressWarnings);
-    } else {
-        kpxc.url = document.location.origin;
-        kpxc.submitUrl = action;
+    kpxc.url = document.location.origin;
+    kpxc.submitUrl = action;
 
-        const credentials = await browser.runtime.sendMessage({
-            action: 'retrieve_credentials',
-            args: [ kpxc.url, kpxc.submitUrl, true ] // Sets triggerUnlock to true
-        });
+    const credentials = await browser.runtime.sendMessage({
+        action: 'retrieve_credentials',
+        args: [ kpxc.url, kpxc.submitUrl, true ] // Sets triggerUnlock to true
+    });
 
-        await kpxc.retrieveCredentialsCallback(credentials, true);
-        kpxc.fillIn(combination, onlyPassword, suppressWarnings);
-    }
+    await kpxc.retrieveCredentialsCallback(credentials, true);
+    kpxc.fillIn(combination, onlyPassword, suppressWarnings);
+  
 };
 
 kpxc.fillInFromActiveElement = function(suppressWarnings, passOnly = false) {


### PR DESCRIPTION
Fix #765 Password is not being refreshed after creating a new one in KeePassXC
Implements solution 2
kpxc.fillInCredentials now always requests all credentials from KeePassXC

I have tested it once with a good case. It seems to be working fine.
I have not tested any side-effects yet.