### PR TITLE
Modify TOTP keyboard shortcut

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -94,8 +94,8 @@
         "fill_totp": {
             "description": "__MSG_contextMenuFillTOTP__",
             "suggested_key": {
-                "default": "Alt+Shift+T",
-                "mac": "MacCtrl+Shift+T"
+                "default": "Alt+Shift+O",
+                "mac": "MacCtrl+Shift+O"
             }
         },
         "show_password_generator": {


### PR DESCRIPTION
Windows and Linux enviroments are using the original shortcut `Alt+Shift+T` for opening the tools menu item. Changing the default shortcut for all OS's to `Alt+Shift+O`.

Fixes #759.