### PR TITLE
Add TOTP possibility to Predefined Sites

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -66,3 +66,12 @@ kpxcSites.exceptionFound = function(classList) {
 
     return false;
 };
+
+kpxcSites.expectedTOTPMaxLength = function() {
+    if (document.location.origin.startsWith('https://www.amazon')
+        && document.location.href.includes('/ap/mfa')) {
+        return 20;
+    }
+
+    return MAX_TOTP_INPUT_LENGTH;
+};

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -2,8 +2,8 @@
 
 const ignoreRegex = /(bank|coupon|postal|user|zip).*code|comment|author/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
-const MIN_INPUT_LENGTH = 6;
-const MAX_INPUT_LENGTH = 10;
+const MIN_TOTP_INPUT_LENGTH = 6;
+const MAX_TOTP_INPUT_LENGTH = 10;
 
 const acceptedOTPFields = [
     '2fa',
@@ -57,7 +57,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
         if (ignoredTypes.some(t => t === field.type)
             || field.offsetWidth < MINIMUM_INPUT_FIELD_WIDTH
             || field.size < 2
-            || (field.maxLength > 0 && (field.maxLength < MIN_INPUT_LENGTH || field.maxLength > MAX_INPUT_LENGTH))
+            || (field.maxLength > 0 && (field.maxLength < MIN_TOTP_INPUT_LENGTH || field.maxLength > kpxcSites.expectedTOTPMaxLength()))
             || ignoredTypes.some(t => t === field.autocomplete)
             || field.id.match(ignoreRegex)
             || field.name.match(ignoreRegex)

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -2,8 +2,6 @@
 
 const ignoreRegex = /(bank|coupon|postal|user|zip).*code|comment|author/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
-const MIN_TOTP_INPUT_LENGTH = 6;
-const MAX_TOTP_INPUT_LENGTH = 10;
 
 const acceptedOTPFields = [
     '2fa',

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const MINIMUM_INPUT_FIELD_WIDTH = 60;
+const MIN_TOTP_INPUT_LENGTH = 6;
+const MAX_TOTP_INPUT_LENGTH = 10;
 
 const DatabaseState = {
     DISCONNECTED: 0,


### PR DESCRIPTION
Allows specific TOTP rules for certain sites, e.g. Amazon (which has `maxLength` defined as 20, which we normally ignore).