### PR TITLE
Fix relative icon position with dir='rtl'

### DIFF
--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -30,8 +30,7 @@ kpxcPasswordIcons.isValid = function(field) {
 
 class PasswordIcon extends Icon {
     constructor(field, databaseState = DatabaseState.DISCONNECTED) {
-        super();
-        this.databaseState = databaseState;
+        super(field, databaseState);
         this.nextFieldExists = false;
 
         this.initField(field);
@@ -80,7 +79,7 @@ PasswordIcon.prototype.createIcon = function(field) {
         kpxcPasswordDialog.showDialog(field, icon);
     });
 
-    kpxcUI.setIconPosition(icon, field);
+    kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
 
     const styleSheet = document.createElement('link');

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -75,10 +75,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
 
 class TOTPFieldIcon extends Icon {
     constructor(field, databaseState = DatabaseState.DISCONNECTED, forced = false) {
-        super();
-        this.icon = null;
-        this.inputField = null;
-        this.databaseState = databaseState;
+        super(field, databaseState);
 
         this.initField(field, forced);
         kpxcUI.monitorIconPosition(this);
@@ -127,7 +124,7 @@ TOTPFieldIcon.prototype.createIcon = function(field) {
         kpxc.fillFromTOTP(field);
     });
 
-    kpxcUI.setIconPosition(icon, field);
+    kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
 
     const styleSheet = document.createElement('link');

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -31,10 +31,7 @@ kpxcUsernameIcons.isValid = function(field) {
 
 class UsernameFieldIcon extends Icon {
     constructor(field, databaseState = DatabaseState.DISCONNECTED) {
-        super();
-        this.databaseState = databaseState;
-        this.icon = null;
-        this.inputField = null;
+        super(field, databaseState);
 
         this.initField(field);
         kpxcUI.monitorIconPosition(this);
@@ -63,8 +60,7 @@ UsernameFieldIcon.prototype.initField = function(field) {
     this.inputField = field;
 };
 
-UsernameFieldIcon.prototype.createIcon = function(target) {
-    const field = target;
+UsernameFieldIcon.prototype.createIcon = function(field) {
     const className = getIconClassName(this.databaseState);
 
     // Size the icon dynamically, but not greater than 24 or smaller than 14
@@ -99,7 +95,7 @@ UsernameFieldIcon.prototype.createIcon = function(target) {
         iconClicked(field, icon);
     });
 
-    kpxcUI.setIconPosition(icon, field);
+    kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
 
     const styleSheet = document.createElement('link');


### PR DESCRIPTION
https://github.com/keepassxreboot/keepassxc-browser/pull/840 broke the icon position with right-to-left pages.

Also adds `text-align: right` and `dir=rtl` detection to Icon constructor.

Fixes #1019.