### PR TITLE
Check input field visibility for TOTP icons

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1068,6 +1068,10 @@ kpxc.initPasswordGenerator = function(inputs) {
 
 kpxc.initOTPFields = function(inputs) {
     for (const i of inputs) {
+        if (!kpxcFields.isVisible(i)) {
+            continue;
+        }
+
         const id = i.getLowerCaseAttribute('id');
         const name = i.getLowerCaseAttribute('name');
         const autocomplete = i.getLowerCaseAttribute('autocomplete');


### PR DESCRIPTION
One simple check missing before displaying TOTP icon(s).

Fixes #889.