### PR TITLE
Increase max TOTP field length

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -2,6 +2,8 @@
 
 const ignoreRegex = /(zip|postal).*code/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
+const MIN_INPUT_LENGTH = 6;
+const MAX_INPUT_LENGTH = 10;
 
 const acceptedOTPFields = [
     '2fa',
@@ -55,10 +57,8 @@ kpxcTOTPIcons.isValid = function(field, forced) {
         if (ignoredTypes.some(t => t === field.type)
             || field.offsetWidth < MINIMUM_INPUT_FIELD_WIDTH
             || field.size < 2
-            || (field.maxLength > 0 && (field.maxLength < 6 || field.maxLength > 8))
+            || (field.maxLength > 0 && (field.maxLength < MIN_INPUT_LENGTH || field.maxLength > MAX_INPUT_LENGTH))
             || ignoredTypes.some(t => t === field.autocomplete)
-            || field.getAttribute('kpxc-totp-field') === 'true'
-            || (field.hasAttribute('kpxc-defined') && field.getAttribute('kpxc-defined') !== 'totp')
             || field.id.match(ignoreRegex)
             || field.name.match(ignoreRegex)
             || field.readOnly) {


### PR DESCRIPTION
Increases the maximum length of accepted TOTP field to 10. This ensures support with NextCloud, and other sites (AWS?) too.