### PR TITLE
Do not initialize Autocomplete input field events twice

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -36,15 +36,18 @@ class Autocomplete {
 
         this.autoSubmit = autoSubmit;
         this.input = input;
-        this.started = true;
 
-        input.addEventListener('click', ev => this.click(ev, this.input));
-        input.addEventListener('keydown', ev => this.keyPress(ev));
-        input.setAttribute('autocomplete', 'off');
+        if (!this.started) {
+            input.addEventListener('click', ev => this.click(ev, this.input));
+            input.addEventListener('keydown', ev => this.keyPress(ev));
+            input.setAttribute('autocomplete', 'off');
+        }
 
         if (showListInstantly) {
             this.showList(input);
         }
+
+        this.started = true;
     }
 
     mouseOver(e, div, item) {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.5",
-    "version_name": "1.7.5",
+    "version": "1.7.6",
+    "version_name": "1.7.6",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.4",
+  "version": "1.7.6",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
Autocomplete related input field events got triggered more than once, causing Autocomplete menu to work incorrectly.

Fixes #1207.