### PR TITLE
Fix multiple simultaneous HTTP Auth calls

### DIFF
--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -48,7 +48,7 @@ httpAuth.handleRequestCallback = function(details, callback) {
 };
 
 httpAuth.retrieveCredentials = async function(tabId, url, submitUrl) {
-    return await keepass.retrieveCredentials(tabId, [ url, submitUrl, false, true ]).catch((err) => {
+    return await page.retrieveCredentials(tabId, [ url, submitUrl, false, true ]).catch((err) => {
         console.log('httpAuth.retrieveCredentials error: ' + err);
         return Promise.reject();
     });

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -241,7 +241,7 @@ page.removePageInformationFromNotExistingTabs = async function() {
 // Retrieves the credentials. Returns cached values when found.
 // Page reload or tab switch clears the cache.
 page.retrieveCredentials = async function(tab, args = []) {
-    const [ url, submitUrl ] = args;
+    const [ url, submitUrl, triggerUnlock = false, httpAuth = false ] = args;
     if (page.tabs[tab.id] && page.tabs[tab.id].credentials.length > 0) {
         return page.tabs[tab.id].credentials;
     }


### PR DESCRIPTION
Use the cached `retrieveCredentials()` introduces in 1.7.0 to handle multiple simultaneous HTTP Auth calls.

Fixes #882.