### PR TITLE
Add extra checks for document.body

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1588,7 +1588,8 @@ kpxcObserverHelper.ignoredElement = function(target) {
 // Ignores all nodes that doesn't contain elements
 // Also ignore few Youtube-specific custom nodeNames
 kpxcObserverHelper.ignoredNode = function(target) {
-    if (kpxcObserverHelper.ignoredNodeTypes.some(e => e === target.nodeType)
+    if (!target
+        ||kpxcObserverHelper.ignoredNodeTypes.some(e => e === target.nodeType)
         || kpxcObserverHelper.ignoredNodeNames.some(e => e === target.nodeName)
         || target.nodeName.startsWith('YTMUSIC')
         || target.nodeName.startsWith('YT-')) {
@@ -1647,7 +1648,9 @@ kpxcObserverHelper.initObserver = async function() {
         }
     });
 
-    kpxc.observer.observe(document.body, kpxcObserverHelper.observerConfig);
+    if (document.body) {
+        kpxc.observer.observe(document.body, kpxcObserverHelper.observerConfig);
+    }
 };
 
 MutationObserver = window.MutationObserver || window.WebKitMutationObserver;

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -55,9 +55,12 @@ class Icon {
 }
 
 const kpxcUI = {};
-kpxcUI.bodyRect = document.body.getBoundingClientRect();
-kpxcUI.bodyStyle = getComputedStyle(document.body);
 kpxcUI.mouseDown = false;
+
+if (document.body) {
+    kpxcUI.bodyRect = document.body.getBoundingClientRect();
+    kpxcUI.bodyStyle = getComputedStyle(document.body);
+}
 
 // Wrapper for creating elements
 kpxcUI.createElement = function(type, classes, attributes, textContent) {


### PR DESCRIPTION
The site https://www.biggerpockets.com/forums gives interesting results with the content script. `document.body` is not initialized at all until a short time has passed. The scripts don't handle that situation.