### PR TITLE
Reload credentials after save

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -268,14 +268,15 @@ page.removePageInformationFromNotExistingTabs = async function() {
 
 // Retrieves the credentials. Returns cached values when found.
 // Page reload or tab switch clears the cache.
+// If the retrieval is forced (from Credential Banner), get new credentials normally.
 page.retrieveCredentials = async function(tab, args = []) {
-    const [ url, submitUrl ] = args;
-    if (page.tabs[tab.id] && page.tabs[tab.id].credentials.length > 0) {
+    const [ url, submitUrl, force ] = args;
+    if (page.tabs[tab.id] && page.tabs[tab.id].credentials.length > 0 && !force) {
         return page.tabs[tab.id].credentials;
     }
 
     // Ignore duplicate requests
-    if (page.currentRequest.url === url && page.currentRequest.submitUrl === submitUrl) {
+    if (page.currentRequest.url === url && page.currentRequest.submitUrl === submitUrl && !force) {
         return [];
     } else {
         page.currentRequest.url = url;

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -9,6 +9,10 @@ kpxcBanner.credentials = {};
 kpxcBanner.wrapper = undefined;
 
 kpxcBanner.destroy = async function() {
+    if (!kpxcBanner.created) {
+        return;
+    }
+
     kpxcBanner.created = false;
     kpxcBanner.credentials = {};
 
@@ -302,13 +306,15 @@ kpxcBanner.updateCredentials = async function(credentials = {}) {
     }
 };
 
-kpxcBanner.verifyResult = function(code) {
+kpxcBanner.verifyResult = async function(code) {
     if (code === 'error') {
         kpxcUI.createNotification('error', tr('rememberErrorCannotSaveCredentials'));
     } else if (code === 'created') {
         kpxcUI.createNotification('success', tr('rememberCredentialsSaved', kpxcBanner.credentials.username || tr('rememberEmptyUsername')));
+        await kpxc.retrieveCredentials(true); // Forced reload
     } else if (code === 'updated') {
         kpxcUI.createNotification('success', tr('rememberCredentialsUpdated', kpxcBanner.credentials.username || tr('rememberEmptyUsername')));
+        await kpxc.retrieveCredentials(true); // Forced reload
     } else if (code === 'canceled') {
         kpxcUI.createNotification('warning', tr('rememberCredentialsNotSaved'));
     } else {

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -57,6 +57,9 @@ $(async () => {
         await browser.runtime.sendMessage({
             action: 'associate'
         });
+
+        // This does not work with Firefox because of https://bugzilla.mozilla.org/show_bug.cgi?id=1665380
+        await sendMessageToTab('retrive_credentials_forced');
         close();
     });
 


### PR DESCRIPTION
After user has saved new or modified credentials using the Credential Banner, new credentials are immediately loaded. This prevents the banner to reappear after the login and seeing the recently saved credentials as a new one. It also shows the updated credentials immediately in Autocomplete Menu and the popup login menu.

- [x] Reload credentials after saving new/modified ones
- [x] Reload credentials after database connect (Firefox gives me a headache with this bug https://bugzilla.mozilla.org/show_bug.cgi?id=1665380)
- [x] Save credentials to the default group when Credential Banner is disabled

Fixes #1225.