### PR TITLE
Increase reliability of custom login fields functionality

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -432,12 +432,16 @@ kpxcFields.getCombination = async function(field, givenType) {
 
 // Gets of generates an unique ID for the element
 kpxcFields.getId = function(target) {
+    if (target.name) {
+        return `${target.nodeName} ${target.type} ${target.name} ${target.placeholder}`;
+    }
+
     if (target.classList.length > 0) {
-        return `${target.nodeName} ${target.type} ${target.classList.value} ${target.name} ${target.placeholder}`;
+        return `${target.nodeName} ${target.type} ${target.classList.value} ${target.placeholder}`;
     }
 
     if (target.id && target.id !== '') {
-        return `${target.nodeName} ${target.type} ${kpxcFields.prepareId(target.id)} ${target.name} ${target.placeholder}`;
+        return `${target.nodeName} ${target.type} ${kpxcFields.prepareId(target.id)} ${target.placeholder}`;
     }
 
     return `kpxc ${target.type} ${target.clientTop}${target.clientLeft}${target.clientWidth}${target.clientHeight}${target.offsetTop}${target.offsetLeft}`;


### PR DESCRIPTION
Some (possibly a lot of) websites, like https://042564560466.signin.aws.amazon.com/console nowadays are generating dynamic classNames in their forms. ClassNames there depend on multitude factors, such as which field is currently selected or if field is empty. In case of formerly mentioned websites, this looks to be the case for AngularJS framework, which injects classes like `ng-untouched`, `ng-valid`, `ng-not-empty` and so on. This means keepassxc detects these fields first time only (and sometimes again randomly). I don't know reasons why this extension went for a solution where classNames were playing major part of the role of identifying the fields, but it turned out to be unreliable. This patch removes this factor and instead relies on more stable attributes, especially input/target name. Extra/custom field associations in other password field managers like 1Password7 and Enpass detect the fields automatically, very reliably. I think this is closer to how they do it.