### PR TITLE
Purecss compat - force letter-spacing

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -11,6 +11,9 @@
     width: auto;
     color: var(--kpxc-text-color);
     font-size: .9em !important;
+    letter-spacing: normal !important;
+    word-spacing: normal !important;
+    text-rendering: auto !important;
 }
 
 .kpxcAutocomplete-items div:last-child {

--- a/keepassxc-browser/css/notification.css
+++ b/keepassxc-browser/css/notification.css
@@ -5,6 +5,9 @@
     cursor: pointer;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 14px;
+    letter-spacing: normal !important;
+    word-spacing: normal !important;
+    text-rendering: auto !important;
     margin: 0px auto;
     margin-bottom: 20px;
     padding: 15px;


### PR DESCRIPTION
In pages based on purecss, the default letter-spacing is negative. This lead to
unreadable keepassxc entries in the autocomplete list and notifications.

This patch forces the letter-spacing and word-spacing to 'normal', and
text-rendering to 'auto', which is what purecss does in elements
displaying text.