### PR TITLE
Prevent CSS leaking

### DIFF
--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -82,11 +82,9 @@ PasswordIcon.prototype.createIcon = function(field) {
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
 
-    const styleSheet = document.createElement('link');
-    styleSheet.setAttribute('rel', 'stylesheet');
-    styleSheet.setAttribute('href', browser.runtime.getURL('css/pwgen.css'));
-
+    const styleSheet = createStylesheet('css/pwgen.css');
     const wrapper = document.createElement('div');
+
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(styleSheet);
     this.shadowRoot.append(icon);

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -130,11 +130,9 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
     kpxcUI.setIconPosition(icon, field, this.rtl, segmented);
     this.icon = icon;
 
-    const styleSheet = document.createElement('link');
-    styleSheet.setAttribute('rel', 'stylesheet');
-    styleSheet.setAttribute('href', browser.runtime.getURL('css/totp.css'));
-
+    const styleSheet = createStylesheet('css/totp.css');
     const wrapper = document.createElement('div');
+
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(styleSheet);
     this.shadowRoot.append(icon);

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -98,11 +98,9 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
 
-    const styleSheet = document.createElement('link');
-    styleSheet.setAttribute('rel', 'stylesheet');
-    styleSheet.setAttribute('href', browser.runtime.getURL('css/username.css'));
-
+    const styleSheet = createStylesheet('css/username.css');
     const wrapper = document.createElement('div');
+
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(styleSheet);
     this.shadowRoot.append(icon);

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.9.1",
-    "version_name": "1.7.9.1",
+    "version": "1.7.10",
+    "version_name": "1.7.10",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {
@@ -63,17 +63,6 @@
                 "content/totp-autocomplete.js",
                 "content/totp-field.js",
                 "content/username-field.js"
-            ],
-            "css": [
-                "css/autocomplete.css",
-                "css/banner.css",
-                "css/button.css",
-                "css/colors.css",
-                "css/define.css",
-                "css/notification.css",
-                "css/pwgen.css",
-                "css/totp.css",
-                "css/username.css"
             ],
             "run_at": "document_idle",
             "all_frames": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.4",
+  "version": "1.7.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "KeePassXC-Browser",
-      "version": "1.7.4",
+      "version": "1.7.10",
       "license": "GPL-3.0",
       "dependencies": {
         "file-url": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.9.1",
+  "version": "1.7.10",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
CSS files shouldn't be injected to every page via `manifest.json`. Injecting them to Shadow DOM works without it.

Fixes #1340.