### PR TITLE
Call password generator directly if 2.7.0 or newer

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -325,7 +325,7 @@ keepass.generatePassword = async function(tab) {
             return [];
         }
 
-        let passwords = [];
+        let password;
         const kpAction = kpActions.GENERATE_PASSWORD;
         const [ nonce, incrementedNonce ] = keepass.getNonces();
 
@@ -348,22 +348,18 @@ keepass.generatePassword = async function(tab) {
             keepass.setcurrentKeePassXCVersion(parsed.version);
 
             if (keepass.verifyResponse(parsed, incrementedNonce)) {
-                if (parsed.entries) {
-                    passwords = parsed.entries;
-                    keepass.updateLastUsed(keepass.databaseHash);
-                } else {
-                    console.log('No entries returned. Is KeePassXC up-to-date?');
-                }
+                password = parsed.entries ?? parsed.password;
+                keepass.updateLastUsed(keepass.databaseHash);
             } else {
                 console.log('GeneratePassword rejected');
             }
 
-            return passwords;
+            return password;
         } else if (response.error && response.errorCode) {
             keepass.handleError(tab, response.errorCode, response.error);
         }
 
-        return passwords;
+        return password;
     } catch (err) {
         console.log('generatePassword failed: ', err);
         return [];

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -187,7 +187,10 @@ page.switchTab = async function(tab) {
     browser.contextMenus.update('fill_attribute', { visible: false });
 
     // Clears all logins from other tabs after a timeout
-    clearTimeout(page.clearCredentialsTimeout);
+    if (page.clearCredentialsTimeout) {
+        clearTimeout(page.clearCredentialsTimeout);
+    }
+
     page.clearCredentialsTimeout = setTimeout(() => {
         for (const pageTabId of Object.keys(page.tabs)) {
             if (tab.id !== Number(pageTabId)) {

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -70,12 +70,18 @@ PasswordIcon.prototype.createIcon = function(field) {
         icon.style.filter = 'saturate(0%)';
     }
 
-    icon.addEventListener('click', function(e) {
+    icon.addEventListener('click', async function(e) {
         if (!e.isTrusted) {
             return;
         }
 
         e.preventDefault();
+
+        if (await useKeePassXCPasswordGenerator()) {
+            kpxcPasswordDialog.generate(null, field);
+            return;
+        }
+
         kpxcPasswordDialog.showDialog(field, icon);
     });
 
@@ -206,7 +212,12 @@ kpxcPasswordDialog.openDialog = function() {
     }
 };
 
-kpxcPasswordDialog.trigger = function() {
+kpxcPasswordDialog.trigger = async function() {
+    if (await useKeePassXCPasswordGenerator()) {
+        kpxcPasswordDialog.generate(null, document.activeElement);
+        return;
+    }
+
     kpxcPasswordDialog.showDialog(document.activeElement, kpxcPasswordDialog.icon);
 };
 
@@ -243,13 +254,18 @@ kpxcPasswordDialog.showDialog = function(field, icon) {
     }
 };
 
-kpxcPasswordDialog.generate = async function(e) {
+kpxcPasswordDialog.generate = async function(e, field) {
     // This function can be also called from non-events
     if (e) {
         if (!e.isTrusted) {
             return;
         }
         e.preventDefault();
+    }
+
+    if (await useKeePassXCPasswordGenerator()) {
+        kpxcPasswordDialog.newFill(field, await sendMessage('generate_password'));
+        return;
     }
 
     callbackGeneratedPassword(await sendMessage('generate_password'));
@@ -291,6 +307,27 @@ kpxcPasswordDialog.fill = function(e) {
     }
 };
 
+// New way to fill the password
+kpxcPasswordDialog.newFill = function(elem, password) {
+    if (!elem || !password) {
+        return;
+    }
+
+    if (elem.getAttribute('maxlength')) {
+        if (password.value.length > elem.getAttribute('maxlength')) {
+            const message = tr('passwordGeneratorErrorTooLong') + '\r\n'
+                            + tr('passwordGeneratorErrorTooLongCut') + '\r\n' + tr('passwordGeneratorErrorTooLongRemember');
+            message.style.whiteSpace = 'pre';
+            sendMessage('show_notification', [ message ]);
+            return;
+        }
+    }
+
+    elem.value = password;
+    elem.dispatchEvent(new Event('input', { bubbles: true }));
+    elem.dispatchEvent(new Event('change', { bubbles: true }));
+};
+
 kpxcPasswordDialog.copyPasswordToClipboard = function() {
     kpxcPasswordDialog.shadowSelector('.kpxc-pwgen-input').select();
     try {
@@ -301,8 +338,8 @@ kpxcPasswordDialog.copyPasswordToClipboard = function() {
     return false;
 };
 
-const callbackGeneratedPassword = function(entries) {
-    if (entries && entries.length >= 1) {
+const callbackGeneratedPassword = function(passwords) {
+    if (passwords && passwords.length >= 1) {
         const errorMessage = kpxcPasswordDialog.shadowSelector('#kpxc-pwgen-error');
         if (errorMessage) {
             enableButtons();
@@ -312,7 +349,7 @@ const callbackGeneratedPassword = function(entries) {
             errorMessage.remove();
         }
 
-        kpxcPasswordDialog.shadowSelector('.kpxc-pwgen-input').value = entries[0].password;
+        kpxcPasswordDialog.shadowSelector('.kpxc-pwgen-input').value = passwords[0].password;
     } else {
         if (kpxcPasswordDialog.shadowSelectorAll('div#kpxc-pwgen-error').length === 0) {
             const input = kpxcPasswordDialog.shadowSelector('.kpxc-pwgen-input');
@@ -338,4 +375,17 @@ const disableButtons = function() {
     kpxcPasswordDialog.shadowSelector('#kpxc-pwgen-btn-generate').textContent = tr('passwordGeneratorTryAgain');
     kpxcPasswordDialog.shadowSelector('#kpxc-pwgen-btn-copy').style.display = 'none';
     kpxcPasswordDialog.shadowSelector('#kpxc-pwgen-btn-fill').style.display = 'none';
+};
+
+const useKeePassXCPasswordGenerator = async function() {
+    const response = await browser.runtime.sendMessage({
+        action: 'get_keepassxc_versions'
+    });
+
+    const result = await browser.runtime.sendMessage({
+        action: 'compare_version',
+        args: [ '2.7.0', response.current ]
+    });
+
+    return result || response.current === '2.7.0-snapshot';
 };


### PR DESCRIPTION
Supports launching KeePassXC's password generator popup directly from the extension. The extension's own password generator dialog still exists for backwards compatibility, but it will be removed later in some future release.
This feature will be supported only with KeePassXC 2.7.0 and newer.

Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/6529