### PR TITLE
Allow file:// protocol in site preferences

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -992,7 +992,7 @@
         "description": "Label for adding site manually on Site preferences tab."
     },
     "optionsSitePreferencesManualAddHelp": {
-        "message": "The URL must start with either <code>https://</code>, <code>http://</code>, <code>file://</code>, or <code>ftp://</code> and must be at least 10 characters long.",
+        "message": "The URL must start with either <code>https://</code>, <code>http://</code>, <code>file://</code>, or <code>ftp://</code> and must be at least 5 characters long.",
         "description": "Help text for adding site manually on Site preferences tab."
     },
     "optionsSitePreferencesConfirmation": {

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -992,7 +992,7 @@
         "description": "Label for adding site manually on Site preferences tab."
     },
     "optionsSitePreferencesManualAddHelp": {
-        "message": "The URL must start with either <code>https://</code>, <code>http://</code>, or <code>ftp://</code> and must be at least 10 characters long.",
+        "message": "The URL must start with either <code>https://</code>, <code>http://</code>, <code>file://</code>, or <code>ftp://</code> and must be at least 10 characters long.",
         "description": "Help text for adding site manually on Site preferences tab."
     },
     "optionsSitePreferencesConfirmation": {

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -64,6 +64,7 @@ const matchPatternToRegExp = function(pattern) {
     // special handling of file:// since there is no host
     if (pattern.startsWith('file://')) {
         let regex = '^';
+        pattern = pattern.replace(/\./g, '\\.');
         if (pattern.endsWith('*')) {
             regex += pattern.slice(0, -1);
         }

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -12,7 +12,7 @@ const SORT_BY_USERNAME = 'sortByUsername';
 const SORT_BY_GROUP_AND_TITLE = 'sortByGroupAndTitle';
 const SORT_BY_GROUP_AND_USERNAME = 'sortByGroupAndUsername';
 
-const schemeSegment = '(\\*|http|https|ws|wss|file|ftp)';
+const schemeSegment = '(\\*|http|https|ws|wss|ftp)';
 const hostSegment = '(\\*|(?:\\*\\.)?(?:[^/*]+))?';
 const pathSegment = '(.*)';
 

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -61,6 +61,18 @@ const matchPatternToRegExp = function(pattern) {
         return (/^(?:http|https|file|ftp|app):\/\//);
     }
 
+    // special handling of file:// since there is no host
+    if (pattern.startsWith('file://')) {
+        let regex = '^';
+        if (pattern.endsWith('*')) {
+            regex += pattern.slice(0, -1);
+        }
+        else {
+            regex += `${pattern}$`;
+        }
+        return new RegExp(regex);
+    }
+
     const matchPatternRegExp = new RegExp(
         `^${schemeSegment}://${hostSegment}/${pathSegment}$`
     );

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -541,7 +541,7 @@
                     <div class="form-group">
                         <label for="manualUrl" data-i18n="optionsSitePreferencesManualAddText"></label>
                       <div class="input-group" id="manualUrlGroup">
-                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="10" maxlength="2000" required>
+                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="5" maxlength="2000" required>
                         <div class="input-group-append">
                           <button class="btn btn-sm btn-primary" type="button" id="sitePreferencesManualAdd"><i class="fa fa-plus" aria-hidden="true"></i><span data-i18n="optionsButtonAdd"></span></button>
                         </div>

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -541,7 +541,7 @@
                     <div class="form-group">
                         <label for="manualUrl" data-i18n="optionsSitePreferencesManualAddText"></label>
                       <div class="input-group" id="manualUrlGroup">
-                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="ftp://.*|http://.*|https://.*" minlength="10" required>
+                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="10" required>
                         <div class="input-group-append">
                           <button class="btn btn-sm btn-primary" type="button" id="sitePreferencesManualAdd"><i class="fa fa-plus" aria-hidden="true"></i><span data-i18n="optionsButtonAdd"></span></button>
                         </div>

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -541,7 +541,7 @@
                     <div class="form-group">
                         <label for="manualUrl" data-i18n="optionsSitePreferencesManualAddText"></label>
                       <div class="input-group" id="manualUrlGroup">
-                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="10" required>
+                        <input class="form-control form-control-sm col-lg-10" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="10" maxlength="2000" required>
                         <div class="input-group-append">
                           <button class="btn btn-sm btn-primary" type="button" id="sitePreferencesManualAdd"><i class="fa fa-plus" aria-hidden="true"></i><span data-i18n="optionsButtonAdd"></span></button>
                         </div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -502,38 +502,37 @@ options.initSitePreferences = function() {
 
         const errorMessage = tr('optionsErrorValueExists');
         let value = manualUrl.value;
-        if (value.length > 10 && value.length <= 2000) {
-            // Fills the last / char if needed. This ensures the compatibility with Match Patterns
-            if (slashNeededForUrl(value)) {
-                value += '/';
-            }
 
-            // Check if the URL is already in the list
-            if (options.settings['sitePreferences'].some(s => s.url === value)) {
-                options.createWarning(manualUrl, errorMessage);
-                return;
-            }
-
-            if (options.settings['sitePreferences'] === undefined) {
-                options.settings['sitePreferences'] = [];
-            }
-
-            const newValue = options.settings['sitePreferences'].length + 1;
-            const trClone = $('#tab-site-preferences table tr.clone:first').clone(true);
-            trClone.removeClass('clone d-none');
-
-            const tr = trClone.clone(true);
-            tr.data('url', value.toLowerCase());
-            tr.attr('id', 'tr-scf' + newValue);
-            tr.children('td:first').text(value);
-            tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
-            $('#tab-site-preferences table tbody:first').append(tr);
-            $('#tab-site-preferences table tbody:first tr.empty:first').hide();
-
-            options.settings['sitePreferences'].push({ url: value.toLowerCase(), ignore: IGNORE_NOTHING, usernameOnly: false });
-            options.saveSettings();
-            manualUrl.value = '';
+        // Fills the last / char if needed. This ensures the compatibility with Match Patterns
+        if (slashNeededForUrl(value)) {
+            value += '/';
         }
+
+        // Check if the URL is already in the list
+        if (options.settings['sitePreferences'].some(s => s.url === value)) {
+            options.createWarning(manualUrl, errorMessage);
+            return;
+        }
+
+        if (options.settings['sitePreferences'] === undefined) {
+            options.settings['sitePreferences'] = [];
+        }
+
+        const newValue = options.settings['sitePreferences'].length + 1;
+        const trClone = $('#tab-site-preferences table tr.clone:first').clone(true);
+        trClone.removeClass('clone d-none');
+
+        const tr = trClone.clone(true);
+        tr.data('url', value.toLowerCase());
+        tr.attr('id', 'tr-scf' + newValue);
+        tr.children('td:first').text(value);
+        tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
+        $('#tab-site-preferences table tbody:first').append(tr);
+        $('#tab-site-preferences table tbody:first tr.empty:first').hide();
+
+        options.settings['sitePreferences'].push({ url: value.toLowerCase(), ignore: IGNORE_NOTHING, usernameOnly: false });
+        options.saveSettings();
+        manualUrl.value = '';
     });
 
     $('#dialogDeleteSite .modal-footer:first button.yes:first').click(function(e) {

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -500,7 +500,7 @@ options.initSitePreferences = function() {
             return;
         }
 
-        let value = manualUrl.value;
+        let value = manualUrl.value.toLowerCase();
 
         // Fills the last / char if needed. This ensures the compatibility with Match Patterns
         if (slashNeededForUrl(value)) {
@@ -522,14 +522,14 @@ options.initSitePreferences = function() {
         trClone.removeClass('clone d-none');
 
         const tr = trClone.clone(true);
-        tr.data('url', value.toLowerCase());
+        tr.data('url', value);
         tr.attr('id', 'tr-scf' + newValue);
         tr.children('td:first').text(value);
         tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
         $('#tab-site-preferences table tbody:first').append(tr);
         $('#tab-site-preferences table tbody:first tr.empty:first').hide();
 
-        options.settings['sitePreferences'].push({ url: value.toLowerCase(), ignore: IGNORE_NOTHING, usernameOnly: false });
+        options.settings['sitePreferences'].push({ url: value, ignore: IGNORE_NOTHING, usernameOnly: false });
         options.saveSettings();
         manualUrl.value = '';
     });

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -338,24 +338,24 @@ options.initConnectedDatabases = function() {
 
     $('#tab-connected-databases tr.clone:first .dropdown-menu:first').width('230px');
 
-    const trClone = $('#tab-connected-databases table tr.clone:first').clone(true);
-    trClone.removeClass('clone d-none');
+    const rowClone = $('#tab-connected-databases table tr.clone:first').clone(true);
+    rowClone.removeClass('clone d-none');
 
     const addHashToTable = function(hash) {
         $('#tab-connected-databases table tbody:first tr.empty:first').hide();
-        const tr = trClone.clone(true);
-        tr.data('hash', hash);
-        tr.attr('id', 'tr-cd-' + hash);
+        const row = rowClone.clone(true);
+        row.data('hash', hash);
+        row.attr('id', 'tr-cd-' + hash);
 
-        $('a.dropdown-toggle:first img:first', tr).attr('src', '/icons/toolbar/icon_normal.png');
+        $('a.dropdown-toggle:first img:first', row).attr('src', '/icons/toolbar/icon_normal.png');
 
-        tr.children('td:first').text(options.keyRing[hash].id);
-        tr.children('td:eq(1)').text(options.getPartiallyHiddenKey(options.keyRing[hash].key));
+        row.children('td:first').text(options.keyRing[hash].id);
+        row.children('td:eq(1)').text(options.getPartiallyHiddenKey(options.keyRing[hash].key));
         const lastUsed = (options.keyRing[hash].lastUsed) ? new Date(options.keyRing[hash].lastUsed).toLocaleString() : 'unknown';
-        tr.children('td:eq(2)').text(lastUsed);
+        row.children('td:eq(2)').text(lastUsed);
         const date = (options.keyRing[hash].created) ? new Date(options.keyRing[hash].created).toLocaleDateString() : 'unknown';
-        tr.children('td:eq(3)').text(date);
-        $('#tab-connected-databases table tbody:first').append(tr);
+        row.children('td:eq(3)').text(date);
+        $('#tab-connected-databases table tbody:first').append(row);
     };
 
     let hashList = options.keyRing;
@@ -421,17 +421,17 @@ options.initCustomCredentialFields = function() {
         }
     });
 
-    const trClone = $('#tab-custom-fields table tr.clone:first').clone(true);
-    trClone.removeClass('clone d-none');
+    const rowClone = $('#tab-custom-fields table tr.clone:first').clone(true);
+    rowClone.removeClass('clone d-none');
     let counter = 1;
     for (const url in options.settings['defined-custom-fields']) {
-        const tr = trClone.clone(true);
-        tr.data('url', url);
-        tr.attr('id', 'tr-scf' + counter);
+        const row = rowClone.clone(true);
+        row.data('url', url);
+        row.attr('id', 'tr-scf' + counter);
         ++counter;
 
-        tr.children('td:first').text(url);
-        $('#tab-custom-fields table tbody:first').append(tr);
+        row.children('td:first').text(url);
+        $('#tab-custom-fields table tbody:first').append(row);
     }
 
     if ($('#tab-custom-fields table tbody:first tr').length > 2) {
@@ -518,15 +518,15 @@ options.initSitePreferences = function() {
         }
 
         const newValue = options.settings['sitePreferences'].length + 1;
-        const trClone = $('#tab-site-preferences table tr.clone:first').clone(true);
-        trClone.removeClass('clone d-none');
+        const rowClone = $('#tab-site-preferences table tr.clone:first').clone(true);
+        rowClone.removeClass('clone d-none');
 
-        const tr = trClone.clone(true);
-        tr.data('url', value);
-        tr.attr('id', 'tr-scf' + newValue);
-        tr.children('td:first').text(value);
-        tr.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
-        $('#tab-site-preferences table tbody:first').append(tr);
+        const row = rowClone.clone(true);
+        row.data('url', value);
+        row.attr('id', 'tr-scf' + newValue);
+        row.children('td:first').text(value);
+        row.children('td:nth-child(2)').children('select').val(IGNORE_NOTHING);
+        $('#tab-site-preferences table tbody:first').append(row);
         $('#tab-site-preferences table tbody:first tr.empty:first').hide();
 
         options.settings['sitePreferences'].push({ url: value, ignore: IGNORE_NOTHING, usernameOnly: false });
@@ -555,20 +555,20 @@ options.initSitePreferences = function() {
         }
     });
 
-    const trClone = $('#tab-site-preferences table tr.clone:first').clone(true);
-    trClone.removeClass('clone d-none');
+    const rowClone = $('#tab-site-preferences table tr.clone:first').clone(true);
+    rowClone.removeClass('clone d-none');
     let counter = 1;
     if (options.settings['sitePreferences']) {
         for (const site of options.settings['sitePreferences']) {
-            const tr = trClone.clone(true);
-            tr.data('url', site.url);
-            tr.attr('id', 'tr-scf' + counter);
+            const row = rowClone.clone(true);
+            row.data('url', site.url);
+            row.attr('id', 'tr-scf' + counter);
             ++counter;
 
-            tr.children('td:first').text(site.url);
-            tr.children('td:nth-child(2)').children('select').val(site.ignore);
-            tr.children('td:nth-child(3)').children('input[type=checkbox]').attr('checked', site.usernameOnly);
-            $('#tab-site-preferences table tbody:first').append(tr);
+            row.children('td:first').text(site.url);
+            row.children('td:nth-child(2)').children('select').val(site.ignore);
+            row.children('td:nth-child(3)').children('input[type=checkbox]').attr('checked', site.usernameOnly);
+            $('#tab-site-preferences table tbody:first').append(row);
         }
     }
 

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -500,7 +500,6 @@ options.initSitePreferences = function() {
             return;
         }
 
-        const errorMessage = tr('optionsErrorValueExists');
         let value = manualUrl.value;
 
         // Fills the last / char if needed. This ensures the compatibility with Match Patterns
@@ -510,7 +509,7 @@ options.initSitePreferences = function() {
 
         // Check if the URL is already in the list
         if (options.settings['sitePreferences'].some(s => s.url === value)) {
-            options.createWarning(manualUrl, errorMessage);
+            options.createWarning(manualUrl, tr('optionsErrorValueExists'));
             return;
         }
 


### PR DESCRIPTION
Hello.

I wanted to block the extension from running on all `file://` URLs, but found that I was unable to do so. So here's a PR to make some changes to allow this.

I was actually able to just edit the input field with the browser's developer tools to add `file://.*` to the `pattern` attribute. But since `file://*` is 8 characters, I wasn't able to add it. I was able to change the `minlength` attribute, but there's also a JavaScript check that is harder to bypass (that is why I am removing the JavaScript check in this PR, since the `manualUrl.validity.valid` check already covers it). The JavaScript check actually requires 11 characters to pass (`value.length > 10`).

I was able to add a slightly longer URL though, `file:///users/*`, which should cover most of the local files I am going to load anyway. But this made me think.. I can imagine that it may be nice to be able to ignore `http://*`, so I decided to reduce `minlength` to `5` to allow for this and perhaps other things that I haven't thought of. Maybe we should just remove `minlength` since the pattern will already ensure that the field is not empty?

Please let me know what you think! Thanks!

P.S. It may be time to remove `ftp://` soon. https://blog.mozilla.org/addons/2021/04/15/built-in-ftp-implementation-to-be-removed-in-firefox-90/

Fixes #1337.