### PR TITLE
Add credential sorting

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -683,6 +683,10 @@
         "message": "Color theme",
         "description": "Theme selection header text."
     },
+    "optionsCredentialSortSelectionHeader": {
+        "message": "Sort matching credentials by",
+        "description": "Credential sort option header text."
+    },
     "optionsThemeSelection": {
         "message": "Select color theme",
         "description": "Theme selection title text."
@@ -902,6 +906,22 @@
     "optionsSelectionFull": {
         "message": "Disable all features",
         "description": "Site preferences option selection."
+    },
+    "optionsSortByTitle": {
+        "message": "Title",
+        "desription": "Sort matching credentials by title option selection."
+    },
+    "optionsSortByUsername": {
+        "message": "Username",
+        "desription": "Sort matching credentials by username option selection."
+    },
+    "optionsSortByGroupAndTitle": {
+        "message": "Group and title",
+        "desription": "Sort matching credentials by group and title option selection."
+    },
+    "optionsSortByGroupAndUsername": {
+        "message": "Group and username",
+        "desription": "Sort matching credentials by group and username option selection."
     },
     "optionsCustomFieldsNotFound": {
         "message": "No saved custom login fields found.",

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -10,6 +10,7 @@ const defaultSettings = {
     autoSubmit: false,
     checkUpdateKeePassXC: 3,
     colorTheme: 'system',
+    credentialSorting: SORT_BY_GROUP_AND_TITLE,
     defaultGroup: '',
     defaultGroupAlwaysAsk: false,
     redirectAllowance: 1,
@@ -80,6 +81,10 @@ page.initSettings = async function() {
 
         if (!('colorTheme' in page.settings)) {
             page.settings.colorTheme = defaultSettings.colorTheme;
+        }
+
+        if (!('credentialSorting' in page.settings)) {
+            page.settings.credentialSorting = defaultSettings.credentialSorting;
         }
 
         if (!('defaultGroup' in page.settings)) {

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -1,9 +1,16 @@
 'use strict';
 
+// Site Preferences ignore options
 const IGNORE_NOTHING = 'ignoreNothing';
 const IGNORE_NORMAL = 'ignoreNormal';
 const IGNORE_AUTOSUBMIT = 'ignoreAutoSubmit';
 const IGNORE_FULL = 'ignoreFull';
+
+// Credential sorting options
+const SORT_BY_TITLE = 'sortByTitle';
+const SORT_BY_USERNAME = 'sortByUsername';
+const SORT_BY_GROUP_AND_TITLE = 'sortByGroupAndTitle';
+const SORT_BY_GROUP_AND_USERNAME = 'sortByGroupAndUsername';
 
 const schemeSegment = '(\\*|http|https|ws|wss|file|ftp)';
 const hostSegment = '(\\*|(?:\\*\\.)?(?:[^/*]+))?';

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.6",
-    "version_name": "1.7.6",
+    "version": "1.7.7",
+    "version_name": "1.7.7",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -142,6 +142,18 @@
 
                   <div class="form-group">
                     <div class="form-check">
+                      <label for="credentialSorting" data-i18n="optionsCredentialSortSelectionHeader"></label>
+                      <select class="form-control form-control-sm col-md-2" id="credentialSorting" data-i18n="[title]optionsCredentialSortSelection">
+                        <option value="sortByTitle" data-i18n="optionsSortByTitle"></option>
+                        <option value="sortByUsername" data-i18n="optionsSortByUsername"></option>
+                        <option value="sortByGroupAndTitle" data-i18n="optionsSortByGroupAndTitle"></option>
+                        <option value="sortByGroupAndUsername" data-i18n="optionsSortByGroupAndUsername"></option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div class="form-group">
+                    <div class="form-check">
                       <input class="form-check-input" type="checkbox" name="autoSubmit" id="autoSubmit" value="true" />
                       <label class="form-check-label" for="autoSubmit" data-i18n="optionsCheckboxAutoSubmit"></label>
                       <span class="form-text text-muted" data-i18n="optionsAutoSubmitHelpText"></span>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -73,10 +73,15 @@ options.initGeneralSettings = function() {
         $('#tab-general-settings select#colorTheme').val(options.settings['colorTheme']);
     }
 
-    $('#tab-general-settings select:first').change(async function() {
+    $('#tab-general-settings select#colorTheme').change(async function() {
         options.settings['colorTheme'] = $(this).val();
         await options.saveSettings();
         location.reload();
+    });
+
+    $('#tab-general-settings select#credentialSorting').change(async function() {
+        options.settings['credentialSorting'] = $(this).val();
+        await options.saveSettings();
     });
 
     $('#tab-general-settings input[type=checkbox]').each(function() {
@@ -115,6 +120,7 @@ options.initGeneralSettings = function() {
         }
     });
 
+    $('#tab-general-settings select#credentialSorting').val(options.settings['credentialSorting']);
     $('#tab-general-settings input#defaultGroup').val(options.settings['defaultGroup']);
 
     $('#tab-general-settings input[type=radio]').each(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
Adds credential sorting to the extension. This makes KeePassXC's sorting in Browser Integration tab redundant and it must be removed for 2.7.0.

This feature adds four different options for the user:
- Sort matching credentials by title
- Sort matching credentials by username
- Sort matching credentials by group & title
- Sort matching credentials by group & username

Option page now has a combo box under the Autocomplete option:
<img width="679" alt="Screenshot 2021-03-24 at 17 23 35" src="https://user-images.githubusercontent.com/24570482/112339624-805f2900-8cc8-11eb-9c76-e687e45350a4.png">

Fixes #1217.