### PR TITLE
Add minimum font size to autocomplete menu

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -12,7 +12,7 @@
     border-top-width: 0px !important;
     width: auto;
     color: var(--kpxc-text-color);
-    font-size: .9em !important;
+    font-size: max(10px, .9em) !important;
     letter-spacing: normal !important;
     word-spacing: normal !important;
     text-rendering: auto !important;
@@ -29,7 +29,7 @@
     border: 1px solid rgba(0,0,0,.125) !important;
     width: auto;
     color: #000;
-    font-size: .8em !important;
+    font-size: max(9px, .8em) !important;
     font-style: italic;
 }
 


### PR DESCRIPTION
Adds a minimum font size to the Autocomplete Menu. The default is still `.9em` but if it's smaller than `10px` we will use the latter. Fixes a site for example site https://www.teamblind.com/ where the font size is way too small to see properly.