### PR TITLE
Various fixes for 1.7.1

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -190,7 +190,7 @@ kpxcAutocomplete.keyPress = function(e) {
         if (kpxcAutocomplete.index >= 0 && items && items[kpxcAutocomplete.index] !== undefined) {
             e.preventDefault();
             kpxcAutocomplete.input.value = kpxcAutocomplete.elements[kpxcAutocomplete.index].value;
-            kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index);
+            kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index, kpxcAutocomplete.elements[kpxcAutocomplete.index].uuid);
             kpxcAutocomplete.closeList();
         }
     } else if (e.key === 'Tab') {
@@ -201,7 +201,7 @@ kpxcAutocomplete.keyPress = function(e) {
         }
 
         kpxcAutocomplete.index = kpxcAutocomplete.elements.findIndex(c => c.value === kpxcAutocomplete.input.value);
-        kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index);
+        kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index, kpxcAutocomplete.elements[kpxcAutocomplete.index].uuid);
         kpxcAutocomplete.closeList();
     } else if (e.key === 'Escape') {
         kpxcAutocomplete.closeList();

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -144,11 +144,11 @@ kpxcBanner.saveNewCredentials = async function(credentials = {}) {
 
     if (!result.defaultGroupAlwaysAsk) {
         if (result.defaultGroup === '' || result.defaultGroup === DEFAULT_BROWSER_GROUP) {
-             // Default group is used
-             const args = [ credentials.username, credentials.password, credentials.url ];
-             const res = await sendMessage('add_credentials', args);
-             kpxcBanner.verifyResult(res);
-             return;
+            // Default group is used
+            const args = [ credentials.username, credentials.password, credentials.url ];
+            const res = await sendMessage('add_credentials', args);
+            kpxcBanner.verifyResult(res);
+            return;
         } else {
             // A specified group is used
             let gname = '';

--- a/keepassxc-browser/content/define.js
+++ b/keepassxc-browser/content/define.js
@@ -14,7 +14,7 @@ kpxcDefine.diffX = 0;
 kpxcDefine.diffY = 0;
 kpxcDefine.eventFieldClick = null;
 kpxcDefine.inputQueryPattern = 'input[type=\'text\'], input[type=\'email\'], input[type=\'password\'], input[type=\'tel\'], input[type=\'number\'], input[type=\'username\'], input:not([type])';
-kpxcDefine.markedFields= [];
+kpxcDefine.markedFields = [];
 kpxcDefine.keyDown = null;
 kpxcDefine.startPosX = 0;
 kpxcDefine.startPosY = 0;

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -223,7 +223,7 @@ kpxcPasswordDialog.showDialog = function(field, icon) {
     // Save next password field if found
     if (kpxc.inputs.length > 0) {
         const index = kpxc.inputs.indexOf(field);
-        const nextField = kpxc.inputs[index+1];
+        const nextField = kpxc.inputs[index + 1];
         kpxcPasswordDialog.nextField = (nextField && nextField.getLowerCaseAttribute('type') === 'password') ? nextField : undefined;
     }
 
@@ -278,7 +278,7 @@ kpxcPasswordDialog.fill = function(e) {
             const message = tr('passwordGeneratorErrorTooLong') + '\r\n'
                             + tr('passwordGeneratorErrorTooLongCut') + '\r\n' + tr('passwordGeneratorErrorTooLongRemember');
             message.style.whiteSpace = 'pre';
-            sendMessage('show_notification' [ message ]);
+            sendMessage('show_notification', [ message ]);
             return;
         }
     }

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -34,8 +34,12 @@ kpxcTOTPIcons.isAcceptedTOTPField = function(field) {
     const id = field.getLowerCaseAttribute('id');
     const name = field.getLowerCaseAttribute('name');
     const autocomplete = field.getLowerCaseAttribute('autocomplete');
+    const placeholder = field.getLowerCaseAttribute('placeholder');
 
-    if (autocomplete === 'one-time-code' || acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f)))) {
+    // Checks if the field id, name or placeholder includes some of the acceptedOTPFields but not any from ignoredTypes
+    if (autocomplete === 'one-time-code'
+        || (acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f) || placeholder && placeholder.includes(f))))
+            && !ignoredTypes.some(f => (id && id.includes(f)) || (name && name.includes(f) || placeholder && placeholder.includes(f)))) {
         return true;
     }
 

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.0",
-    "version_name": "1.7.0",
+    "version": "1.7.1",
+    "version_name": "1.7.1",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {


### PR DESCRIPTION
- Add `name` and `placeholder` to `kpxcField.getId()`
- Don't override Custom Login Field variables in `kpxcFields.useCustomLoginFields()`
- Add missing `uuid` to Autocomplete when filling using keyboard.
- Respect Autocomplete Menu setting when filling using keyboard or Username Icon.
- Fix Auto-Submit (wrong function call).
- Fix Auto-Fill (e.g. with Google). The popup logins were also displayed incorrectly when this was enabled.


This also disables CSS animation support. This caused more problems than it solved. For some reason the event listener for it overrides the page's own scripts if those are handling `transitionend`. That should not happen, but both Firefox and Chromium does it for some reason, and there's no reliable way to call the "parent event" after our own handling.

WIP as more small fixes can be added.

Fixes #988.
Fixes #991.
Fixes #998.
Fixes #999.
Fixes #1002.
Fixes #1004.
Fixes #1007.
Fixes #1008.