### PR TITLE
Remove one TOTP ignore regex

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ignoreRegex = /(act|bank|coupon|postal|user|zip).*code|comment|author/i;
+const ignoreRegex = /(bank|coupon|postal|user|zip).*code|comment|author/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
 const MIN_INPUT_LENGTH = 6;
 const MAX_INPUT_LENGTH = 10;


### PR DESCRIPTION
Removes `act` from `ignoreRegex` because it matches e.g. twoF**act**or, breaking Protonmail and possibly some other sites.

I'm not happy about this one. We really need to re-implement this whole accept/ignore TOTP in the future. Before that I will do any necessary tests for the Content Tests branch which includes 2FA fields from most common sites (and the ones we have had problems with), so we will have a possibility to quickly test any fixes.