### PR TITLE
Trim entry name in Autocomplete Menu when needed

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const MAX_AUTOCOMPLETE_NAME_LEN = 50;
+
 const kpxcAutocomplete = {};
 kpxcAutocomplete.autoSubmit = false;
 kpxcAutocomplete.elements = [];

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1140,9 +1140,12 @@ kpxc.initLoginPopup = function() {
     }
 
     const getLoginText = function(credential, withGroup) {
+        const name = credential.name.length < MAX_AUTOCOMPLETE_NAME_LEN
+                   ? credential.name
+                   : credential.name.substr(0, MAX_AUTOCOMPLETE_NAME_LEN) + '…';
         const group = (withGroup && credential.group) ? `[${credential.group}] ` : '';
         const visibleLogin = (credential.login.length > 0) ? credential.login : tr('credentialsNoUsername');
-        const text = `${group}${credential.name} (${visibleLogin})`;
+        const text = `${group}${name} (${visibleLogin})`;
 
         if (credential.expired && credential.expired === 'true') {
             return `${text} [${tr('credentialExpired')}]`;


### PR DESCRIPTION
If entry name exceeds 50 characters, it will be trimmed and `…` is added to the end. It fixes a problem where the Autocomplete Menu width can be wider than the page itself.

Fixes #1153.