### PR TITLE
Fix retrieving credentials for authenticating against proxies

### DIFF
--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -63,7 +63,11 @@ httpAuth.processPendingCallbacks = async function(details, resolve, reject) {
     httpAuth.requests.push(details.requestId);
 
     if (details.challenger) {
-        details.proxyUrl = details.challenger.host;
+        // Non-HTTP proxies are possible with PAC scripts, while currently only
+        // Firefox provides info about the proxy protocol used [1].
+        // [1] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
+        let scheme = details.proxyInfo ? details.proxyInfo.type : 'http';
+        details.proxyUrl = scheme + '://' + details.challenger.host;
     }
 
     details.searchUrl = (details.isProxy && details.proxyUrl) ? details.proxyUrl : details.url;


### PR DESCRIPTION
KeePassXC uses QUrl for matching URLs against entries [1], so
standard-compliant URLs are needed.

[1] https://github.com/keepassxreboot/keepassxc/blob/9d2e066acae0cd7bd3447bf3c5fa8ff0c0c4f073/src/browser/BrowserService.cpp#L356

Tested on Firefox 76.0.1 with an HTTP proxy requiring digest authentication.