### PR TITLE
Allow filling KPH attributes from context menu

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -27,6 +27,10 @@
         "message": "Show Password Generator",
         "description": "Show password generator text."
     },
+    "contextMenuFillAttribute": {
+      "message": "Fill attribute…",
+      "description": "Context menu parent item for filling a custom attribute."
+    },
     "multipleCredentialsDetected": {
         "message": "HTTP authentication with multiple credentials detected. Click on the extension icon to choose the correct one.",
         "description": "Notification when HTTP Authentication has multiple credentials detected."

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -236,5 +236,6 @@ kpxcEvent.messageHandlers = {
     'update_credentials': keepass.updateCredentials,
     'username_field_detected': kpxcEvent.onUsernameFieldDetected,
     'save_settings': kpxcEvent.onSaveSettings,
-    'update_available_keepassxc': kpxcEvent.onUpdateAvailableKeePassXC
+    'update_available_keepassxc': kpxcEvent.onUpdateAvailableKeePassXC,
+    'update_context_menu': page.updateContextMenu
 };

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -107,6 +107,7 @@ const contextMenuItems = [
     { title: tr('contextMenuFillUsernameAndPassword'), action: 'fill_username_password' },
     { title: tr('contextMenuFillPassword'), action: 'fill_password' },
     { title: tr('contextMenuFillTOTP'), action: 'fill_totp' },
+    { title: tr('contextMenuFillAttribute'), id: 'fill_attribute', visible: false },
     { title: tr('contextMenuShowPasswordGenerator'), action: 'show_password_generator' },
     { title: tr('contextMenuSaveCredentials'), action: 'remember_credentials' }
 ];
@@ -122,6 +123,8 @@ for (const item of contextMenuItems) {
     browser.contextMenus.create({
         title: item.title,
         contexts: menuContexts,
+        visible: item.visible,
+        id: item.id,
         onclick: (info, tab) => {
             browser.tabs.sendMessage(tab.id, {
                 action: item.action


### PR DESCRIPTION
Adds a new option "Fill attribute…" to the context menu when String Fields are found with `KPH: ` attributes.

If multiple credentials use KPH attributes, a username is shown at the start of the attribute name.

Fixes #390.