### PR TITLE
Add support for reload extension shortcut

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -146,7 +146,8 @@ browser.commands.onCommand.addListener(async (command) => {
     if (contextMenuItems.some(e => e.action === command)
         || command === 'redetect_fields'
         || command === 'choose_credential_fields'
-        || command === 'retrive_credentials_forced') {
+        || command === 'retrive_credentials_forced'
+        || command === 'reload_extension') {
         const tabs = await browser.tabs.query({ active: true, currentWindow: true });
         if (tabs.length) {
             browser.tabs.sendMessage(tabs[0].id, { action: command });

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -2108,6 +2108,8 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             kpxc.inputs = [];
             kpxc.combinations = [];
             kpxc.initCredentialFields();
+        } else if (req.action === 'reload_extension') {
+            sendMessage('reconnect');
         } else if (req.action === 'save_credentials') {
             kpxc.rememberCredentialsFromContextMenu();
         } else if (req.action === 'retrive_credentials_forced') {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -111,6 +111,9 @@
         },
         "request_autotype": {
             "description": "__MSG_contextMenuRequestGlobalAutoType__"
+        },
+        "reload_extension": {
+            "description": "__MSG_popupReloadButton__"
         }
     },
     "web_accessible_resources": [


### PR DESCRIPTION
A simple addition for supportin a keyboard shortcut for reloading the extension. Because of the limit of predefined keyboard shortcuts is still four, user must set this manually.

Fixes #1418.