### PR TITLE
Fix filling dynamic popups

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -92,6 +92,9 @@ class Autocomplete {
             item.addEventListener('mouseover', ev => this.mouseOver(ev, div, item));
             item.addEventListener('mouseout', ev => this.mouseOut(ev, item));
 
+            item.addEventListener('mousedown', ev => ev.stopPropagation());
+            item.addEventListener('mouseup', ev => ev.stopPropagation());
+
             div.appendChild(item);
         }
 

--- a/keepassxc-browser/content/credential-autocomplete.js
+++ b/keepassxc-browser/content/credential-autocomplete.js
@@ -6,6 +6,8 @@ CredentialAutocomplete.prototype.click = async function(e, input) {
         return;
     }
 
+    e.stopPropagation();
+
     if (input.value !== '') {
         input.select();
     }
@@ -20,6 +22,8 @@ CredentialAutocomplete.prototype.itemClick = async function(e, item, input, uuid
     if (!e.isTrusted) {
         return;
     }
+
+    e.stopPropagation();
 
     const index = Array.prototype.indexOf.call(e.currentTarget.parentElement.childNodes, e.currentTarget);
     const usernameValue = item.getElementsByTagName('input')[0].value;

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -75,9 +75,12 @@ PasswordIcon.prototype.createIcon = function(field) {
             return;
         }
 
-        e.preventDefault();
+        e.stopPropagation();
         kpxcPasswordDialog.showDialog(field, icon);
     });
+
+    icon.addEventListener('mousedown', ev => ev.stopPropagation());
+    icon.addEventListener('mouseup', ev => ev.stopPropagation());
 
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -122,10 +122,13 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
             return;
         }
 
-        e.preventDefault();
+        e.stopPropagation();
         await kpxc.receiveCredentialsIfNecessary();
         kpxc.fillFromTOTP(field);
     });
+
+    icon.addEventListener('mousedown', ev => ev.stopPropagation());
+    icon.addEventListener('mouseup', ev => ev.stopPropagation());
 
     kpxcUI.setIconPosition(icon, field, this.rtl, segmented);
     this.icon = icon;

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -257,6 +257,8 @@ document.addEventListener('mousemove', function(e) {
         return;
     }
 
+    e.stopPropagation();
+
     if (kpxcPasswordDialog.selected === kpxcPasswordDialog.titleBar) {
         const xPos = e.clientX - kpxcPasswordDialog.diffX;
         const yPos = e.clientY - kpxcPasswordDialog.diffY;
@@ -283,6 +285,7 @@ document.addEventListener('mousedown', function(e) {
         return;
     }
 
+    e.stopPropagation();
     kpxcUI.mouseDown = true;
 });
 
@@ -291,6 +294,7 @@ document.addEventListener('mouseup', function(e) {
         return;
     }
 
+    e.stopPropagation();
     kpxcPasswordDialog.selected = null;
     kpxcDefine.selected = null;
     kpxcUI.mouseDown = false;

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -91,9 +91,12 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
             return;
         }
 
-        e.preventDefault();
+        e.stopPropagation();
         iconClicked(field, icon);
     });
+
+    icon.addEventListener('mousedown', ev => ev.stopPropagation());
+    icon.addEventListener('mouseup', ev => ev.stopPropagation());
 
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;


### PR DESCRIPTION
Use `stopPropagation()` to prevent event bubbling to the main DOM. These events should be only handled inside the extension.

Fixes filling for sites like https://qsuper.qld.gov.au/ and https://www.veikkaus.fi with dynamic popups/panels which normally close when they see a mouse click outside of the popup/panel.

Related (already closed) issue #1250.