### PR TITLE
Add support for multiple menu locations

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -4,9 +4,9 @@ const MAX_AUTOCOMPLETE_NAME_LEN = 50;
 
 class Autocomplete {
     constructor() {
+        this.autocompleteList = [];
         this.autoSubmit = false;
         this.elements = [];
-        this.started = false;
         this.index = -1;
         this.input = undefined;
         this.shadowRoot = undefined;
@@ -35,19 +35,17 @@ class Autocomplete {
         }
 
         this.autoSubmit = autoSubmit;
-        this.input = input;
 
-        if (!this.started) {
-            input.addEventListener('click', ev => this.click(ev, this.input));
+        if (!this.autocompleteList.includes(input)) {
+            input.addEventListener('click', ev => this.click(ev, input));
             input.addEventListener('keydown', ev => this.keyPress(ev));
             input.setAttribute('autocomplete', 'off');
+            this.autocompleteList.push(input);
         }
 
         if (showListInstantly) {
             this.showList(input);
         }
-
-        this.started = true;
     }
 
     mouseOver(e, div, item) {

--- a/keepassxc-browser/content/credential-autocomplete.js
+++ b/keepassxc-browser/content/credential-autocomplete.js
@@ -10,7 +10,10 @@ CredentialAutocomplete.prototype.click = async function(e, input) {
         input.select();
     }
 
-    this.showList(input);
+    const field = this.autocompleteList.find(a => a === input);
+    if (field) {
+        this.showList(field);
+    }
 };
 
 CredentialAutocomplete.prototype.itemClick = async function(e, item, input, uuid) {


### PR DESCRIPTION
If a web page has multiple login fields the Autocomplete Menu always shows only in the last of them. This fix adds an internal list to the class which can handle multiple menus without creating a new class for each one (which would be way too much).

Fixes #1244.