### PR TITLE
Additional keyboard shortcuts

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -28,8 +28,8 @@
         "description": "Show password generator text."
     },
     "contextMenuFillAttribute": {
-      "message": "Fill attribute…",
-      "description": "Context menu parent item for filling a custom attribute."
+        "message": "Fill attribute…",
+        "description": "Context menu parent item for filling a custom attribute."
     },
     "multipleCredentialsDetected": {
         "message": "HTTP authentication with multiple credentials detected. Click on the extension icon to choose the correct one.",
@@ -168,8 +168,8 @@
         "description": "Username field icon hover text when database is locked."
     },
     "usernameDisconnectedFieldText": {
-      "message": "KeePassXC is disconnected",
-      "description": "Username field icon hover text when KeePassXC is disconnected."
+        "message": "KeePassXC is disconnected",
+        "description": "Username field icon hover text when KeePassXC is disconnected."
     },
     "usernameFieldIcon": {
         "message": "Username field icon",
@@ -268,8 +268,8 @@
         "description": "Alert message when no credentials are found for the given username."
     },
     "credentialsNoTOTPFound": {
-      "message": "No TOTP found.",
-      "description": "Alert message when no TOTP is found."
+        "message": "No TOTP found.",
+        "description": "Alert message when no TOTP is found."
     },
     "credentialExpired": {
         "message": "Expired",
@@ -1020,8 +1020,8 @@
         "description": "Debug info text."
     },
     "optionsAboutSupporters": {
-      "message": "Supporters",
-      "description": "Supporters label text."
+        "message": "Supporters",
+        "description": "Supporters label text."
     },
     "optionsErrorInvalidValue": {
         "message": "Invalid value. Please check the input.",

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -139,7 +139,8 @@ for (const item of contextMenuItems) {
 browser.commands.onCommand.addListener(async (command) => {
     if (contextMenuItems.some(e => e.action === command)
         || command === 'redetect_fields'
-        || command === 'choose_credential_fields') {
+        || command === 'choose_credential_fields'
+        || command === 'retrive_credentials_forced') {
         const tabs = await browser.tabs.query({ active: true, currentWindow: true });
         if (tabs.length) {
             browser.tabs.sendMessage(tabs[0].id, { action: command });

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -109,7 +109,7 @@ const contextMenuItems = [
     { title: tr('contextMenuFillTOTP'), action: 'fill_totp' },
     { title: tr('contextMenuFillAttribute'), id: 'fill_attribute', visible: false },
     { title: tr('contextMenuShowPasswordGenerator'), action: 'show_password_generator' },
-    { title: tr('contextMenuSaveCredentials'), action: 'remember_credentials' }
+    { title: tr('contextMenuSaveCredentials'), action: 'save_credentials' }
 ];
 
 const menuContexts = [ 'editable' ];
@@ -137,7 +137,9 @@ for (const item of contextMenuItems) {
 
 // Listen for keyboard shortcuts specified by user
 browser.commands.onCommand.addListener(async (command) => {
-    if (contextMenuItems.some(e => e.action === command)) {
+    if (contextMenuItems.some(e => e.action === command)
+        || command === 'redetect_fields'
+        || command === 'choose_credential_fields') {
         const tabs = await browser.tabs.query({ active: true, currentWindow: true });
         if (tabs.length) {
             browser.tabs.sendMessage(tabs[0].id, { action: command });

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1899,7 +1899,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             kpxc.inputs = [];
             kpxc.combinations = [];
             kpxc.initCredentialFields();
-        } else if (req.action === 'remember_credentials') {
+        } else if (req.action === 'save_credentials') {
             kpxc.rememberCredentialsFromContextMenu();
         } else if (req.action === 'retrive_credentials_forced') {
             await kpxc.retrieveCredentials(true);

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -107,6 +107,15 @@
                 "default": "Alt+Shift+G",
                 "mac": "MacCtrl+Shift+G"
             }
+        },
+        "save_credentials": {
+            "description": "__MSG_contextMenuSaveCredentials__"
+        },
+        "redetect_fields": {
+          "description": "__MSG_popupRedetectButton__"
+        },
+        "choose_credential_fields": {
+          "description": "__MSG_popupChooseCredentialsText__"
         }
     },
     "web_accessible_resources": [

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -112,10 +112,13 @@
             "description": "__MSG_contextMenuSaveCredentials__"
         },
         "redetect_fields": {
-          "description": "__MSG_popupRedetectButton__"
+            "description": "__MSG_popupRedetectButton__"
         },
         "choose_credential_fields": {
-          "description": "__MSG_popupChooseCredentialsText__"
+            "description": "__MSG_popupChooseCredentialsText__"
+        },
+        "retrive_credentials_forced": {
+            "description": "__MSG_popupReopenButton__"
         }
     },
     "web_accessible_resources": [


### PR DESCRIPTION
Adds possibility to configure the following keyboard shortcuts:
- Save Credentials
- Choose Custom Login Fields
- Redetect Login Fields
- Reopen Database

Please note that there are no default key binding defined. This is because of restrictions with manifest.json files. Only four suggested keys per manifest are supported. For more information, see: https://developer.chrome.com/docs/extensions/reference/commands/

Fixes #732.
Fixes #839.
Fixes #993.
Fixes #1255.