### PR TITLE
Sort the page uuid first in the list

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -961,19 +961,43 @@
     },
     "optionsSortByTitle": {
         "message": "Title",
-        "desription": "Sort matching credentials by title option selection."
+        "description": "Sort matching credentials by title option selection."
     },
     "optionsSortByUsername": {
         "message": "Username",
-        "desription": "Sort matching credentials by username option selection."
+        "description": "Sort matching credentials by username option selection."
     },
     "optionsSortByGroupAndTitle": {
         "message": "Group and title",
-        "desription": "Sort matching credentials by group and title option selection."
+        "description": "Sort matching credentials by group and title option selection."
     },
     "optionsSortByGroupAndUsername": {
         "message": "Group and username",
-        "desription": "Sort matching credentials by group and username option selection."
+        "description": "Sort matching credentials by group and username option selection."
+    },
+    "optionsFillSortPriority": {
+        "message": "Sort credentials after fill by",
+        "description": ""
+    },
+    "optionsFillSortPriorityHelpText": {
+        "message": "When Relevant credential first option is selected, the credential for previously filled login is set as first in Autocomplete Menu's listing.",
+        "description": "Help text for Sort credentials after fill."
+    },
+    "optionsFillSortPriorityTotp": {
+        "message": "Sort credentials after fill for TOTP by",
+        "description": ""
+    },
+    "optionsFillSortPriorityTotpHelpText": {
+        "message": "When Relevant credential first option is selected, the TOTP for previously filled login is set as first in Autocomplete Menu's listing.",
+        "description": "Help text for Sort credentials after fill for TOTP."
+    },
+    "optionsFillSortDefault": {
+        "message": "Default",
+        "description": "Default option for Sort after fill."
+    },
+    "optionsFillSortRelevant": {
+        "message": "Relevant credential first",
+        "description": "Relevatn credential first option for Sort after fill."
     },
     "optionsCustomFieldsNotFound": {
         "message": "No saved custom login fields found.",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -991,11 +991,11 @@
         "message": "When Relevant credential first option is selected, the TOTP for previously filled login is set as first in Autocomplete Menu's listing.",
         "description": "Help text for Sort credentials after fill for TOTP."
     },
