### PR TITLE
Change KeePassXC update message from danger to warning

### DIFF
--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -22,7 +22,7 @@
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
         <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
-        <div id="update-available" class="alert alert-danger">
+        <div id="update-available" class="alert alert-warning">
           <span data-i18n="popupUpdateAvailable"></span>
           <br />
           <a target="_blank" class="alert-link" href="https://keepassxc.org/download"><span data-i18n="popupDownloadNewVersion"></span></a>.

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -22,7 +22,7 @@
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
         <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
-        <div id="update-available" class="alert alert-danger">
+        <div id="update-available" class="alert alert-warning">
           <span data-i18n="popupUpdateAvailable"></span>
           <br />
           <a target="_blank" class="alert-link" href="https://keepassxc.org/download"><span data-i18n="popupDownloadNewVersion"></span></a>.

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -22,7 +22,7 @@
         <button id="btn-choose-credential-fields" class="btn btn-sm btn-warning"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupChooseCredentialsText"></span></button>
         <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase"><i class="fa fa-lock" aria-hidden="true"></i></button>
 
-        <div id="update-available" class="alert alert-danger">
+        <div id="update-available" class="alert alert-warning">
           <span data-i18n="popupUpdateAvailable"></span>
           <br />
           <a target="_blank" class="alert-link" href="https://keepassxc.org/download"><span data-i18n="popupDownloadNewVersion"></span></a>.


### PR DESCRIPTION
Makes the "You are using an old version of KeePassXC." message shown as a warning instead of an error.