### PR TITLE
Fix range input type saving with Firefox

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -145,9 +145,9 @@ options.initGeneralSettings = function() {
     });
 
     // Only save the setting when mouse is released from the range input
-    $('#tab-general-settings input[type=range]').change(function(e) {
+    $('#tab-general-settings input[type=range]').change(async function(e) {
         options.settings['redirectAllowance'] = e.target.valueAsNumber;
-        options.saveSettings();
+        await options.saveSettingsPromise();
     });
 
     browser.runtime.sendMessage({
@@ -254,7 +254,7 @@ options.initGeneralSettings = function() {
     $('#copyVersionToClipboard').on('click', function () {
         const copyText = document.getElementById('versionInfo').innerText;
         navigator.clipboard.writeText(copyText);
-    })
+    });
 };
 
 options.showKeePassXCVersions = function(response) {


### PR DESCRIPTION
With Firefox the settings are not properly saved before loading them again. Use a Promise version of the save to solve that.

Fixes #822.