### PR TITLE
Seperate card for In/Export

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -307,12 +307,17 @@
                       <span class="form-text text-muted" data-i18n="optionsSaveDomainOnlyCustomLoginHelpText"></span>
                     </div>
                   </div>
+                </div>
+              </div>
 
+              <div class="card my-4 shadow">
+                <div class="card-header h6 rounded-0">
+                  <i class="fa fa-exchange fa-rotate-90" aria-hidden="true"></i>
+                  <span data-i18n="optionsImportExportSettings"></span>
+                </div>
+
+                <div class="card-body">
                   <div class="form-group">
-                    <div class="help-block">
-                      <span data-i18n="optionsImportExportSettings"></span>
-                    </div>
-                    <br />
                     <button class="btn btn-sm btn-primary" id="importSettingsButton"><i class="fa fa-arrow-down" aria-hidden="true"></i><span data-i18n="optionsButtonImport"></span></button>
                     <button class="btn btn-sm btn-primary" id="exportSettingsButton"><i class="fa fa-arrow-up" aria-hidden="true"></i><span data-i18n="optionsButtonExport"></span></button>
                   </div>


### PR DESCRIPTION
Instead of the help text, put the in/export into a separate card. it is no advanced setting.

![image](https://user-images.githubusercontent.com/1295633/76871022-d5bd5a80-686a-11ea-80fd-cb8d0d02cf82.png)
