### PR TITLE
Fix detecting eBay password input fields

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -56,7 +56,7 @@ kpxcSites.exceptionFound = function(classList) {
     if (document.location.origin === 'https://idmsa.apple.com'
         && [ 'password', 'form-row', 'show-password' ].every(c => classList.contains(c))) {
         return true;
-    } else if (document.location.origin.startsWith('https://signin.ebay.com')
+    } else if (document.location.origin.startsWith('https://signin.ebay.')
                && classList.contains('null')) {
         return true;
     } else if (document.location.origin.startsWith('https://www.fidelity.com')


### PR DESCRIPTION
Handle password input pages for all eBay domains with Predefined Sites, not just `.com`.

Fixes #1158.