### PR TITLE
Adds ability to resolve totp field by parent selector

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -18,6 +18,10 @@ const acceptedOTPFields = [
     'twofactor'
 ];
 
+const acceptedParents = [
+    '.mfa-verify',
+];
+
 var kpxcTOTPIcons = {};
 kpxcTOTPIcons.icons = [];
 
@@ -42,7 +46,7 @@ kpxcTOTPIcons.isAcceptedTOTPField = function(field) {
 
     // Checks if the field id, name or placeholder includes some of the acceptedOTPFields but not any from ignoredTypes
     if (autocomplete === 'one-time-code'
-        || (acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f) || placeholder && placeholder.includes(f))))
+        || (acceptedOTPFields.some(f => (id && id.includes(f)) || (name && name.includes(f) || placeholder && placeholder.includes(f))) || acceptedParents.some(s => field.closest(s)))
             && !ignoredTypes.some(f => (id && id.includes(f)) || (name && name.includes(f) || placeholder && placeholder.includes(f)))) {
         return true;
     }


### PR DESCRIPTION
In some cases I would have to open KP to get the TOTP because it wasn't detecting fields in SSO provider. This extends the TOTP search to check if the input has any preceding element with the specified selectors.

<img width="393" alt="Screen Shot 2021-07-22 at 9 39 52 AM" src="https://user-images.githubusercontent.com/3640743/126649062-95e727ea-bd13-4558-8322-150f3f67c55c.png">
