### PR TITLE
Disable group name settings with older versions

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -281,7 +281,7 @@
                       <input class="form-check-input" type="checkbox" name="showGroupNameInAutocomplete" id="showGroupNameInAutocomplete" value="true" />
                       <label class="form-check-label" for="showGroupNameInAutocomplete" data-i18n="optionsCheckboxShowGroupNameInAutocomplete"></label>
                       <span class="form-text text-muted" data-i18n="optionsShowGroupNameInAutocompleteHelpText"></span>
-                      <div class="alert alert-info mt-3 col-lg-9" role="alert">
+                      <div class="alert alert-info mt-3 col-lg-9" role="alert" id="versionRequiredAlert">
                         <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
                         <span data-i18n="optionsKeePassXCVersionRequired" i18n-placeholder="2.6.0"></span>
                       </div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -269,6 +269,12 @@ options.showKeePassXCVersions = function(response) {
     $('#tab-about em.versionKPH').text(response.current);
     $('#tab-about span.kpxcVersion').text(response.current);
     $('#tab-general-settings button.checkUpdateKeePassXC:first').attr('disabled', false);
+
+    if (response.current.startsWith('2.6') || response.current === '2.5.3-snapshot') {
+        $('#tab-general-settings #versionRequiredAlert').hide();
+    } else {
+        $('#tab-general-settings #showGroupNameInAutocomplete').attr('disabled', true);
+    }
 };
 
 options.getPartiallyHiddenKey = function(key) {


### PR DESCRIPTION
- Disables the Display group name option with older KeePassXC versions that don't support it
- Hides the warning if the version requirement is met