### PR TITLE
Do not allow identical field ID's with Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/define.js
+++ b/keepassxc-browser/content/define.js
@@ -386,7 +386,8 @@ kpxcDefine.confirm = async function() {
     }
 
     if (kpxcDefine.selection.password) {
-        kpxcDefine.selection.password = kpxcFields.getId(kpxcDefine.selection.password.originalElement);
+        kpxcDefine.selection.password = kpxcFields.getId(kpxcDefine.selection.password.originalElement,
+            kpxcDefine.selection.username);
     }
 
     if (kpxcDefine.selection.totp) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -430,14 +430,24 @@ kpxcFields.getCombination = async function(field, givenType) {
     return undefined;
 };
 
-// Gets of generates an unique ID for the element
-kpxcFields.getId = function(target) {
+/**
+ * Returns an unique ID for the element
+ * @param {HTMLElement} target Input field
+ * @param {String} previouslySet Used for comparison so two ID's cannot be identical
+ */
+kpxcFields.getId = function(target, previouslySet) {
     if (target.classList.length > 0) {
-        return `${target.nodeName} ${target.type} ${target.classList.value} ${target.name} ${target.placeholder}`;
+        const id = `${target.nodeName} ${target.type} ${target.classList.value} ${target.name} ${target.placeholder}`;
+        if (id !== previouslySet) {
+            return id;
+        }
     }
 
     if (target.id && target.id !== '') {
-        return `${target.nodeName} ${target.type} ${kpxcFields.prepareId(target.id)} ${target.name} ${target.placeholder}`;
+        const id = `${target.nodeName} ${target.type} ${kpxcFields.prepareId(target.id)} ${target.name} ${target.placeholder}`;
+        if (id !== previouslySet) {
+            return id;
+        }
     }
 
     return `kpxc ${target.type} ${target.clientTop}${target.clientLeft}${target.clientWidth}${target.clientHeight}${target.offsetTop}${target.offsetLeft}`;


### PR DESCRIPTION
When creating ID's for Custom Login fields, always skip to the next ID method if it's a duplicate.