### PR TITLE
Switch from index to uuid

### DIFF
--- a/keepassxc-browser/content/credential-autocomplete.js
+++ b/keepassxc-browser/content/credential-autocomplete.js
@@ -38,7 +38,7 @@ CredentialAutocomplete.prototype.fillPassword = async function(value, index, uui
     const combination = await kpxcFields.getCombination(this.input);
     combination.loginId = index;
 
-    await sendMessage('page_set_login_id', index);
+    await sendMessage('page_set_login_id', uuid);
 
     const manualFill = await sendMessage('page_get_manual_fill');
     await kpxc.fillInCredentials(combination, value, uuid, manualFill === ManualFill.PASSWORD);

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.8",
-    "version_name": "1.7.8",
+    "version": "1.7.8.1",
+    "version_name": "1.7.8.1",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.8",
+  "version": "1.7.8.1",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
Switch from index to uuid when filling credentials/TOTP from previous page. With the new sorting system just an index is not a reliable way to handle data.

Fixes #1302.
Fixes #1303.