### PR TITLE
Add twofa as accepted TOTP field

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -12,6 +12,7 @@ const acceptedOTPFields = [
     'mfa',
     'otp',
     'token',
+    'twofa',
     'twofactor'
 ];
 


### PR DESCRIPTION
Adds `twofa` to the accepted list. This fixes for example Protonmail's new page (current beta).