### PR TITLE
Ignore banner on tab change

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -214,13 +214,17 @@ kpxcEvent.pageClearSubmitted = function() {
     return Promise.resolve();
 };
 
-kpxcEvent.pageGetSubmitted = async function() {
+kpxcEvent.pageGetSubmitted = async function(tab) {
+    // Do not return any credentials if the tab ID does not match.
+    if (tab.id !== page.submittedCredentials.tabId) {
+        return {};
+    }
     return page.submittedCredentials;
 };
 
 kpxcEvent.pageSetSubmitted = function(tab, args = []) {
     const [ submitted, username, password, url, oldCredentials ] = args;
-    page.setSubmittedCredentials(submitted, username, password, url, oldCredentials);
+    page.setSubmittedCredentials(submitted, username, password, url, oldCredentials, tab.id);
     return Promise.resolve();
 };
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -180,12 +180,13 @@ page.clearLogins = function(tabId) {
     page.passwordFilled = false;
 };
 
-page.setSubmittedCredentials = function(submitted, username, password, url, oldCredentials) {
+page.setSubmittedCredentials = function(submitted, username, password, url, oldCredentials, tabId) {
     page.submittedCredentials.submitted = submitted;
     page.submittedCredentials.username = username;
     page.submittedCredentials.password = password;
     page.submittedCredentials.url = url;
     page.submittedCredentials.oldCredentials = oldCredentials;
+    page.submittedCredentials.tabId = tabId;
 };
 
 page.clearSubmittedCredentials = function() {


### PR DESCRIPTION
The Credential Banner could be shown on a wrong tab if switched quickly during a login/submit process.

Solution:
Store the tab ID to `page.submittedCredentials` object and compare the value before returning anything to the content script.

Fixes #860.