### PR TITLE
TypeError: identifier.contains is not a function

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1435,7 +1435,7 @@ kpxc.passwordFilled = async function() {
  * @returns {boolean}           True if password has been already filled
  */
 kpxc.passwordFilledWithExceptions = async function(currentForm) {
-    if (currentForm.password && kpxcSites.exceptionFound(currentForm.password.id)) {
+    if (currentForm.password && kpxcSites.exceptionFound(currentForm.password.classList)) {
         return false;
     }
 


### PR DESCRIPTION
This PR solves a problem I experienced when trying to fill in my login details on the https://appstoreconnect.apple.com/login website.

It is a crash in the `kpxcSites.exceptionFound` method that causes autocomplete to fail. Specifically, `TypeError: identifier.contains is not a function`. In most calls, the type of `identifier` is DOMTokenList. An exception occurs when `string` is passed.

Since I don't have the necessary insight into this add-on, this is a simple fix that resolves only the wrong parameter type. 
With this fix autocomplete works fine.