### PR TITLE
Fix showing autocomplete list without input field focus

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -727,19 +727,22 @@ kpxc.fillInFromActiveElement = async function(passOnly = false) {
     }
 
     const el = document.activeElement;
-    if (el.nodeName !== 'INPUT') {
-        // No active input element selected -> fill the first combination found
-        if (kpxc.combinations.length > 0) {
-            kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
-
-            // Focus to the input field
-            const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
-            if (field) {
-                field.focus();
-            }
+    if (el.nodeName !== 'INPUT' && kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
+        // No active input element selected -> focus to the input field
+        const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
+        if (field) {
+            field.focus();
         }
 
-        return;
+        if (kpxc.credentials.length > 1) {
+            // More than one credential -> show autocomplete list
+            kpxcAutocomplete.showList(field);
+            return
+        } else {
+            // Just one credential -> fill the first combination found
+            kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
+            return;
+        }
     } else if (kpxc.credentials.length > 1 && kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
         kpxcAutocomplete.showList(el);
         return;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -727,25 +727,26 @@ kpxc.fillInFromActiveElement = async function(passOnly = false) {
     }
 
     const el = document.activeElement;
-    if (el.nodeName !== 'INPUT' && kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
-        // No active input element selected -> focus to the input field
-        const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
-        if (field) {
-            field.focus();
-        }
 
-        if (kpxc.credentials.length > 1) {
-            // More than one credential -> show autocomplete list
-            kpxcAutocomplete.showList(field);
-            return
-        } else {
-            // Just one credential -> fill the first combination found
-            kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
+    if (kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
+        const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
+        if (field && field.id !== el.id) {
+            // focus to the correct input field
+            field.focus();
+
+            if (kpxc.credentials.length > 1) {
+                // More than one credential -> show autocomplete list
+                kpxcAutocomplete.showList(field);
+                return
+            } else {
+                // Just one credential -> fill the first combination found
+                kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
+                return;
+            }
+        } else if (kpxc.credentials.length > 1) {
+            kpxcAutocomplete.showList(el);
             return;
         }
-    } else if (kpxc.credentials.length > 1 && kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
-        kpxcAutocomplete.showList(el);
-        return;
     }
 
     // No previous combinations detected. Create a new one from active element

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -726,30 +726,24 @@ kpxc.fillInFromActiveElement = async function(passOnly = false) {
         return;
     }
 
-    const el = document.activeElement;
-
     if (kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
         const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
-        if (field && field.id !== el.id) {
-            // focus to the correct input field
-            field.focus();
+        // set focus to the input field
+        field.focus();
 
-            if (kpxc.credentials.length > 1) {
-                // More than one credential -> show autocomplete list
-                kpxcAutocomplete.showList(field);
-                return
-            } else {
-                // Just one credential -> fill the first combination found
-                kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
-                return;
-            }
-        } else if (kpxc.credentials.length > 1) {
-            kpxcAutocomplete.showList(el);
+        if (kpxc.credentials.length > 1) {
+            // More than one credential -> show autocomplete list
+            kpxcAutocomplete.showList(field);
+            return
+        } else {
+            // Just one credential -> fill the first combination found
+            kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
             return;
         }
     }
 
     // No previous combinations detected. Create a new one from active element
+    const el = document.activeElement;
     let combination;
     if (kpxc.combinations.length === 0) {
         combination = await kpxc.createCombination(el);

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -727,7 +727,18 @@ kpxc.fillInFromActiveElement = async function(passOnly = false) {
     }
 
     if (kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
-        const field = passOnly ? kpxc.combinations[0].password : kpxc.combinations[0].username;
+        const combination = passOnly
+            ? kpxc.combinations.find(c => c.password)
+            : kpxc.combinations.find(c => c.username);
+        if (!combination) {
+            return;
+        }
+
+        const field = passOnly ? combination.password : combination.username;
+        if (!field) {
+            return;
+        }
+
         // set focus to the input field
         field.focus();
 
@@ -737,7 +748,7 @@ kpxc.fillInFromActiveElement = async function(passOnly = false) {
             return
         } else {
             // Just one credential -> fill the first combination found
-            kpxc.fillInCredentials(kpxc.combinations[0], kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
+            kpxc.fillInCredentials(combination, kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
             return;
         }
     }


### PR DESCRIPTION
If input field does not have focus:
- show autocomplete list if there are multiple credentials
- otherwise fill in credentials

Fixes #1081 