### PR TITLE
Added more dispatchEvents to fill()

### DIFF
--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -283,11 +283,17 @@ kpxcPasswordDialog.fill = function(e) {
     }
 
     kpxcPasswordDialog.input.value = password.value;
+    kpxcPasswordDialog.input.dispatchEvent(new Event('keydown', { bubbles: true }));
+    kpxcPasswordDialog.input.dispatchEvent(new Event('keyup', { bubbles: true }));
     kpxcPasswordDialog.input.dispatchEvent(new Event('input', { bubbles: true }));
     kpxcPasswordDialog.input.dispatchEvent(new Event('change', { bubbles: true }));
 
     if (kpxcPasswordDialog.nextField) {
         kpxcPasswordDialog.nextField.value = password.value;
+        kpxcPasswordDialog.nextField.dispatchEvent(new Event('keydown', { bubbles: true }));
+        kpxcPasswordDialog.nextField.dispatchEvent(new Event('keyup', { bubbles: true }));
+        kpxcPasswordDialog.nextField.dispatchEvent(new Event('input', { bubbles: true }));
+        kpxcPasswordDialog.nextField.dispatchEvent(new Event('change', { bubbles: true }));
     }
 };
 


### PR DESCRIPTION
Some websites check the strength of the password (and some also check if password and password-repeat are the same) with JavaScript (and block the form until the password is strong enough). Most of them listen to key-events to evaluate.

To make sure these websites accept the password filled out by keepass, I added more dispatchEvents to be triggered.