### PR TITLE
Do not autofill the password when Tab is pressed if the list is closed

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -200,6 +200,11 @@ class Autocomplete {
                 this.closeList();
             }
         } else if (e.key === 'Tab') {
+            // Return if the list is not open
+            if (items.length === 0) {
+                return;
+            }
+
             // Return if value is not in the list
             if (inputField.value !== '' && !this.elements.some(c => c.value === inputField.value)) {
                 this.closeList();


### PR DESCRIPTION
Hello.

This fixes an annoying issue which I have encountered a couple of times. If I want to use the KeePassXC Auto-Type feature and fill with the usual `{USERNAME}{TAB}{PASSWORD}{ENTER}` sequence, then if the browser extension happens to be connected to the database, it will mess it up when the Tab key is pressed, which results in the password being repeated twice and my login failing.

This simple fix resolved the problem for me.

Thanks for considering!