### PR TITLE
Fix TOTP field maxLength comparison & do not override TOTP icon

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -34,7 +34,7 @@ TOTPFieldIcon.prototype.initField = function(field) {
         || field.getAttribute('kpxc-totp-field') === 'true'
         || field.offsetWidth < MINIMUM_SIZE
         || field.size < 2
-        || (field.maxLength > 0 && field.maxLength < 4)
+        || (field.maxLength > 0 && (field.maxLength < 6 || field.maxLength > 8))
         || field.id.match(ignoreRegex)
         || field.name.match(ignoreRegex)) {
         return;

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -41,7 +41,10 @@ class UsernameFieldIcon extends Icon {
 }
 
 UsernameFieldIcon.prototype.initField = function(field) {
-    if (!field || field.getAttribute('kpxc-username-field') === 'true' || !kpxcFields.isVisible(field)) {
+    if (!field
+        || field.getAttribute('kpxc-username-field') === 'true'
+        || field.getAttribute('kpxc-totp-field') === 'true'
+        || !kpxcFields.isVisible(field)) {
         return;
     }
 


### PR DESCRIPTION
Comparison `field.maxLength < 4` doesn't work properly when `maxLength` is greater than allowed value.

Also fixes an issue where the username icon would override TOTP icon.

Fixes #842.