### PR TITLE
Adjust PayPal URL in Predefined Sites

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -2,7 +2,7 @@
 
 const PREDEFINED_SITELIST = [
     'https://accounts.google.com/*',
-    'https://www.paypal.com/*',
+    'https://www.paypal.com/*/signin',
     'https://outlook.live.com/*',
     'https://login.live.com/*',
     'https://login.microsoftonline.com/*',


### PR DESCRIPTION
Adjusts the site's Match Pattern URL to include only the signin page in any language (`/fi/`, `/se/`, `/de/` etc.).

Fixes #1139.