### PR TITLE
 Update datetime on reconnect

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -839,6 +839,8 @@ keepass.saveKey = function(hash, id, key) {
         keepass.keyRing[hash].id = id;
         keepass.keyRing[hash].key = key;
         keepass.keyRing[hash].hash = hash;
+        keepass.keyRing[hash].created = new Date().valueOf();
+        keepass.keyRing[hash].lastUsed = new Date().valueOf();
     }
     browser.storage.local.set({ 'keyRing': keepass.keyRing });
 };
@@ -849,6 +851,7 @@ keepass.updateLastUsed = function(hash) {
         browser.storage.local.set({ 'keyRing': keepass.keyRing });
     }
 };
+
 // Update the databaseHash from legacy hash
 keepass.updateDatabaseHash = function(oldHash, newHash) {
     if (!oldHash || !newHash || oldHash === newHash) {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.5.4",
-    "version_name": "1.5.4",
+    "version": "1.6.0",
+    "version_name": "1.6.0",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -287,7 +287,7 @@ options.initConnectedDatabases = function() {
         });
     });
 
-    $('#dialogDeleteConnectedDatabase .modal-footer:first button.yes:first').click(function(e) {
+    $('#dialogDeleteConnectedDatabase .modal-footer:first button.yes:first').click(async function(e) {
         $('#dialogDeleteConnectedDatabase').modal('hide');
 
         const hash = $('#dialogDeleteConnectedDatabase').data('hash');
@@ -296,6 +296,11 @@ options.initConnectedDatabases = function() {
         delete options.keyRing[hash];
         options.saveKeyRing();
         hashList = options.keyRing;
+
+        // Force reconnect so the extension will disconnect the current database
+        await browser.runtime.sendMessage({ action: 'reconnect' }).catch(err => {
+            console.log(err);
+        });
 
         if ($('#tab-connected-databases table tbody:first tr').length > 2) {
             $('#tab-connected-databases table tbody:first tr.empty:first').hide();


### PR DESCRIPTION
If the hash already exists in the extension, the Created datetime is not updated properly. The connection is also not disconnected when the key is removed from the extension.

The manifest version bumb is made here, as this is the last PR for the new release.