### PR TITLE
Add scrolling to autocomplete list

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -1,5 +1,7 @@
 .kpxcAutocomplete-items {
     position: absolute !important;
+    max-height: 250px;
+    overflow-y: auto;
 }
 
 .kpxcAutocomplete-items div {


### PR DESCRIPTION
This makes long lists easier to use.

Look, I have way too many Google accounts. Opening the autocomplete list adds a scrollbar to the window which makes the experience less than stellar. I think it is better to scroll inside the list itself.

Before:

<img width="520" alt="Screen Shot 2021-11-07 at 13 03 44" src="https://user-images.githubusercontent.com/1991151/140661935-2595141e-47fd-4c99-b23f-9a8779b6b435.png">

With this change:

<img width="520" alt="Screen Shot 2021-11-07 at 13 03 24" src="https://user-images.githubusercontent.com/1991151/140661941-3da9f4b7-ce68-4574-995f-2b56c7ff70cd.png">

250px was not scientifically picked, so let me know if you prefer another value.