### PR TITLE
Handle Site Preferences URLs as lowercase

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -644,7 +644,7 @@ kpxc.url = null;
 // Add page to Site Preferences with Username-only detection enabled. Set from the popup
 kpxc.addToSitePreferences = async function() {
     // Returns a predefined URL for certain sites
-    let site = trimURL(window.top.location.href);
+    let site = trimURL(window.top.location.href).toLowerCase();
 
     // Check if the site already exists -> update the current settings
     let siteExists = false;
@@ -1437,11 +1437,11 @@ kpxc.siteIgnored = async function(condition) {
     if (kpxc.settings.sitePreferences) {
         let currentLocation;
         try {
-            currentLocation = window.top.location.href;
+            currentLocation = window.top.location.href.toLowerCase();
         } catch (err) {
             // Cross-domain security error inspecting window.top.location.href.
             // This catches an error when an iframe is being accessed from another (sub)domain -> use the iframe URL instead.
-            currentLocation = window.self.location.href;
+            currentLocation = window.self.location.href.toLowerCase();
         }
 
         const currentSetting = condition || IGNORE_FULL;

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -502,14 +502,14 @@ options.initSitePreferences = function() {
             trClone.removeClass('clone d-none');
 
             const tr = trClone.clone(true);
-            tr.data('url', value);
+            tr.data('url', value.toLowerCase());
             tr.attr('id', 'tr-scf' + newValue);
             tr.children('td:first').text(value);
             tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
             $('#tab-site-preferences table tbody:first').append(tr);
             $('#tab-site-preferences table tbody:first tr.empty:first').hide();
 
-            options.settings['sitePreferences'].push({ url: value, ignore: IGNORE_NOTHING, usernameOnly: false });
+            options.settings['sitePreferences'].push({ url: value.toLowerCase(), ignore: IGNORE_NOTHING, usernameOnly: false });
             options.saveSettings();
             manualUrl.value = '';
         }


### PR DESCRIPTION
In some web pages the login page URL can first include only lowercase letters, but manually the same URL can have also uppercase letters. Site Preferences URL's are stored as case sensitive which breaks settings for such sites.

Fixes #1200.