### PR TITLE
Fix Auto-Submit for eBay

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -41,6 +41,7 @@ const PREDEFINED_SITELIST = [
 ];
 
 const kpxcSites = {};
+kpxcSites.ebayUrl = 'https://www.ebay.';
 kpxcSites.googlePasswordFormUrl = 'https://accounts.google.com/signin/v2/challenge/password';
 kpxcSites.googleUrl = 'https://accounts.google.com';
 kpxcSites.savedForm = undefined;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -171,6 +171,13 @@ kpxcForm.getFormSubmitButton = function(form) {
         const buttons = findDiv.getElementsByTagName('button');
         kpxcSites.savedForm = form;
         return buttons.length > 0 ? buttons[0] : undefined;
+    } else if (form.action.startsWith(kpxcSites.ebayUrl)) {
+        // For eBay we must return the first button.
+        for (const i of form.elements) {
+            if (i.type === 'button') {
+                return i;
+            }
+        }
     }
 
     if (action.includes(document.location.origin + document.location.pathname)) {


### PR DESCRIPTION
eBay detects the Apple ID button as submit button. Instead, we need to specify the first button of the form for this site.

Fixes #1160.