### PR TITLE
Scroll login list instead of the whole popup body

### DIFF
--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -88,6 +88,11 @@ code {
     padding-left: 0px;
 }
 
+#login-list {
+    overflow-y: auto;
+    max-height: 380px;
+}
+
 #child {
     border-top: 0px;
 }


### PR DESCRIPTION
If a page has many credentials, the login list does not fit to the popup -> the whole popup becomes scrollable. Just the login list should scroll instead.