### PR TITLE
Fix document max size calculation

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -329,8 +329,8 @@ kpxcFields.isVisible = function(field) {
     if (rect.x < 0
         || rect.y < 0
         || rect.width < 8
-        || rect.x > document.body.offsetWidth
-        || rect.y > document.body.offsetHeight
+        || rect.x > Math.max(document.body.scrollWidth, document.body.offsetWidth, document.documentElement.clientWidth)
+        || rect.y > Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight)
         || rect.height < 8) {
         return false;
     }

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.6.5",
-    "version_name": "1.6.5",
+    "version": "1.6.6",
+    "version_name": "1.6.6",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {


### PR DESCRIPTION
Calculating the document max size is not reliable with `document.body.offsetWidth` or `offsetHeight`. On some pages it might be zero. In these situations `document.documentElement.clientHeight` must be used.

Ensured that the maximum value is always used.

Fixes #936.
Fixes https://github.com/keepassxreboot/keepassxc/issues/5052