### PR TITLE
Try to identify more form buttons

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1283,6 +1283,16 @@ kpxc.getFormSubmitButton = function(form) {
         return buttons[0];
     }
 
+    // Try to find similar buttons outside the form which are added via 'form' property
+    for (const e of form.elements) {
+        if ((e.nodeName === 'BUTTON' && e.type === 'button')
+            || (e.nodeName === 'BUTTON' && e.type === 'submit')
+            || (e.nodeName === 'INPUT' && e.type === 'button')
+            || (e.nodeName === 'BUTTON' && e.type === '')) {
+            return e;
+        }
+    }
+
     return undefined;
 };
 


### PR DESCRIPTION
Sometimes form submit buttons are added outside the form, for example if a form is with ID `login-form` the button might have a property `form="login-form"` and it's not identified with a direct `querySelectorAll()` call to the form element itself.

Fixes #897.