### PR TITLE
Parse input fields correctly before passing them forward

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,6 +25,7 @@ function adjustManifest(manifest) {
         for (const elem in data['browser_action']['default_icon']) {
             data['browser_action']['default_icon'][elem] = 'icons/keepassxc.svg';
         }
+        delete data['version_name'];
     } else if (manifest.includes('chromium')) {
         delete data['applications'];
     }

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -962,7 +962,7 @@ kpxc.initObserver = function() {
                 // Check if some class is changed that holds a form or input field(s). Ignore large forms.
                 const formInput = mut.target.querySelector('form input');
                 if (mut.attributeName === 'class' && formInput !== null && formInput.form.length < 20) {
-                    kpxc.handleCredentialFields(Array.from(formInput.form.getElementsByTagName('input')));
+                    kpxc.handleCredentialFields(kpxcObserverHelper.getInputs(formInput.form));
                     continue;
                 }
 

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.6.4",
-    "version_name": "1.6.4",
+    "version": "1.6.5",
+    "version_name": "1.6.5",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {


### PR DESCRIPTION
Form input fields needs to be parsed correctly before sending them to `kpxc.handleCredentialFields()`. Otherwise the `data-kpxc-id` attribute will be missing from the inputs and those are ignored later.

Also removes unsupported `version_name` parameter from the Firefox build. Otherwise it always shows a warning in `about:addons`.