### PR TITLE
Add wildcard to the ignored URL

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -107,7 +107,8 @@ kpxcBanner.create = async function(credentials = {}) {
             kpxcBanner.banner.removeChild(dialog);
         } else {
             if (ignoreCheckbox.checked) {
-                kpxc.ignoreSite([ window.top.location.href ]);
+                const ignoreUrl = window.location.href.slice(0, window.location.href.lastIndexOf('/') + 1) + '*';
+                kpxc.ignoreSite([ ignoreUrl ]);
             }
             kpxcBanner.destroy();
         }


### PR DESCRIPTION
When using the Credentials Banner and selecting _Don't ask again for this site_ always saves an absolute URL which is prone to errors. The end of the URL might change depending on the situation/token/etc.

For example `https://mail.pasteur.la/?_task=login` saved to the Site Preferences no longer works with the main site. Instead, we are now saving the URL always with a wildcard appended after the last `/` (with the remaining deleted), so the final form is `https://mail.pasteur.la/*`.