### PR TITLE
add namespace to `slidein` animation

### DIFF
--- a/keepassxc-browser/css/banner.css
+++ b/keepassxc-browser/css/banner.css
@@ -1,6 +1,6 @@
 div.kpxc-banner {
     animation-duration: 0.2s;
-    animation-name: slidein;
+    animation-name: kpxc-slidein;
     background-color: var(--kpxc-background-color);
     border-bottom: 1px solid #38383d !important;
     box-shadow: 0 4px 6px 0 hsla(0, 0%, 0%, 0.2) !important;
@@ -22,7 +22,7 @@ div.kpxc-banner {
     justify-content: space-between !important;
 }
 
-@keyframes slidein {
+@keyframes kpxc-slidein {
     from {
         max-height: 0em;
     }


### PR DESCRIPTION
I ran into a conflict on a site which also used a CSS animation named `slidein`, so I'd suggest this change or something like it to namespace the animation.  The `slidein` animation from this extension caused elements on the site to not appear.