### PR TITLE
Improve eBay login flow

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -79,7 +79,7 @@ kpxcSites.exceptionFound = function(identifier) {
         && [ 'password', 'form-row', 'show-password' ].every(c => identifier.contains(c))) {
         return true;
     } else if (document.location.origin.startsWith('https://signin.ebay.')
-               && identifier.contains('null')) {
+               && (identifier === 'null' || identifier.value === 'null' || identifier === 'pass')) {
         return true;
     } else if (document.location.origin.startsWith('https://www.fidelity.com')
                && identifier.contains('fs-mask-username')) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -300,7 +300,9 @@ kpxcForm.onSubmit = async function(e) {
         return;
     }
 
-    await kpxc.setPasswordFilled(true);
+    if (passwordField) {
+        await kpxc.setPasswordFilled(true);
+    }
 
     const url = trimURL(kpxc.settings.saveDomainOnlyNewCreds ? window.top.location.origin : window.top.location.href);
     await sendMessage('page_set_submitted', [ true, usernameValue, passwordValue, url, kpxc.credentials ]);


### PR DESCRIPTION
eBay has a two-step login flow, and currently there has been some changes in the site. The password field was not detected correctly. It wasn't detected correctly either when re-logging, where username has been already filled, and user is prompted only with the password.