### PR TITLE
TOTP icon improvements

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MINIMUM_SIZE = 60;
+const ignoreRegex = /^(zip|postal).*code$/i;
 
 var kpxcTOTPIcons = {};
 kpxcTOTPIcons.icons = [];
@@ -28,10 +29,13 @@ class TOTPFieldIcon extends Icon {
 
 TOTPFieldIcon.prototype.initField = function(field) {
     if (!field
+        || field.type === 'password'
         || field.getAttribute('kpxc-totp-field') === 'true'
         || field.offsetWidth < MINIMUM_SIZE
         || field.size < 2
-        || (field.maxLength > 0 && field.maxLength < 4)) {
+        || (field.maxLength > 0 && field.maxLength < 4)
+        || field.id.match(ignoreRegex)
+        || field.name.match(ignoreRegex)) {
         return;
     }
 


### PR DESCRIPTION
Ignores TOTP field icons when input field type is `password` or input field name/id begins with `zip`/`postal` and ends with `code`.

Fixes #768.