### PR TITLE
Fix Google login page submit

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -201,7 +201,10 @@ kpxcAutocomplete.keyPress = function(e) {
         }
 
         kpxcAutocomplete.index = kpxcAutocomplete.elements.findIndex(c => c.value === kpxcAutocomplete.input.value);
-        kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index, kpxcAutocomplete.elements[kpxcAutocomplete.index].uuid);
+        if (kpxcAutocomplete.index >= 0) {
+            kpxcAutocomplete.fillPassword(kpxcAutocomplete.input.value, kpxcAutocomplete.index, kpxcAutocomplete.elements[kpxcAutocomplete.index].uuid);
+        }
+
         kpxcAutocomplete.closeList();
     } else if (e.key === 'Escape') {
         kpxcAutocomplete.closeList();

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -156,6 +156,18 @@ kpxcForm.getCredentialFieldsFromForm = function(form) {
 // Get the form submit button instead if action URL is same as the page itself
 kpxcForm.getFormSubmitButton = function(form) {
     const action = kpxc.submitUrl || form.action;
+
+    // Special handling for accounts.google.com. The submit button is outside the form.
+    if (form.action.startsWith('https://accounts.google.com')) {
+        const findDiv = $('#identifierNext');
+        if (!findDiv) {
+            return undefined;
+        }
+
+        const buttons = findDiv.getElementsByTagName('button');
+        return buttons.length > 0 ? buttons[0] : undefined;
+    }
+
     if (action.includes(document.location.origin + document.location.pathname)) {
         for (const i of form.elements) {
             if (i.type === 'submit') {


### PR DESCRIPTION
Google login page has a submit button outside that form. Because this is one of the most common sites, a special handling is added to `kpxcForm.getFormSubmitButton()`. If we need some more special handling for certain sites in the future, we have to make an own function for these cases. For now, this one exception will do.

Fixes #802.