### PR TITLE
Fix credential retrieval on page reload

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -62,7 +62,7 @@ browser.tabs.onActivated.addListener(async function(activeInfo) {
             }
         }
     } catch (err) {
-        console.log('Error: ' + err);
+        console.log('Error: ' + err.message);
     }
 });
 
@@ -96,6 +96,11 @@ browser.webNavigation.onCommitted.addListener((details) => {
         || details.transitionType === 'form_submit') {
         page.redirectCount += 1;
         return;
+    }
+
+    // Clear credentials on reload so a new retrieval can be made
+    if (details.transitionType === 'reload') {
+        page.clearLogins(details.tabId);
     }
 
     page.redirectCount = 0;

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.8.1",
-    "version_name": "1.7.8.1",
+    "version": "1.7.9",
+    "version_name": "1.7.9",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.8.1",
+  "version": "1.7.9",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
https://github.com/keepassxreboot/keepassxc-browser/pull/1283 probably broke the page reload and new credentials are not retrieved until a tab is closed and recreated.
This fix ensures credentials are cleared if user wishes to reload the page, causing a new access confirmation from KeePassXC.