### PR TITLE
TOTP ignoredTypes fix

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ignoreRegex = /(zip|postal).*code/i;
+const ignoreRegex = /(act|bank|coupon|postal|user|zip).*code|comment|author/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
 const MIN_INPUT_LENGTH = 6;
 const MAX_INPUT_LENGTH = 10;


### PR DESCRIPTION
Adds some more strings to ignoreRegex. Fixes invalid TOTP detections for example with SoundCloud.

Fixes #855.
Fixes #1030.
Fixes #1039.