### PR TITLE
Check visibility of dynamically added fields

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -694,12 +694,12 @@ kpxcObserverHelper.getInputs = function(target) {
 
     // Only include input fields that match with kpxcObserverHelper.inputTypes
     const inputs = [];
-    for (const i of inputFields) {
-        const type = i.getLowerCaseAttribute('type');
+    for (const field of inputFields) {
+        const type = field.getLowerCaseAttribute('type');
 
-        if (kpxcObserverHelper.inputTypes.includes(type)) {
-            kpxcFields.setUniqueId(i);
-            inputs.push(i);
+        if (kpxcObserverHelper.inputTypes.includes(type) && kpxcFields.isVisible(field)) {
+            kpxcFields.setUniqueId(field);
+            inputs.push(field);
         }
     }
     return inputs;


### PR DESCRIPTION
#729 adjusted the `kpxc.initCredentialFields()` so it accepts dynamically added input fields as parameters. Those fields were not checked for visibility, so this can potentially be one reason why people have reported performance issues with the latest releases. It caused all input fields to be processed even if those were invisible, and possible caused `retrieve-credentials` requests without any reason.