### PR TITLE
Check placeholder attribute for ignoring a false positive with TOTP

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ignoreRegex = /(bank|coupon|postal|user|zip).*code|comment|author/i;
+const ignoreRegex = /(bank|coupon|postal|user|zip).*code|comment|author|error/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
 
 const acceptedOTPFields = [
@@ -60,6 +60,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
             || ignoredTypes.some(t => t === field.autocomplete)
             || field.id.match(ignoreRegex)
             || field.name.match(ignoreRegex)
+            || field.placeholder.match(ignoreRegex)
             || field.readOnly) {
             return false;
         }


### PR DESCRIPTION
Checks the `placeholder` attribute for TOTP fields. Disables some false positives. Also adds `error` to the ignore list.

Fixes #1018.