### PR TITLE
Translate Lock database text

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -1004,28 +1004,28 @@
         "description": "Error shown when trying to add a duplicate value to the list."
     },
     "optionsUserInterfaceTitle": {
-      "message": "User interface",
-      "description": "User interface title in settings page"
+        "message": "User interface",
+        "description": "User interface title in settings page"
     },
     "optionsFillingCredentialsTitle": {
-      "message": "Filling credentials",
-      "description": "Filling credentials title in settings page"
+        "message": "Filling credentials",
+        "description": "Filling credentials title in settings page"
     },
     "optionsSavingCredentialsTitle": {
-      "message": "Saving credentials",
-      "description": "Saving credentials title in settings page"
+        "message": "Saving credentials",
+        "description": "Saving credentials title in settings page"
     },
     "optionsUpdatesTitle": {
-      "message": "Updates",
-      "description": "Updates title in settings page"
+        "message": "Updates",
+        "description": "Updates title in settings page"
     },
     "optionsAdvancedSettingsTitle": {
-      "message": "Advanced settings",
-      "description": "Advanced settings title in settings page"
+        "message": "Advanced settings",
+        "description": "Advanced settings title in settings page"
     },
     "optionsExtensionTitle": {
-      "message": "Extension",
-      "description": "Extension title in settings page"
+        "message": "Extension",
+        "description": "Extension title in settings page"
     },
     "openNewTab": {
         "message": "Opens a new tab",
@@ -1038,5 +1038,9 @@
     "autocompleteSubmitMessage": {
         "message": "Your selection will be auto-submitted",
         "description": "Message shown at the bottom of autocomplete menu."
+    },
+    "lockDatabase": {
+        "message": "Lock database",
+        "description": "Lock database button title text."
     }
 }

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -20,7 +20,7 @@
       <div id="settings" class="settings">
         <button id="btn-options" class="btn btn-sm btn-success"><i class="fa fa-cog" aria-hidden="true"></i> <span data-i18n="popupSettingsText"></span></button>
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
-        <button id="lock-database-button" class="btn btn-sm btn-danger" title="Lock database"><i class="fa fa-lock" aria-hidden="true"></i></button>
+        <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
         <div id="update-available" class="alert alert-danger">
           <span data-i18n="popupUpdateAvailable"></span>

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -20,7 +20,7 @@
       <div id="settings" class="settings">
         <button id="btn-options" class="btn btn-sm btn-success"><i class="fa fa-cog" aria-hidden="true"></i> <span data-i18n="popupSettingsText"></span></button>
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
-        <button id="lock-database-button" class="btn btn-sm btn-danger" title="Lock database"><i class="fa fa-lock" aria-hidden="true"></i></button>
+        <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
         <div id="update-available" class="alert alert-danger">
           <span data-i18n="popupUpdateAvailable"></span>

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -20,7 +20,7 @@
       <div id="settings" class="settings">
         <button id="btn-options" class="btn btn-sm btn-success"><i class="fa fa-cog" aria-hidden="true"></i> <span data-i18n="popupSettingsText"></span></button>
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
-        <button id="lock-database-button" class="btn btn-sm btn-danger" title="Lock database"><i class="fa fa-lock" aria-hidden="true"></i></button>
+        <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
         <div id="update-available" class="alert alert-danger">
           <span data-i18n="popupUpdateAvailable"></span>

--- a/keepassxc-browser/popups/popup_multiple-fields.html
+++ b/keepassxc-browser/popups/popup_multiple-fields.html
@@ -19,7 +19,7 @@
       <div id="settings" class="settings">
         <button id="btn-options" class="btn btn-sm btn-success"><i class="fa fa-cog" aria-hidden="true"></i> <span data-i18n="popupSettingsText"></span></button>
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
-        <button id="lock-database-button" class="btn btn-sm btn-danger" title="Lock database"><i class="fa fa-lock" aria-hidden="true"></i></button>
+        <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
         <div id="update-available" class="alert alert-danger">
           <span data-i18n="popupUpdateAvailable"></span>


### PR DESCRIPTION
Removes the hard-coded text and replaces it with a valid translation.

Fixes #834.