### PR TITLE
Allow fill to readOnly fields

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -10,6 +10,10 @@ kpxcAutocomplete.shadowRoot = undefined;
 kpxcAutocomplete.wrapper = undefined;
 
 kpxcAutocomplete.create = function(input, showListInstantly = false, autoSubmit = false) {
+    if (input.readOnly) {
+        return;
+    }
+
     kpxcAutocomplete.autoSubmit = autoSubmit;
     kpxcAutocomplete.input = input;
     kpxcAutocomplete.started = true;
@@ -238,7 +242,6 @@ kpxcAutocomplete.updatePosition = function(inputField, elem) {
         div.style.top = Pixels(rect.top + document.scrollingElement.scrollTop + inputField.offsetHeight);
         div.style.left = Pixels(rect.left + document.scrollingElement.scrollLeft);
     }
-
 };
 
 // Detect click outside autocomplete

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -705,7 +705,7 @@ kpxcObserverHelper.getInputs = function(target) {
     // Filter out any input fields with type 'hidden' right away
     const inputFields = [];
     Array.from(target.getElementsByTagName('input')).forEach(e => {
-        if (e.type !== 'hidden' && !e.readOnly) {
+        if (e.type !== 'hidden') {
             inputFields.push(e);
         }
     });

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -24,7 +24,7 @@ class PasswordIcon extends Icon {
 }
 
 PasswordIcon.prototype.initField = function(field, inputs, pos) {
-    if (!field) {
+    if (!field || field.readOnly) {
         return;
     }
 

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -42,7 +42,8 @@ TOTPFieldIcon.prototype.initField = function(field, forced) {
             || field.size < 2
             || (field.maxLength > 0 && (field.maxLength < 6 || field.maxLength > 8))
             || field.id.match(ignoreRegex)
-            || field.name.match(ignoreRegex)) {
+            || field.name.match(ignoreRegex)
+            || field.readOnly) {
             return;
         }
     } else {

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -39,7 +39,8 @@ UsernameFieldIcon.prototype.initField = function(field) {
         || field.getAttribute('kpxc-username-field') === 'true'
         || field.getAttribute('kpxc-totp-field') === 'true'
         || (field.hasAttribute('kpxc-defined') && field.getAttribute('kpxc-defined') !== 'username')
-        || !kpxcFields.isVisible(field)) {
+        || !kpxcFields.isVisible(field)
+        || field.readOnly) {
         return;
     }
 


### PR DESCRIPTION
Fix to a previous commit https://github.com/keepassxreboot/keepassxc-browser/commit/d36d4f4c36bc8873d4ce7ea1e597fb4ca0eb4d66#diff-412b80e8f63d0bb8ff5dcc811ec72823 where input fields were ignored if they were `readOnly`.

Now the fields are still accepted, but no icons or autocomplete menu is shown for them. This fix allows the `readOnly` input fields to be filled if they are specified as custom login field or a String Field.

Fixes #818.