### PR TITLE
Pass full URL

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1035,7 +1035,7 @@ kpxc.initCredentialFields = async function(forceCall, inputs) {
         return;
     }
 
-    kpxc.url = document.location.origin;
+    kpxc.url = document.location.href;
     kpxc.submitUrl = kpxc.getFormActionUrl(kpxcFields.combinations[0]);
 
     // Get submitUrl for a single input
@@ -1310,10 +1310,10 @@ kpxc.fillInCredentials = async function(combination, onlyPassword, suppressWarni
         kpxc.p = p;
     }
 
-    if (kpxc.url === document.location.origin && kpxc.submitUrl === action && kpxc.credentials.length > 0) {
+    if (kpxc.url === document.location.href && kpxc.submitUrl === action && kpxc.credentials.length > 0) {
         kpxc.fillIn(combination, onlyPassword, suppressWarnings);
     } else {
-        kpxc.url = document.location.origin;
+        kpxc.url = document.location.href;
         kpxc.submitUrl = action;
 
         const credentials = await browser.runtime.sendMessage({


### PR DESCRIPTION
Full URL will be passed to KeePassXC instead of `document.location.origin` which doesn't include the URL path at all. This is required if we wish to do matching agaist paths in KeePassXC.