### PR TITLE
Fixes for 1.5.5

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -29,7 +29,11 @@ kpxcBanner.destroy = function() {
 };
 
 kpxcBanner.create = async function(credentials = {}) {
-    if (!kpxc.settings.showLoginNotifications || kpxcBanner.created) {
+    const connectedDatabase = await browser.runtime.sendMessage({
+        action: 'get_connected_database'
+    });
+
+    if (!kpxc.settings.showLoginNotifications || kpxcBanner.created || connectedDatabase.identifier === null) {
         return;
     }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -303,7 +303,7 @@ kpxcFields.isVisible = function(field) {
 
 kpxcFields.isAutocompleteAppropriate = function(field) {
     const autocomplete = field.getLowerCaseAttribute('autocomplete');
-    return !(autocomplete === 'off' || autocomplete === 'new-password');
+    return autocomplete !== 'new-password';
 };
 
 kpxcFields.getAllFields = function() {
@@ -334,7 +334,7 @@ kpxcFields.getAllFields = function() {
 kpxcFields.prepareVisibleFieldsWithID = function(pattern) {
     const patterns = document.querySelectorAll(pattern);
     for (const i of patterns) {
-        if (kpxcFields.isVisible(i) && i.style.visibility !== 'hidden' && i.style.visibility !== 'collapsed') {
+        if (kpxcFields.isVisible(i)) {
             kpxcFields.setUniqueId(i);
         }
     }
@@ -347,7 +347,7 @@ kpxcFields.getAllCombinations = function(inputs) {
     for (const i of inputs) {
         if (i) {
             if (i.getLowerCaseAttribute('type') === 'password') {
-                const uId = (!uField || uField.length < 1) ? null : uField.getAttribute('data-kpxc-id');
+                const uId = (!uField || uField.size < 1) ? null : uField.getAttribute('data-kpxc-id');
 
                 const combination = {
                     username: uId,
@@ -673,6 +673,7 @@ kpxcObserverHelper.getInputs = function(target) {
         let type = i.getLowerCaseAttribute('type');
 
         if (kpxcObserverHelper.inputTypes.includes(type)) {
+            kpxcFields.setUniqueId(i);
             inputs.push(i);
         }
     }


### PR DESCRIPTION
Final fixes for the next release:
- Don't show Credential Banner if the active database is not connected.
- Remove `autocomplete="off"` check added from #723. It causes problems with a lot of pages.
- Add unique ID's dynamically detected fields.
- Switch undefined `.length` check to `.size`.