### PR TITLE
Do not select the contents of the text field when there are no credentials

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -60,6 +60,12 @@ class Autocomplete {
 
     async showList(inputField) {
         this.closeList();
+
+        // Return if there are no credentials
+        if (this.elements.length === 0) {
+            return;
+        }
+
         this.input = inputField;
         this.input.select();
 


### PR DESCRIPTION
Return early if there are no credentials. This fixes an annoying behavior where the extension selects the contents of a text field that does not contain credentials (e.g. misidentified TOTP field). Selecting the contents of a text field when it is clicked is not normal behavior and feels really off.

Example:

![Screen Shot 2021-11-09 at 08 06 25](https://user-images.githubusercontent.com/1991151/140961350-831658f5-8954-4c47-a723-0f35a8d55dbb.png)

This text field is not a TOTP field and I am not sure why the extension thinks it is one. Clicking the icon gives me `Warning! No TOTP found.`

Even though no list appears, the contents of the text field is selected when I click the field. This is not something that I expect and it just feels really off.

Returning early fixes it for me.

I was about to also delete this code snippet, but it doesn't seem to have an effect in this particular case. Should it be changed as well?

https://github.com/keepassxreboot/keepassxc-browser/blob/eeb69820bd19cdbecc17700faef887849070dfed/keepassxc-browser/content/credential-autocomplete.js#L11-L13