### PR TITLE
Fix form detection from style attribute

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1976,7 +1976,7 @@ kpxcObserverHelper.initObserver = async function() {
                 } else if (mut.removedNodes.length > 0) {
                     kpxcObserverHelper.handleObserverRemove(mut.removedNodes[0]);
                 }
-            } else if (mut.type === 'attributes' && mut.attributeName === 'class') {
+            } else if (mut.type === 'attributes' && (mut.attributeName === 'class' || mut.attributeName === 'style')) {
                 // Only accept targets with forms
                 const forms = mut.target.nodeName === 'FORM' ? mut.target : mut.target.getElementsByTagName('form');
                 if (forms.length === 0 && !kpxcSites.exceptionFound(mut.target.classList)) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -125,10 +125,12 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         left += size + 10;
     }
 
-    icon.style.top = Pixels(top + document.scrollingElement.scrollTop + offset + 1);
+    const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;
+    const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : 0;
+    icon.style.top = Pixels(top + scrollTop + offset + 1);
     icon.style.left = rtl
-                    ? Pixels((left + document.scrollingElement.scrollLeft) + offset)
-                    : Pixels(left + document.scrollingElement.scrollLeft + field.offsetWidth - size - offset);
+                    ? Pixels((left + scrollLeft) + offset)
+                    : Pixels(left + scrollLeft + field.offsetWidth - size - offset);
 };
 
 kpxcUI.deleteHiddenIcons = function(iconList, attr) {


### PR DESCRIPTION
MutationObserver's form detection was not handling an `attribute` with `attributeName=style`.
Also found a exception where `document.scrollingElement` might not be set.

Fixes #1347.