### PR TITLE
Add a command to fill the username and password + TOTP.

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -3,6 +3,10 @@
         "message": "KeePassXC integration for modern web browsers",
         "description": "Name of the extension."
     },
+    "contextMenuFillUsernameAndPasswordTOTP": {
+        "message": "Fill Username and Pass+TOTP",
+        "description": "Context menu item for filling both username and password + TOTP."
+    },
     "contextMenuFillUsernameAndPassword": {
         "message": "Fill Username and Password",
         "description": "Context menu item for filling both username and password."
@@ -258,6 +262,10 @@
     "credentialsNoUsernameFound": {
         "message": "No credentials for the given username found.",
         "description": "Alert message when no credentials are found for the given username."
+    },
+    "credentialsNoTOTPFound": {
+        "message": "No TOTP for the given username found.",
+        "description": "Alert message when no TOTP is found for the given username."
     },
     "credentialExpired": {
         "message": "Expired",

--- a/keepassxc-browser/_locales/es/messages.json
+++ b/keepassxc-browser/_locales/es/messages.json
@@ -3,6 +3,10 @@
         "message": "Integración de KeePassXC para navegadores web modernos.",
         "description": "Name of the extension."
     },
+    "contextMenuFillUsernameAndPasswordTOTP": {
+        "message": "Llene nombre de Usuario y Contraseña+TOTP",
+        "description": "Context menu item for filling both username and password + TOTP."
+    },
     "contextMenuFillUsernameAndPassword": {
         "message": "Llene nombre de Usuario y Contraseña",
         "description": "Context menu item for filling both username and password."
@@ -218,6 +222,10 @@
     "credentialsNoUsernameFound": {
         "message": "Error:\nNo se encontraron credenciales para el nombre de usuario dado.",
         "description": "Alert message when no credentials are found for the given username."
+    },
+    "credentialsNoTOTPFound": {
+        "message": "Error: \nNo se encontro el campo TOTP en las credenciales del usuario.",
+        "description": "Alert message when no TOTP is found for the given username."
     },
     "fieldsFill": {
         "message": "Error:\nNo se pueden encontrar campos para rellenar.",

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -106,6 +106,7 @@ browser.runtime.onMessage.addListener(kpxcEvent.onMessage);
 
 const contextMenuItems = [
     { title: tr('contextMenuFillUsernameAndPassword'), action: 'fill_username_password' },
+    { title: tr('contextMenuFillUsernameAndPasswordTOTP'), action: 'fill_username_password_totp' },
     { title: tr('contextMenuFillPassword'), action: 'fill_password' },
     { title: tr('contextMenuFillTOTP'), action: 'fill_totp' },
     { title: tr('contextMenuShowPasswordGenerator'), action: 'show_password_generator' },

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -84,6 +84,9 @@
                 "mac": "MacCtrl+Shift+U"
             }
         },
+        "fill_username_password_totp": {
+            "description": "__MSG_contextMenuFillUsernameAndPasswordTOTP__"
+        },
         "fill_password": {
             "description": "__MSG_contextMenuFillPassword__",
             "suggested_key": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -104,6 +104,7 @@
                 </div>
                 <div class="card-body">
                   <p>
+                    <span data-i18n="contextMenuFillUsernameAndPasswordTOTP"></span>: <span id="fill_username_password_totp-shortcut">error</span><br />
                     <span data-i18n="contextMenuFillUsernameAndPassword"></span>: <span id="fill_username_password-shortcut">error</span><br />
                     <span data-i18n="contextMenuFillPassword"></span>: <span id="fill_password-shortcut">error</span><br />
                     <span data-i18n="contextMenuFillTOTP"></span>: <span id="fill_totp-shortcut">error</span><br />

--- a/keepassxc-browser/options/shortcuts.html
+++ b/keepassxc-browser/options/shortcuts.html
@@ -30,6 +30,12 @@
       <hr />
       <div class="conf-content">
         <div class="conf-row">
+          <div><label for="fill_username_password_totp" data-i18n="contextMenuFillUsernameAndPasswordTOTP"></label></div>
+          <input type="text" id="fill_username_password_totp"/>
+          <button class="btn btn-sm btn-primary" id="buttonSaveUserandPassTOTP" type="button"><i class="fa fa-save" aria-hidden="true"></i> <span data-i18n="optionsButtonSave"/></button>
+          <button class="btn btn-sm btn-danger"><i class="fa fa-remove" aria-hidden="true"></i> <span data-i18n="optionsButtonReset"></span></button>
+        </div>
+        <div class="conf-row">
           <div><label for="fill_username_password" data-i18n="contextMenuFillUsernameAndPassword"></label></div>
           <input type="text" id="fill_username_password"/>
           <button class="btn btn-sm btn-primary" id="buttonSaveUserandPass" type="button"><i class="fa fa-save" aria-hidden="true"></i> <span data-i18n="optionsButtonSave"/></button>


### PR DESCRIPTION
In some 2FA environments the password field must be filled
not only with the password but with the concatenation
of the passwword and the TOTP.

This patch allows to set up a key combination to do
do the job.

Signed-off-by: Miguel Martín <m4mnux@gmail.com>