### PR TITLE
Fix shadowSelectorAll check

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1834,7 +1834,7 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
     }
 
     // Append any input fields in Shadow DOM
-    if (target.shadowRoot) {
+    if (target.shadowRoot && typeof target.shadowSelectorAll === 'function') {
         target.shadowSelectorAll('input').forEach(e => {
             if (e.type !== 'hidden' && !e.disabled && !kpxcObserverHelper.alreadyIdentified(e)) {
                 inputFields.push(e);


### PR DESCRIPTION
Firefox has sometimes problems setting `shadowRoot` to a proper object. Add an extra check that our `shadowSelectorAll()` is actually a function we are trying to use.

Fixes #1352.