### PR TITLE
Improve TOTP detection and custom field overriding

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -632,7 +632,9 @@ kpxcFields.useDefinedCredentialFields = function() {
 
         // Handle custom TOTP field
         if (_f(creds.totp)) {
-            kpxcTOTPIcons.newIcon(_f(creds.totp), _databaseState);
+            const totpField = _f(creds.totp);
+            totpField.setAttribute('kpxc-defined', 'totp');
+            kpxcTOTPIcons.newIcon(totpField, _databaseState, true);
         }
 
         let found = _f(creds.username) || _f(creds.password);
@@ -644,6 +646,14 @@ kpxcFields.useDefinedCredentialFields = function() {
         }
 
         if (found) {
+            if (creds.username) {
+                _f(creds.username).setAttribute('kpxc-defined', 'username');
+            }
+
+            if (creds.password) {
+                _f(creds.password).setAttribute('kpxc-defined', 'password');
+            }
+
             const fields = {
                 username: creds.username,
                 password: creds.password,
@@ -1036,18 +1046,18 @@ kpxc.initCredentialFields = async function(forceCall, inputs) {
 
     _databaseState = !res.keePassXCAvailable ? DatabaseState.DISCONNECTED : DatabaseState.LOCKED;
 
+    if (!kpxcFields.useDefinedCredentialFields()) {
+        // Get all combinations of username + password fields
+        kpxcFields.combinations = kpxcFields.getAllCombinations(inputs);
+    }
+    kpxcFields.prepareCombinations(kpxcFields.combinations);
+
     kpxcFields.prepareVisibleFieldsWithID('select');
     kpxc.initPasswordGenerator(inputs);
 
     if (kpxc.settings.showOTPIcon) {
         kpxc.initOTPFields(inputs);
     }
-
-    if (!kpxcFields.useDefinedCredentialFields()) {
-        // Get all combinations of username + password fields
-        kpxcFields.combinations = kpxcFields.getAllCombinations(inputs);
-    }
-    kpxcFields.prepareCombinations(kpxcFields.combinations);
 
     if (kpxcFields.combinations.length === 0 && inputs.length === 0) {
         browser.runtime.sendMessage({

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -28,7 +28,8 @@ PasswordIcon.prototype.initField = function(field, inputs, pos) {
         return;
     }
 
-    if (field.getAttribute('kpxc-password-generator')) {
+    if (field.getAttribute('kpxc-password-generator')
+        || (field.hasAttribute('kpxc-defined') && field.getAttribute('kpxc-defined') !== 'password')) {
         return;
     }
 
@@ -62,8 +63,7 @@ PasswordIcon.prototype.initField = function(field, inputs, pos) {
 PasswordIcon.prototype.createIcon = function(field) {
     const className = (isFirefox() ? 'key-moz' : 'key');
     const size = (field.offsetHeight > 28) ? 24 : 16;
-    let offset = Math.floor((field.offsetHeight - size) / 3);
-    offset = (offset < 0) ? 0 : offset;
+    const offset = kpxcUI.calculateIconOffset(field, size);
 
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-pwgen-icon ' + className,
         {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -80,12 +80,17 @@ kpxcUI.updateIconPosition = function(iconClass) {
     }
 };
 
+kpxcUI.calculateIconOffset = function(field, size) {
+    const offset = Math.floor((field.offsetHeight - size) / 3);
+    return (offset < 0) ? 0 : offset;
+};
+
 kpxcUI.setIconPosition = function(icon, field) {
     const rect = field.getBoundingClientRect();
     const bodyRect = document.body.getBoundingClientRect();
     const bodyStyle = getComputedStyle(document.body);
-    const offset = Number(icon.getAttribute('offset'));
     const size = (document.dir !== 'rtl') ? Number(icon.getAttribute('size')) : 0;
+    const offset = kpxcUI.calculateIconOffset(field, size);
 
     if (bodyStyle.position.toLowerCase() === 'relative') {
         icon.style.top = Pixels(rect.top - bodyRect.top + document.scrollingElement.scrollTop + offset + 1);

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -38,6 +38,7 @@ UsernameFieldIcon.prototype.initField = function(field) {
     if (!field
         || field.getAttribute('kpxc-username-field') === 'true'
         || field.getAttribute('kpxc-totp-field') === 'true'
+        || (field.hasAttribute('kpxc-defined') && field.getAttribute('kpxc-defined') !== 'username')
         || !kpxcFields.isVisible(field)) {
         return;
     }
@@ -71,8 +72,7 @@ UsernameFieldIcon.prototype.createIcon = function(target) {
         return;
     }
 
-    let offset = Math.floor((field.offsetHeight - size) / 3);
-    offset = (offset < 0) ? 0 : offset;
+    const offset = kpxcUI.calculateIconOffset(field, size);
 
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-username-icon ' + className,
         {


### PR DESCRIPTION
- Ignores TOTP fields if element `autocomplete` property defined as username, password or email field.
- Forces TOTP icon to show if defined via Custom Fields.
- Delete duplicate code and implement `kpxcUI.calculateIconOffset()`.

Fixes #900.
Fixes #907.