### PR TITLE
Move isSearchField() to a better location

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -378,7 +378,7 @@ kpxcFields.getAllPageInputs = async function(previousInputs = []) {
             continue;
         }
 
-        if (kpxcFields.isVisible(input) && !kpxcFields.isSearchField(input) && kpxcFields.isAutocompleteAppropriate(input)) {
+        if (kpxcFields.isVisible(input) && kpxcFields.isAutocompleteAppropriate(input)) {
             fields.push(input);
         }
     }
@@ -1527,7 +1527,8 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
     // Only include input fields that match with kpxcObserverHelper.inputTypes
     const inputs = [];
     for (const field of inputFields) {
-        if (!ignoreVisibility && !kpxcFields.isVisible(field)) {
+        if ((!ignoreVisibility && !kpxcFields.isVisible(field))
+            || kpxcFields.isSearchField(field)) {
             continue;
         }
 


### PR DESCRIPTION
Moves `isSearchField()` inside `kpxcObserverHelper.getInputs()` so search fields can be filtered out in one place instead of checking it in multiple functions.

Fixes username field icon with e.g. https://outlook.live.com.