### PR TITLE
Fix default group saving

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.6.1",
-    "version_name": "1.6.1",
+    "version": "1.6.2",
+    "version_name": "1.6.2",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -197,8 +197,8 @@
                     <div class="input-group">
                       <input class="form-control form-control-sm col-md-8 col-lg-6" type="text" id="defaultGroup" placeholder="KeePassXC-Browser Passwords">
                       <div class="input-group-append">
-                        <button class="btn btn-sm btn-primary" type="button"><i class="fa fa-save" aria-hidden="true"></i><span data-i18n="optionsButtonSave"></span></button>
-                        <button class="btn btn-sm btn-danger" type="button"><i class="fa fa-remove" aria-hidden="true"></i><span data-i18n="optionsButtonReset"></span></button>
+                        <button class="btn btn-sm btn-primary" type="button" id="defaultGroupButton"><i class="fa fa-save" aria-hidden="true"></i><span data-i18n="optionsButtonSave"></span></button>
+                        <button class="btn btn-sm btn-danger" type="button" id="defaultGroupButtonReset"><i class="fa fa-remove" aria-hidden="true"></i><span data-i18n="optionsButtonReset"></span></button>
                       </div>
                       <span class="form-text text-muted w-100" data-i18n="optionsDefaultGroupHelpText"></span>
                     </div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -179,18 +179,18 @@ options.initGeneralSettings = function() {
         });
     });
 
-    $('#defaultGroupButton').click(function() {
+    $('#defaultGroupButton').click(async function() {
         const value = $('#defaultGroup').val();
         if (value.length > 0) {
             options.settings['defaultGroup'] = value;
-            options.saveSettings();
+            await options.saveSettingsPromise();
         }
     });
 
-    $('#defaultGroupButtonReset').click(function() {
+    $('#defaultGroupButtonReset').click(async function() {
         $('#defaultGroup').val('');
         options.settings['defaultGroup'] = '';
-        options.saveSettings();
+        await options.saveSettingsPromise();
     });
 
     let temporarySettings;


### PR DESCRIPTION
With the new theme, the button ID's were accidentally removed and the saving didn't work properly.

Fixes #827.