### PR TITLE
Fix id and name check for form

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -407,8 +407,10 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
     };
 
     const form = inputs.length > 0 ? inputs[0].form : undefined;
-    if (form && (acceptedOTPFields.some(f => form.className.includes(f) || form.id.includes(f) || form.name.includes(f))
-        || form.length === 6)) {
+    if (form && (acceptedOTPFields.some(f => (form.className && form.className.includes(f))
+        || (form.id && typeof(form.id) === 'string' && form.id.includes(f))
+        || (form.name && typeof(form.name) === 'string' && form.name.includes(f))
+        || form.length === 6))) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements);
     } else if (inputs.length === 6 && inputs.every(i => i.inputMode === 'numeric' && i.pattern.includes('0-9'))) {


### PR DESCRIPTION
Adds some extra checks for form's `id` and `name` elements. With Chromium-based browsers, those fields can actually be HTML elements, even referencing the input field itself.

Fixes #1289.