### PR TITLE
Fix segmented TOTP with text type

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -419,6 +419,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements);
     } else if (inputs.length === 6 && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
+                || (i.type === 'text' && i.maxLength == 1)
                 || i.type === 'tel')) {
         // No form is found, but input fields are possibly segmented TOTP fields
         addTotpFieldsToCombination(inputs);


### PR DESCRIPTION
Allow segmented TOTP fields if `type` is `text` and input fields has `maxLength` set to 1.

Fixes TOTP with for example https://app.hackthebox.eu/login.