-    "optionsFillSortDefault": {
-        "message": "Default",
-        "description": "Default option for Sort after fill."
+    "optionsFillSortByMatchingCredentials": {
+        "message": "Matching credentials setting",
+        "description": "Default option for Sort after fill. Respects the Matching Credentials sorting setting."
     },
-    "optionsFillSortRelevant": {
+    "optionsFillSortByRelevantEntry": {
         "message": "Relevant credential first",
         "description": "Relevatn credential first option for Sort after fill."
     },

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const defaultSettings = {
-    afterFillSorting: SORT_BY_DEFAULT,
-    afterFillSortingTotp: SORT_BY_RELEVANT,
+    afterFillSorting: SORT_BY_MATCHING_CREDENTIALS_SETTING,
+    afterFillSortingTotp: SORT_BY_RELEVANT_ENTRY,
     autoCompleteUsernames: true,
     showGroupNameInAutocomplete: true,
     autoFillAndSend: false,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -2,7 +2,7 @@
 
 const defaultSettings = {
     afterFillSorting: SORT_BY_DEFAULT,
-    afterFillSortingTotp: SORT_BY_DEFAULT,
+    afterFillSortingTotp: SORT_BY_RELEVANT,
     autoCompleteUsernames: true,
     showGroupNameInAutocomplete: true,
     autoFillAndSend: false,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const defaultSettings = {
+    afterFillSorting: SORT_BY_DEFAULT,
+    afterFillSortingTotp: SORT_BY_DEFAULT,
     autoCompleteUsernames: true,
     showGroupNameInAutocomplete: true,
     autoFillAndSend: false,
@@ -52,6 +54,14 @@ page.initSettings = async function() {
         const item = await browser.storage.local.get({ 'settings': {} });
         page.settings = item.settings;
         page.settings.autoReconnect = false;
+
+        if (!('afterFillSorting' in page.settings)) {
+            page.settings.afterFillSorting = defaultSettings.afterFillSorting;
+        }
+
+        if (!('afterFillSortingTotp' in page.settings)) {
+            page.settings.afterFillSortingTotp = defaultSettings.afterFillSortingTotp;
+        }
 
         if (!('autoCompleteUsernames' in page.settings)) {
             page.settings.autoCompleteUsernames = defaultSettings.autoCompleteUsernames;

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -13,8 +13,8 @@ const SORT_BY_TITLE = 'sortByTitle';
 const SORT_BY_USERNAME = 'sortByUsername';
 const SORT_BY_GROUP_AND_TITLE = 'sortByGroupAndTitle';
 const SORT_BY_GROUP_AND_USERNAME = 'sortByGroupAndUsername';
-const SORT_BY_DEFAULT = 'sortByDefault';
-const SORT_BY_RELEVANT = 'sortByRelevant';
+const SORT_BY_MATCHING_CREDENTIALS_SETTING = 'sortByMatchingCredentials';
+const SORT_BY_RELEVANT_ENTRY = 'sortByRelevantEntry';
 
 // Update check intervals
 const CHECK_UPDATE_NEVER = 0;

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -13,6 +13,8 @@ const SORT_BY_TITLE = 'sortByTitle';
 const SORT_BY_USERNAME = 'sortByUsername';
 const SORT_BY_GROUP_AND_TITLE = 'sortByGroupAndTitle';
 const SORT_BY_GROUP_AND_USERNAME = 'sortByGroupAndUsername';
+const SORT_BY_DEFAULT = 'sortByDefault';
+const SORT_BY_RELEVANT = 'sortByRelevant';
 
 // Update check intervals
 const CHECK_UPDATE_NEVER = 0;

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -4,7 +4,7 @@ const MAX_AUTOCOMPLETE_NAME_LEN = 50;
 
 class Autocomplete {
     constructor() {
-        this.afterFillSort = SORT_BY_DEFAULT;
+        this.afterFillSort = SORT_BY_MATCHING_CREDENTIALS_SETTING;
         this.autocompleteList = [];
         this.autoSubmit = false;
         this.elements = [];
@@ -31,7 +31,7 @@ class Autocomplete {
 
     }
 
-    async create(input, showListInstantly = false, autoSubmit = false, afterFillSort = SORT_BY_DEFAULT) {
+    async create(input, showListInstantly = false, autoSubmit = false, afterFillSort = SORT_BY_MATCHING_CREDENTIALS_SETTING) {
         if (input.readOnly) {
             return;
         }
@@ -117,7 +117,7 @@ class Autocomplete {
 
                 // If this page has an associated uuid and it matches this credential, then put it on top of the list
                 if (username === c.value
-                    || (this.afterFillSort === SORT_BY_RELEVANT && c.uuid === pageUuid)) {
+                    || (this.afterFillSort === SORT_BY_RELEVANT_ENTRY && c.uuid === pageUuid)) {
                     this.list.prepend(item);
                 } else {
                     this.list.appendChild(item);

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -119,8 +119,7 @@ class Autocomplete {
                 if (username === c.value
                     || (this.afterFillSort === SORT_BY_RELEVANT && c.uuid === pageUuid)) {
                     this.list.prepend(item);
-                }
-                else {
+                } else {
                     this.list.appendChild(item);
                 }
             }

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -241,14 +241,14 @@ kpxc.initAutocomplete = function() {
 
     for (const c of kpxc.combinations) {
         if (c.username) {
-            kpxcUserAutocomplete.create(c.username, false, kpxc.settings.autoSubmit);
+            kpxcUserAutocomplete.create(c.username, false, kpxc.settings.autoSubmit, kpxc.settings.afterFillSorting);
         } else if (!c.username && c.password) {
             // Single password field
-            kpxcUserAutocomplete.create(c.password, false, kpxc.settings.autoSubmit);
+            kpxcUserAutocomplete.create(c.password, false, kpxc.settings.autoSubmit, kpxc.settings.afterFillSorting);
         }
 
         if (c.totp) {
-            kpxcTOTPAutocomplete.create(c.totp, false, kpxc.settings.autoSubmit);
+            kpxcTOTPAutocomplete.create(c.totp, false, kpxc.settings.autoSubmit, kpxc.settings.afterFillSortingTotp);
         }
     }
 };

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -194,8 +194,32 @@
                     </select>
                   </div>
 
+                  <!-- Credential sorting after fill -->
+                  <div class="form-group col-sm-3 pb-2">
+                    <label for="afterFillSorting" class="py-2" data-i18n="optionsFillSortPriority"></label>
+                    <select class="form-control form-control-sm col-md-2" id="afterFillSorting" data-i18n="[title]optionsFillSortPriority">
+                      <option value="sortByDefault" data-i18n="optionsFillSortDefault"></option>
+                      <option value="sortByRelevant" data-i18n="optionsFillSortRelevant"></option>
+                    </select>
+                  </div>
+                  <div>
+                    <span class="form-text text-muted" data-i18n="optionsFillSortPriorityHelpText"></span>
+                  </div>
+
+                  <!-- Credential sorting after fill for TOTP -->
+                  <div class="form-group col-sm-3 pb-2">
+                    <label for="afterFillSortingTotp" class="py-2" data-i18n="optionsFillSortPriorityTotp"></label>
+                    <select class="form-control form-control-sm col-md-2" id="afterFillSortingTotp" data-i18n="[title]optionsFillSortPriorityTotp">
+                      <option value="sortByDefault" data-i18n="optionsFillSortDefault"></option>
+                      <option value="sortByRelevant" data-i18n="optionsFillSortRelevant"></option>
+                    </select>
+                  </div>
+                  <div>
+                    <span class="form-text text-muted" data-i18n="optionsFillSortPriorityTotpHelpText"></span>
+                  </div>
+
                   <!-- Use Auto-Submit -->
-                  <div class="form-group">
+                  <div class="form-group py-2">
                     <div class="form-check">
                       <input class="form-check-input" type="checkbox" name="autoSubmit" id="autoSubmit" value="true" />
                       <label class="form-check-label" for="autoSubmit" data-i18n="optionsCheckboxAutoSubmit"></label>

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -198,8 +198,8 @@
                   <div class="form-group col-sm-3 pb-2">
                     <label for="afterFillSorting" class="py-2" data-i18n="optionsFillSortPriority"></label>
                     <select class="form-control form-control-sm col-md-2" id="afterFillSorting" data-i18n="[title]optionsFillSortPriority">
-                      <option value="sortByDefault" data-i18n="optionsFillSortDefault"></option>
-                      <option value="sortByRelevant" data-i18n="optionsFillSortRelevant"></option>
+                      <option value="sortByMatchingCredentials" data-i18n="optionsFillSortByMatchingCredentials"></option>
+                      <option value="sortByRelevantEntry" data-i18n="optionsFillSortByRelevantEntry"></option>
                     </select>
                   </div>
                   <div>
@@ -210,8 +210,8 @@
                   <div class="form-group col-sm-3 pb-2">
                     <label for="afterFillSortingTotp" class="py-2" data-i18n="optionsFillSortPriorityTotp"></label>
                     <select class="form-control form-control-sm col-md-2" id="afterFillSortingTotp" data-i18n="[title]optionsFillSortPriorityTotp">
-                      <option value="sortByDefault" data-i18n="optionsFillSortDefault"></option>
-                      <option value="sortByRelevant" data-i18n="optionsFillSortRelevant"></option>
+                      <option value="sortByMatchingCredentials" data-i18n="optionsFillSortByMatchingCredentials"></option>
+                      <option value="sortByRelevantEntry" data-i18n="optionsFillSortByRelevantEntry"></option>
                     </select>
                   </div>
                   <div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -128,6 +128,8 @@ options.initGeneralSettings = function() {
         options.settings['redirectAllowance'] === 11 ? 'Infinite' : String(options.settings['redirectAllowance']));
 
     $('#tab-general-settings select#credentialSorting').value = options.settings['credentialSorting'];
+    $('#tab-general-settings select#afterFillSorting').value = options.settings['afterFillSorting'];
+    $('#tab-general-settings select#afterFillSortingTotp').value = options.settings['afterFillSortingTotp'];
     $('#tab-general-settings input#defaultGroup').value = options.settings['defaultGroup'];
     $('#tab-general-settings input#clearCredentialTimeout').value = options.settings['clearCredentialsTimeout'];
 
@@ -150,6 +152,16 @@ options.initGeneralSettings = function() {
 
     $('#tab-general-settings select#credentialSorting').addEventListener('change', async function(e) {
         options.settings['credentialSorting'] = e.currentTarget.value;
+        await options.saveSettings();
+    });
+
+    $('#tab-general-settings select#afterFillSorting').addEventListener('change', async function(e) {
+        options.settings['afterFillSorting'] = e.currentTarget.value;
+        await options.saveSettings();
+    });
+
+    $('#tab-general-settings select#afterFillSortingTotp').addEventListener('change', async function(e) {
+        options.settings['afterFillSortingTotp'] = e.currentTarget.value;
         await options.saveSettings();
     });
 


### PR DESCRIPTION
Sort the page uuid first in the list. This is useful for pages that make you enter the username on one page and then the password on a second page (e.g. Google). You do not have to search for the same entry in the list again since it will conveniently be placed on top.

Since there are existing settings for sorting this list, perhaps a setting should be introduced for this behavior?

I've noticed that the TOTP list only lists one credential. I don't know exactly how that works under the hood, but perhaps it would be useful to only list the selected credential in this case too (but only when the password field is autocompleted)?

Please let me know if there's anything I should change.