### PR TITLE
Add support for downloading favicons after saving a credential

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -775,6 +775,14 @@
         "message": "When saving new custom login fields, save only the domain instead of full URL.",
         "description": "Save domain only option help text."
     },
+    "optionsDownloadFaviconAfterSave": {
+        "message": "Download favicon after save",
+        "description": "Download favicon after save checkbox label text."
+    },
+    "optionsDownloadFaviconAfterSaveHelpText": {
+        "message": "Favicon will be automatically downloaded for the new credential.",
+        "description": "Download favicon after save help text."
+    },
     "optionsAutoFillAndSendHelpText": {
         "message": "If credentials are found for a page and the login-type is an HTTP Basic Auth request, KeePassXC-Browser tries to login automatically with the first given credentials. When multiple credentials are present, the extension popup can be used to choose the correct one. Even when this feature is enabled, it is still possible to enter HTTP Basic Auth login manually.",
         "description": "Auto-Fill And Send option help text."

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -191,6 +191,10 @@ keepass.updateCredentials = async function(tab, args = []) {
             messageData.uuid = entryId;
         }
 
+        if (!entryId && page.settings.downloadFaviconAfterSave) {
+            messageData.downloadFavicon = 'true';
+        }
+
         if (group && groupUuid) {
             messageData.group = group;
             messageData.groupUuid = groupUuid;

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -14,6 +14,7 @@ const defaultSettings = {
     credentialSorting: SORT_BY_GROUP_AND_TITLE,
     defaultGroup: '',
     defaultGroupAlwaysAsk: false,
+    downloadFaviconAfterSave: false,
     redirectAllowance: 1,
     saveDomainOnly: true,
     showLoginFormIcon: true,
@@ -99,6 +100,10 @@ page.initSettings = async function() {
 
         if (!('defaultGroupAlwaysAsk' in page.settings)) {
             page.settings.defaultGroupAlwaysAsk = defaultSettings.defaultGroupAlwaysAsk;
+        }
+
+        if (!('downloadFaviconAfterSave' in page.settings)) {
+            page.settings.downloadFaviconAfterSave = defaultSettings.downloadFaviconAfterSave;
         }
 
         if (!('redirectAllowance' in page.settings)) {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.10.1",
-    "version_name": "1.7.10.1",
+    "version": "1.7.11",
+    "version_name": "1.7.11",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -253,6 +253,15 @@
                     </div>
                   </div>
 
+                  <!-- Download favicon to entry after save -->
+                  <div class="form-group" id="downloadFaviconAfterSaveFormGroup">
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" name="downloadFaviconAfterSave" id="downloadFaviconAfterSave" value="true">
+                      <label class="form-check-label" for="downloadFaviconAfterSave" data-i18n="optionsDownloadFaviconAfterSave"></label>
+                      <span class="form-text text-muted" data-i18n="optionsDownloadFaviconAfterSaveHelpText"></span>
+                    </div>
+                  </div>
+
                   <!-- Number of allowed redirects -->
                   <div class="form-group">
                     <label id="redirectAllowanceLabel" class="font-weight-normal" for="redirectAllowance" data-i18n="optionsRedirectAllowance" i18n-placeholder="1"></label>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -280,6 +280,7 @@ options.initGeneralSettings = function() {
     }
 };
 
+// Also hides/disables any options with KeePassXC versions that are too old
 options.showKeePassXCVersions = async function(response) {
     if (response.current === '') {
         response.current = 'unknown';
@@ -293,15 +294,26 @@ options.showKeePassXCVersions = async function(response) {
     $('#tab-about span.kpxcVersion').text(response.current);
     $('#tab-general-settings button.checkUpdateKeePassXC:first').attr('disabled', false);
 
-    const result = await browser.runtime.sendMessage({
+    // Hide/disable certain options with older KeePassXC versions than 2.6.0
+    const version260Result = await browser.runtime.sendMessage({
         action: 'compare_version',
         args: [ '2.6.0', response.current ]
     });
 
-    if (result) {
+    if (version260Result) {
         $('#tab-general-settings #versionRequiredAlert').hide();
     } else {
         $('#tab-general-settings #showGroupNameInAutocomplete').attr('disabled', true);
+    }
+
+    // Hide certain options with older KeePassXC versions than 2.7.0
+    const version270Result = await browser.runtime.sendMessage({
+        action: 'compare_version',
+        args: [ '2.7.0', response.current ]
+    });
+
+    if (!version270Result) {
+        $('#tab-general-settings #downloadFaviconAfterSaveFormGroup').hide();
     }
 };
 
@@ -611,7 +623,7 @@ options.initTheme = function() {
         document.body.setAttribute('data-color-theme', options.settings['colorTheme']);
     }
     // Sync localStorage setting
-    let localStorageTheme = localStorage.getItem('colorTheme');
+    const localStorageTheme = localStorage.getItem('colorTheme');
     if (localStorageTheme !== options.settings['colorTheme']) {
         localStorage.setItem('colorTheme', options.settings['colorTheme']);
     }

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -231,7 +231,7 @@ Response message data (success, decrypted):
 ```
 
 ### set-login
-Unencrypted message:
+Unencrypted message (downloadFavicon supported in KeePassXC 2.7.0 and later, but not when updating credentials):
 ```json
 {
     "action": "set-login",
@@ -243,7 +243,8 @@ Unencrypted message:
     "password": "passwd1",
     "group": "<group name>",
     "groupUuid": "<group UUID>",
-    "uuid": "<entry UUID>"
+    "uuid": "<entry UUID>",
+    "downloadFavicon": "true"
 }
 ```
 


### PR DESCRIPTION
Adds a new command parameter for supportin favicon download after a credential has been saved.
An implementation is needed to the KeePassXC side. Let's keep this WIP until then.

Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/7179

Fixes #86.