### PR TITLE
Use XPath for element ID creation

### DIFF
--- a/keepassxc-browser/content/define.js
+++ b/keepassxc-browser/content/define.js
@@ -382,20 +382,20 @@ kpxcDefine.confirm = async function() {
     }
 
     if (kpxcDefine.selection.username) {
-        kpxcDefine.selection.username = kpxcFields.getId(kpxcDefine.selection.username.originalElement);
+        kpxcDefine.selection.username = kpxcFields.setId(kpxcDefine.selection.username.originalElement);
     }
 
     if (kpxcDefine.selection.password) {
-        kpxcDefine.selection.password = kpxcFields.getId(kpxcDefine.selection.password.originalElement);
+        kpxcDefine.selection.password = kpxcFields.setId(kpxcDefine.selection.password.originalElement);
     }
 
     if (kpxcDefine.selection.totp) {
-        kpxcDefine.selection.totp = kpxcFields.getId(kpxcDefine.selection.totp.originalElement);
+        kpxcDefine.selection.totp = kpxcFields.setId(kpxcDefine.selection.totp.originalElement);
     }
 
     const fieldIds = [];
     for (const i of kpxcDefine.selection.fields) {
-        fieldIds.push(kpxcFields.getId(i));
+        fieldIds.push(kpxcFields.setId(i));
     }
 
     const location = kpxc.getDocumentLocation();

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -430,17 +430,34 @@ kpxcFields.getCombination = async function(field, givenType) {
     return undefined;
 };
 
-// Gets of generates an unique ID for the element
+// Returns an unique ID for the element
 kpxcFields.getId = function(target) {
-    if (target.classList.length > 0) {
-        return `${target.nodeName} ${target.type} ${target.classList.value} ${target.name} ${target.placeholder}`;
+    let xpath = '';
+    let pos;
+    let temp;
+
+    while (target !== document.documentElement) {
+        pos = 0;
+        temp = target;
+        while (temp) {
+            if (temp.nodeType === 1 && temp.nodeName === target.nodeName) {
+                pos += 1;
+            }
+
+            temp = temp.previousSibling;
+        }
+
+        xpath = `${target.nodeName.toLowerCase()}${(pos > 1 ? `[${pos}]/` : '/')}${xpath}`;
+        target = target.parentNode;
     }
 
-    if (target.id && target.id !== '') {
-        return `${target.nodeName} ${target.type} ${kpxcFields.prepareId(target.id)} ${target.name} ${target.placeholder}`;
-    }
+    xpath = `/${document.documentElement.nodeName.toLowerCase()}/${xpath}`;
+    xpath = xpath.replace(/\/$/, '');
+    return xpath;
+};
 
-    return `kpxc ${target.type} ${target.clientTop}${target.clientLeft}${target.clientWidth}${target.clientHeight}${target.offsetTop}${target.offsetLeft}`;
+kpxcFields.getElementFromId = function(id) {
+    return (new XPathEvaluator()).evaluate(id, document.documentElement, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 };
 
 // Check for new password via autocomplete attribute
@@ -558,7 +575,7 @@ kpxcFields.useCustomLoginFields = async function() {
     // Finds the input field based on the stored ID
     const findInputField = async function(inputFields, id) {
         if (id) {
-            const input = inputFields.find(e => kpxcFields.getId(e) === id);
+            const input = inputFields.find(e => e === kpxcFields.getElementFromId(id));
             if (input) {
                 return input;
             }


### PR DESCRIPTION
Use XPath instead of a custom generated ID for HTML elements. New ID as XPath can be for example `/html/body/div/div/div[2]/div[2]/div[1]/div/div/form/div[4]/div[2]/input` so it doesn't care any names or classes, which might change dynamically, but relies on the page content and element ordering.

Fixes #1195.
Fixes #1233.
Fixes #1259.