### PR TITLE
Ignore buttons with different formaction

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -189,8 +189,9 @@ kpxcForm.getFormSubmitButton = function(form) {
     }
 
     // Try to find another button. Select the last one.
-    // TODO: Possibly change this behavior to select the last one for only certain sites.
-    const buttons = Array.from(form.querySelectorAll(kpxcForm.formButtonQuery));
+    // If any formaction overriding the default action is set, ignore those buttons.
+    const buttons = Array.from(form.querySelectorAll(kpxcForm.formButtonQuery))
+                         .filter(b => b.formAction === document.location.href);
     if (buttons.length > 0) {
         return buttons[buttons.length - 1];
     }

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -190,8 +190,7 @@ kpxcForm.getFormSubmitButton = function(form) {
 
     // Try to find another button. Select the last one.
     // If any formaction overriding the default action is set, ignore those buttons.
-    const buttons = Array.from(form.querySelectorAll(kpxcForm.formButtonQuery))
-                         .filter(b => b.formAction === document.location.href);
+    const buttons = Array.from(form.querySelectorAll(kpxcForm.formButtonQuery)).filter(b => !b.getAttribute('formAction'));
     if (buttons.length > 0) {
         return buttons[buttons.length - 1];
     }


### PR DESCRIPTION
Form buttons have `document.location.href` as a default `formaction`. If `formaction` is set, it will override the default `action`. Those buttons must be ignored.

Fixes #1192.