### PR TITLE
Settings page: load the theme earlier to prevent a white flash

### DIFF
--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -146,6 +146,7 @@
         "http://*/*",
         "https://api.github.com/"
     ],
+    "content_security_policy": "script-src 'self' 'sha256-UD5WN2QEhRDEZ6vkLdHKFlkHwzbemzW2ppJiOLooI8o='; object-src 'none'",
     "applications": {
        "gecko": {
            "id": "keepassxc-browser@keepassxc.org",

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -20,6 +20,13 @@
     <script src="../common/translate.js" defer></script>
   </head>
   <body class="pt-3 pb-5">
+    <script>
+    // We eagerly load the theme here to avoid a white flash
+    let colorTheme = localStorage.getItem('colorTheme');
+    if (colorTheme) {
+      document.body.setAttribute('data-color-theme', colorTheme);
+    }
+    </script>
     <div class="container-fluid">
       <div class="row">
         <nav class="col-md-3 col-lg-2 sidebar">

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -75,6 +75,8 @@ options.initGeneralSettings = function() {
 
     $('#tab-general-settings select#colorTheme').change(async function() {
         options.settings['colorTheme'] = $(this).val();
+        // The theme is also stored in localStorage to prevent a white flash when the settings are first opened
+        localStorage.setItem('colorTheme', options.settings['colorTheme']);
         await options.saveSettings();
         location.reload();
     });
@@ -607,6 +609,11 @@ options.initTheme = function() {
         document.body.removeAttribute('data-color-theme');
     } else {
         document.body.setAttribute('data-color-theme', options.settings['colorTheme']);
+    }
+    // Sync localStorage setting
+    let localStorageTheme = localStorage.getItem('colorTheme');
+    if (localStorageTheme !== options.settings['colorTheme']) {
+        localStorage.setItem('colorTheme', options.settings['colorTheme']);
     }
 };
 


### PR DESCRIPTION
Load the colorTheme earlier to prevent a white flash when the Settings page is opened. This requires storing the theme somewhere where we can load it immediately before the first render (I picked localStorage for simplicity).

My setup is: OS in light mode, KeePassXC-Browser in dark mode. I have only tested this in Chrome.

With this setup, there's a white flash when the settings page is opened up (test it by refreshing the settings page, which makes it very evident). The browser renders the page before the JavaScript has started running. A workaround is to have an inline script that blocks rendering and can apply the style before the first render. I had to add a `content_security_policy` for the inline script to run.

If someone can think of a more elegant way of doing this then please let me know and I can update this branch.

If this hack is a bit too hacky then feel free to close the PR. Since I had a working fix, although not the prettiest, I figured it doesn't hurt to open the PR to start a discussion about this issue.