### PR TITLE
Fix filling from username icon

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -780,6 +780,7 @@ kpxc.fillFromTOTP = async function(target) {
 
 // Fill requested from username icon
 kpxc.fillFromUsernameIcon = async function(combination) {
+    await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
         return;
     } else if (kpxc.credentials.length > 1) {


### PR DESCRIPTION
Username icon does nothing if _Automatically retrieve credentials_ is disabled from the extension settings.