### PR TITLE
Improve form handling with credential saving

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -261,6 +261,11 @@ kpxcForm.onSubmit = async function(e) {
         form = kpxcSites.savedForm;
     }
 
+    // Still not found? Try using the first one from kpxcForm.savedForms
+    if (!form && kpxcForm.savedForms.length > 0) {
+        form = kpxcForm.savedForms[0].form;
+    }
+
     if (!form) {
         return;
     }


### PR DESCRIPTION
If a form is not found on form submit or via exceptions (e.g. exceptions made for Google), include previously saved form to the list.

Partially fixes #1111.