### PR TITLE
Support for triggering Global Auto-Type

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -1074,5 +1074,9 @@
     "lockDatabase": {
         "message": "Lock database",
         "description": "Lock database button title text."
+    },
+    "performGlobalAutoType": {
+        "message": "Perform Global Auto-Type",
+        "description": "Global Auto-Type keyboard shortcut text."
     }
 }

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -140,9 +140,15 @@ browser.commands.onCommand.addListener(async (command) => {
     if (contextMenuItems.some(e => e.action === command)
         || command === 'redetect_fields'
         || command === 'choose_credential_fields'
-        || command === 'retrive_credentials_forced') {
+        || command === 'retrive_credentials_forced'
+        || command === 'perform_autotype') {
         const tabs = await browser.tabs.query({ active: true, currentWindow: true });
         if (tabs.length) {
+            if (command === 'perform_autotype') {
+                await keepass.performAutotype(tabs[0].id, [ tabs[0].url ]);
+                return;
+            }
+
             browser.tabs.sendMessage(tabs[0].id, { action: command });
         }
     }

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -119,6 +119,9 @@
         },
         "retrive_credentials_forced": {
             "description": "__MSG_popupReopenButton__"
+        },
+        "perform_autotype": {
+            "description": "__MSG_performGlobalAutoType__"
         }
     },
     "web_accessible_resources": [


### PR DESCRIPTION
Support for triggering Global Auto-Type from KeePassXC with a separate keyboard shortcut.

URL is transferred to KeePassXC, but not currently used.

Fixes #1191.