### PR TITLE
Replace p with div as wrapper

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -248,7 +248,7 @@
                       <p></p>
                       <button class="btn btn-sm btn-success checkUpdateKeePassXC"><i class="fa fa-refresh" aria-hidden="true"></i><span data-i18n="optionsButtonUpdate"></span></button>
                     </div>
-                    <p>
+                    <div class="mt-3">
                       <div data-i18n="optionsRadioText"></div>
                       <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="checkUpdateKeePassXC" id="inlineRadio1" value="3">
@@ -266,7 +266,7 @@
                         <input class="form-check-input" type="radio" name="checkUpdateKeePassXC" id="inlineRadio4" value="0">
                         <label class="form-check-label" for="inlineRadio4"><span data-i18n="optionsRadioNever"></span></label>
                       </div>
-                    </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
The p works as space because  at gets spitted/closed&opened by the browser to no harm the design.
![image](https://user-images.githubusercontent.com/1295633/75550231-c7310f80-5a31-11ea-8235-0b2334ebf7d8.png)


With change
![image](https://user-images.githubusercontent.com/1295633/75550159-951fad80-5a31-11ea-8fbd-84e52a04f23a.png)
