### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+
+# Get rid of whitespace to avoid diffs with a bunch of EOL changes
+trim_trailing_whitespace = true
+
+[*.{html,json}]
+indent_size = 2
+
+[*.{js,css}]
+indent_size = 4


### PR DESCRIPTION
A lot of editors support a editorconfig (with or without a extra plugin) and sets the behavior like indent to current project and not global preferred setting.
It will cause no harm for a editor without support. Avoids sometimes unnecessary line changes and helps to get uniform code.
https://editorconfig.org/