### PR TITLE
Fix theme switching with Firefox

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -83,9 +83,9 @@ options.initGeneralSettings = function() {
         $('#tab-general-settings select#colorTheme').val(options.settings['colorTheme']);
     }
 
-    $('#tab-general-settings select:first').change(function() {
+    $('#tab-general-settings select:first').change(async function() {
         options.settings['colorTheme'] = $(this).val();
-        options.saveSettings();
+        await options.saveSettingsPromise();
         location.reload();
     });
 


### PR DESCRIPTION
Theme switch & page reload is not working properly with Firefox. The new settings are loaded too soon.

Switched to Promise when saving settings, so it is more reliable for on-the-fly changes.