### PR TITLE
Save to default group when no group are found

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -136,18 +136,22 @@ kpxcBanner.create = async function(credentials = {}) {
 };
 
 kpxcBanner.saveNewCredentials = async function(credentials = {}) {
+    const saveToDefaultGroup = async function(creds) {
+        const args = [ creds.username, creds.password, creds.url ];
+        const res = await sendMessage('add_credentials', args);
+        kpxcBanner.verifyResult(res);
+    };
+
     const result = await sendMessage('get_database_groups');
     if (!result || !result.groups) {
         console.log('Error: Empty result from get_database_groups');
+        await saveToDefaultGroup(credentials);
         return;
     }
 
     if (!result.defaultGroupAlwaysAsk) {
         if (result.defaultGroup === '' || result.defaultGroup === DEFAULT_BROWSER_GROUP) {
-            // Default group is used
-            const args = [ credentials.username, credentials.password, credentials.url ];
-            const res = await sendMessage('add_credentials', args);
-            kpxcBanner.verifyResult(res);
+            await saveToDefaultGroup(credentials);
             return;
         } else {
             // A specified group is used


### PR DESCRIPTION
KeePassXC versions lower than 2.4.0 does not support getting groups, and the result will be empty. This fix allows to save to the default group instead of just showing an error in the console.

Fixes #1016.