### PR TITLE
Output the error from the port on Disconnect to the debug logs

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -1015,7 +1015,8 @@ keepass.onNativeMessage = function(response) {
     }
 };
 
-function onDisconnected() {
+function onDisconnected(port) {
+    let error = (port && port.error) || browser.runtime.lastError;
     keepass.nativePort = null;
     keepass.isConnected = false;
     keepass.isDatabaseClosed = true;
@@ -1026,7 +1027,7 @@ function onDisconnected() {
     page.clearCredentials(page.currentTabId, true);
     keepass.updatePopup('cross');
     keepass.updateDatabaseHashToContent();
-    console.log('Failed to connect: ' + (browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message));
+    console.log('Failed to connect: ' + ((error === null)? 'Unknown error' : error.message);
 }
 
 keepass.getNonce = function() {


### PR DESCRIPTION
Right now the error output on disconnection is taken from `browser.runtime.lastError` which might only make sense if the timming is exactly right.

According to Mozilla's documentation the onDisconnect should be receiving the port argument which contains an error field, I expect this should be the right place to look for a meaningful error to display.
See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port

This is related to: #559