### PR TITLE
Fix Google password fill from popup

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -162,3 +162,16 @@ kpxcSites.formSubmitButtonExceptionFound = function(form) {
 
     return undefined;
 };
+
+/**
+ * Handles a few exceptions for certain sites where popup fill is not working properly.
+ * @param {object} form     Form element
+ * @returns {boolean}       True if exception found
+ */
+kpxcSites.popupExceptionFound = function(combinations) {
+    if (combinations.length > 1 && combinations[0].form && combinations[0].form.action.startsWith(googleUrl)) {
+        return true;
+    }
+
+    return false;
+};

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -106,7 +106,7 @@ kpxcFill.fillFromPopup = async function(id, uuid) {
     // For Google password field we need to do some special handling. The password field is actually in the
     // second combination that was just detected after a username fill.
     let combination = kpxc.combinations[0];
-    if (kpxc.combinations.length > 1 && kpxc.combinations[0].form && kpxc.combinations[0].form.action.startsWith(googleUrl)) {
+    if (kpxcSites.popupExceptionFound(kpxc.combinations)) {
         combination = kpxc.combinations[1];
     }
 

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -103,7 +103,14 @@ kpxcFill.fillFromPopup = async function(id, uuid) {
         return;
     }
 
-    kpxcFill.fillInCredentials(kpxc.combinations[0], selectedCredentials.login, uuid);
+    // For Google password field we need to do some special handling. The password field is actually in the
+    // second combination that was just detected after a username fill.
+    let combination = kpxc.combinations[0];
+    if (kpxc.combinations.length > 1 && kpxc.combinations[0].form && kpxc.combinations[0].form.action.startsWith(googleUrl)) {
+        combination = kpxc.combinations[1];
+    }
+
+    kpxcFill.fillInCredentials(combination, selectedCredentials.login, uuid);
     kpxcUserAutocomplete.closeList();
 };
 


### PR DESCRIPTION
Filling Google's login page password from the popup fails because the password field is actually in a recently detected combination. If there's more than one combination on Google's page, we must use the second one for a successful fill.

Fixes #1523.