### PR TITLE
Add debug logging option

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -663,6 +663,14 @@
         "message": "Automatically fill in HTTP Basic Auth dialogs and submit them.",
         "description": "Auto fill HTTP Basic Auth dialogs and send them checkbox text."
     },
+    "optionsDebugLogging": {
+        "message": "Debug logging",
+        "description": "Debug logging checkbox text."
+    },
+    "optionsDebugLoggingHelpText": {
+        "message": "Enable debug logging. Additional console messages will be visible in both background and content scripts.",
+        "description": "Debug logging help text."
+    },
     "optionsRadioText": {
         "message": "Check for updates of KeePassXC:",
         "description": "Text above radio buttons in the settings page."

--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -29,7 +29,7 @@ browserAction.showDefault = async function(tab) {
     };
 
     const response = await keepass.isConfigured().catch((err) => {
-        console.log('Error: Cannot show default popup: ' + err);
+        showErrorMessage('Cannot show default popup: ' + err);
     });
 
     if (!response && !keepass.isKeePassXCAvailable) {

--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -29,7 +29,7 @@ browserAction.showDefault = async function(tab) {
     };
 
     const response = await keepass.isConfigured().catch((err) => {
-        showErrorMessage('Cannot show default popup: ' + err);
+        logError('Cannot show default popup: ' + err);
     });
 
     if (!response && !keepass.isKeePassXCAvailable) {

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -205,7 +205,7 @@ keepassClient.verifyKeyResponse = function(response, key, nonce) {
     }
 
     if (!keepassClient.checkNonceLength(response.nonce)) {
-        console.log(`${EXTENSION_NAME}: Error. Invalid nonce length`);
+        showErrorMessage('Invalid nonce length.');
         return false;
     }
 
@@ -233,7 +233,7 @@ keepassClient.verifyResponse = function(response, nonce, id) {
 
     keepass.associated.value = (response.nonce === nonce);
     if (keepass.associated.value === false) {
-        console.log(`${EXTENSION_NAME}: Error. Nonce compare failed`);
+        showErrorMessage('Nonce compare failed');
         return false;
     }
 
@@ -252,12 +252,12 @@ keepassClient.verifyDatabaseResponse = function(response, nonce) {
     }
 
     if (!keepassClient.checkNonceLength(response.nonce)) {
-        console.log(`${EXTENSION_NAME}: Error. Invalid nonce length`);
+        showErrorMessage('Invalid nonce length.');
         return false;
     }
 
     if (response.nonce !== nonce) {
-        console.log(`${EXTENSION_NAME}: Error- Nonce compare failed`);
+        showErrorMessage('Nonce compare failed.');
         return false;
     }
 
@@ -322,12 +322,10 @@ function onDisconnected() {
     page.clearCredentials(page.currentTabId, true);
     keepass.updatePopup('cross');
     keepass.updateDatabaseHashToContent();
-    console.log(`${EXTENSION_NAME}: Failed to connect: ${(browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message)}`);
+    showErrorMessage(`Failed to connect: ${(browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message)}`);
 }
 
 keepassClient.onNativeMessage = function(response) {
-    //console.log('Received message: ' + JSON.stringify(response));
-
     // Handle database lock/unlock status
     if (response.action === kpActions.DATABASE_LOCKED || response.action === kpActions.DATABASE_UNLOCKED) {
         keepass.updateDatabase();

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -205,7 +205,7 @@ keepassClient.verifyKeyResponse = function(response, key, nonce) {
     }
 
     if (!keepassClient.checkNonceLength(response.nonce)) {
-        showErrorMessage('Invalid nonce length.');
+        logError('Invalid nonce length.');
         return false;
     }
 
@@ -233,7 +233,7 @@ keepassClient.verifyResponse = function(response, nonce, id) {
 
     keepass.associated.value = (response.nonce === nonce);
     if (keepass.associated.value === false) {
-        showErrorMessage('Nonce compare failed');
+        logError('Nonce compare failed');
         return false;
     }
 
@@ -252,12 +252,12 @@ keepassClient.verifyDatabaseResponse = function(response, nonce) {
     }
 
     if (!keepassClient.checkNonceLength(response.nonce)) {
-        showErrorMessage('Invalid nonce length.');
+        logError('Invalid nonce length.');
         return false;
     }
 
     if (response.nonce !== nonce) {
-        showErrorMessage('Nonce compare failed.');
+        logError('Nonce compare failed.');
         return false;
     }
 
@@ -322,7 +322,7 @@ function onDisconnected() {
     page.clearCredentials(page.currentTabId, true);
     keepass.updatePopup('cross');
     keepass.updateDatabaseHashToContent();
-    showErrorMessage(`Failed to connect: ${(browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message)}`);
+    logError(`Failed to connect: ${(browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message)}`);
 }
 
 keepassClient.onNativeMessage = function(response) {

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -38,14 +38,14 @@ kpxcEvent.showStatus = async function(tab, configured, internalPoll) {
 
 kpxcEvent.onLoadSettings = async function() {
     return await page.initSettings().catch((err) => {
-        console.log('onLoadSettings error: ' + err);
+        showErrorMessage('onLoadSettings error: ' + err);
         return Promise.reject();
     });
 };
 
 kpxcEvent.onLoadKeyRing = async function() {
     const item = await browser.storage.local.get({ 'keyRing': {} }).catch((err) => {
-        console.log('kpxcEvent.onLoadKeyRing error: ' + err);
+        showErrorMessage('kpxcEvent.onLoadKeyRing error: ' + err);
         return Promise.reject();
     });
 
@@ -79,7 +79,7 @@ kpxcEvent.onGetStatus = async function(tab, args = []) {
         const configured = await keepass.isConfigured();
         return kpxcEvent.showStatus(tab, configured, internalPoll);
     } catch (err) {
-        console.log('Error: No status shown: ' + err);
+        showErrorMessage('No status shown: ' + err);
         return Promise.reject();
     }
 };
@@ -90,7 +90,7 @@ kpxcEvent.onReconnect = async function(tab) {
         browser.tabs.sendMessage(tab.id, {
             action: 'redetect_fields'
         }).catch((err) => {
-            console.log(err);
+            showErrorMessage(err);
             return;
         });
     }
@@ -103,7 +103,7 @@ kpxcEvent.lockDatabase = async function(tab) {
         await keepass.lockDatabase(tab);
         return kpxcEvent.showStatus(tab, false);
     } catch (err) {
-        console.log('kpxcEvent.lockDatabase error: ' + err);
+        showErrorMessage('kpxcEvent.lockDatabase error: ' + err);
         return false;
     }
 };

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -38,14 +38,14 @@ kpxcEvent.showStatus = async function(tab, configured, internalPoll) {
 
 kpxcEvent.onLoadSettings = async function() {
     return await page.initSettings().catch((err) => {
-        showErrorMessage('onLoadSettings error: ' + err);
+        logError('onLoadSettings error: ' + err);
         return Promise.reject();
     });
 };
 
 kpxcEvent.onLoadKeyRing = async function() {
     const item = await browser.storage.local.get({ 'keyRing': {} }).catch((err) => {
-        showErrorMessage('kpxcEvent.onLoadKeyRing error: ' + err);
+        logError('kpxcEvent.onLoadKeyRing error: ' + err);
         return Promise.reject();
     });
 
@@ -79,7 +79,7 @@ kpxcEvent.onGetStatus = async function(tab, args = []) {
         const configured = await keepass.isConfigured();
         return kpxcEvent.showStatus(tab, configured, internalPoll);
     } catch (err) {
-        showErrorMessage('No status shown: ' + err);
+        logError('No status shown: ' + err);
         return Promise.reject();
     }
 };
@@ -90,7 +90,7 @@ kpxcEvent.onReconnect = async function(tab) {
         browser.tabs.sendMessage(tab.id, {
             action: 'redetect_fields'
         }).catch((err) => {
-            showErrorMessage(err);
+            logError(err);
             return;
         });
     }
@@ -103,7 +103,7 @@ kpxcEvent.lockDatabase = async function(tab) {
         await keepass.lockDatabase(tab);
         return kpxcEvent.showStatus(tab, false);
     } catch (err) {
-        showErrorMessage('kpxcEvent.lockDatabase error: ' + err);
+        logError('kpxcEvent.lockDatabase error: ' + err);
         return false;
     }
 };

--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -49,7 +49,7 @@ httpAuth.handleRequestCallback = function(details, callback) {
 
 httpAuth.retrieveCredentials = async function(tabId, url, submitUrl) {
     return await keepass.retrieveCredentials(tabId, [ url, submitUrl, false, true ]).catch((err) => {
-        console.log('httpAuth.retrieveCredentials error: ' + err);
+        showErrorMessage('httpAuth.retrieveCredentials error: ' + err);
         return Promise.reject();
     });
 };
@@ -93,6 +93,7 @@ httpAuth.loginOrShowCredentials = function(logins, details, resolve, reject) {
             kpxcEvent.onHTTPAuthPopup({ 'id': details.tabId }, { 'logins': logins, 'url': details.searchUrl, 'resolve': resolve });
         }
     } else {
+        showErrorMessage('No logins found for HTTP Basic Auth.');
         reject({ cancel: false }); // No logins found
     }
 };

--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -49,7 +49,7 @@ httpAuth.handleRequestCallback = function(details, callback) {
 
 httpAuth.retrieveCredentials = async function(tabId, url, submitUrl) {
     return await keepass.retrieveCredentials(tabId, [ url, submitUrl, false, true ]).catch((err) => {
-        showErrorMessage('httpAuth.retrieveCredentials error: ' + err);
+        logError('httpAuth.retrieveCredentials error: ' + err);
         return Promise.reject();
     });
 };
@@ -93,7 +93,7 @@ httpAuth.loginOrShowCredentials = function(logins, details, resolve, reject) {
             kpxcEvent.onHTTPAuthPopup({ 'id': details.tabId }, { 'logins': logins, 'url': details.searchUrl, 'resolve': resolve });
         }
     } else {
-        showErrorMessage('No logins found for HTTP Basic Auth.');
+        logError('No logins found for HTTP Basic Auth.');
         reject({ cancel: false }); // No logins found
     }
 };

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -11,7 +11,7 @@
         await keepass.enableAutomaticReconnect();
         await keepass.updateDatabase();
     } catch (e) {
-        showErrorMessage('init.js failed');
+        logError('init.js failed');
     }
 })();
 
@@ -62,7 +62,7 @@ browser.tabs.onActivated.addListener(async function(activeInfo) {
             }
         }
     } catch (err) {
-        showErrorMessage(err.message);
+        logError(err.message);
     }
 });
 
@@ -135,7 +135,7 @@ for (const item of contextMenuItems) {
             browser.tabs.sendMessage(tab.id, {
                 action: item.action
             }).catch((err) => {
-                showErrorMessage(err);
+                logError(err);
             });
         }
     });

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -11,7 +11,7 @@
         await keepass.enableAutomaticReconnect();
         await keepass.updateDatabase();
     } catch (e) {
-        console.log('init.js failed');
+        showErrorMessage('init.js failed');
     }
 })();
 
@@ -62,7 +62,7 @@ browser.tabs.onActivated.addListener(async function(activeInfo) {
             }
         }
     } catch (err) {
-        console.log('Error: ' + err.message);
+        showErrorMessage(err.message);
     }
 });
 
@@ -135,7 +135,7 @@ for (const item of contextMenuItems) {
             browser.tabs.sendMessage(tab.id, {
                 action: item.action
             }).catch((err) => {
-                console.log(err);
+                showErrorMessage(err);
             });
         }
     });

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -98,7 +98,7 @@ keepass.updateCredentials = async function(tab, args = []) {
             return 'error';
         }
     } catch (err) {
-        showErrorMessage(`updateCredentials failed: ${err}`);
+        logError(`updateCredentials failed: ${err}`);
         return [];
     }
 };
@@ -158,14 +158,14 @@ keepass.retrieveCredentials = async function(tab, args = []) {
                 browserAction.showDefault(tab);
             }
 
-            debugLog(`Found ${entries.length} entries for url ${url}`);
+            logDebug(`Found ${entries.length} entries for url ${url}`);
             return entries;
         }
 
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        showErrorMessage(`retrieveCredentials failed: ${err}`);
+        logError(`retrieveCredentials failed: ${err}`);
         return [];
     }
 };
@@ -201,12 +201,12 @@ keepass.generatePassword = async function(tab) {
             password = response.entries ?? response.password;
             keepass.updateLastUsed(keepass.databaseHash);
         } else {
-            showErrorMessage('generatePassword rejected');
+            logError('generatePassword rejected');
         }
 
         return password;
     } catch (err) {
-        showErrorMessage(`generatePassword failed: ${err}`);
+        logError(`generatePassword failed: ${err}`);
         return [];
     }
 };
@@ -253,7 +253,7 @@ keepass.associate = async function(tab) {
         keepass.handleError(tab, kpErrors.ASSOCIATION_FAILED);
         return AssociatedAction.NOT_ASSOCIATED;
     } catch (err) {
-        showErrorMessage(`associate failed: ${err}`);
+        logError(`associate failed: ${err}`);
     }
 
     return AssociatedAction.NOT_ASSOCIATED;
@@ -322,7 +322,7 @@ keepass.testAssociation = async function(tab, args = []) {
 
         return keepass.isAssociated();
     } catch (err) {
-        showErrorMessage(`testAssociation failed: ${err}`);
+        logError(`testAssociation failed: ${err}`);
         return false;
     }
 };
@@ -404,7 +404,7 @@ keepass.getDatabaseHash = async function(tab, args = []) {
         }
         return keepass.databaseHash;
     } catch (err) {
-        showErrorMessage(`getDatabaseHash failed: ${err}`);
+        logError(`getDatabaseHash failed: ${err}`);
         return keepass.databaseHash;
     }
 };
@@ -444,7 +444,7 @@ keepass.changePublicKeys = async function(tab, enableTimeout = false, connection
         console.log(`${EXTENSION_NAME}: Server public key: ${nacl.util.encodeBase64(keepass.serverPublicKey)}`);
         return true;
     } catch (err) {
-        showErrorMessage(`changePublicKeys failed: ${err}`);
+        logError(`changePublicKeys failed: ${err}`);
         return false;
     }
 };
@@ -478,7 +478,7 @@ keepass.lockDatabase = async function(tab) {
 
         return false;
     } catch (err) {
-        showErrorMessage(`ockDatabase failed: ${err}`);
+        logError(`ockDatabase failed: ${err}`);
         return false;
     }
 };
@@ -519,7 +519,7 @@ keepass.getDatabaseGroups = async function(tab) {
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        showErrorMessage(`getDatabaseGroups failed: ${err}`);
+        logError(`getDatabaseGroups failed: ${err}`);
         return [];
     }
 };
@@ -554,13 +554,13 @@ keepass.createNewGroup = async function(tab, args = []) {
             keepass.updateLastUsed(keepass.databaseHash);
             return response;
         } else {
-            showErrorMessage(`getDatabaseGroups rejected`);
+            logError(`getDatabaseGroups rejected`);
         }
 
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        showErrorMessage(`createNewGroup failed: ${err}`);
+        logError(`createNewGroup failed: ${err}`);
         return [];
     }
 };
@@ -593,7 +593,7 @@ keepass.getTotp = async function(tab, args = []) {
 
         return;
     } catch (err) {
-        showErrorMessage(`getTotp failed: ${err}`);
+        logError(`getTotp failed: ${err}`);
     }
 };
 
@@ -616,7 +616,7 @@ keepass.requestAutotype = async function(tab, args = []) {
         const response = await keepassClient.sendMessage(kpAction, tab, messageData, nonce);
         return response;
     } catch (err) {
-        showErrorMessage(`requestAutotype failed: ${err}`);
+        logError(`requestAutotype failed: ${err}`);
         return false;
     }
 };
@@ -833,14 +833,14 @@ keepass.checkForNewKeePassXCVersion = function() {
     };
 
     xhr.onerror = function(err) {
-        showErrorMessage(`checkForNewKeePassXCVersion error: ${err}`);
+        logError(`checkForNewKeePassXCVersion error: ${err}`);
     };
 
     try {
         xhr.open('GET', keepass.latestVersionUrl, true);
         xhr.send();
     } catch (ex) {
-        showErrorMessage(ex);
+        logError(ex);
     }
     keepass.latestKeePassXC.lastChecked = new Date().valueOf();
 };
@@ -849,7 +849,8 @@ keepass.handleError = function(tab, errorCode, errorMessage = '') {
     if (errorMessage.length === 0) {
         errorMessage = kpErrors.getError(errorCode);
     }
-    showErrorMessage(`${errorCode}: ${errorMessage}`);
+
+    logError(`${errorCode}: ${errorMessage}`);
     if (tab && page.tabs[tab.id]) {
         page.tabs[tab.id].errorMessage = errorMessage;
     }
@@ -884,12 +885,12 @@ keepass.updateDatabaseHashToContent = async function() {
                 hash: { old: keepass.previousDatabaseHash, new: keepass.databaseHash },
                 connected: keepass.isKeePassXCAvailable
             }).catch((err) => {
-                showErrorMessage(`No content script available for this tab.`);
+                logError(`No content script available for this tab.`);
             });
             keepass.previousDatabaseHash = keepass.databaseHash;
         }
     } catch (err) {
-        showErrorMessage(`updateDatabaseHashToContent failed: ${err}`);
+        logError(`updateDatabaseHashToContent failed: ${err}`);
     }
 };
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -98,7 +98,7 @@ keepass.updateCredentials = async function(tab, args = []) {
             return 'error';
         }
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: updateCredentials failed: ${err}`);
+        showErrorMessage(`updateCredentials failed: ${err}`);
         return [];
     }
 };
@@ -158,13 +158,14 @@ keepass.retrieveCredentials = async function(tab, args = []) {
                 browserAction.showDefault(tab);
             }
 
+            debugLog(`Found ${entries.length} entries for url ${url}`);
             return entries;
         }
 
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: retrieveCredentials failed: ${err}`);
+        showErrorMessage(`retrieveCredentials failed: ${err}`);
         return [];
     }
 };
@@ -200,12 +201,12 @@ keepass.generatePassword = async function(tab) {
             password = response.entries ?? response.password;
             keepass.updateLastUsed(keepass.databaseHash);
         } else {
-            console.log(`${EXTENSION_NAME}: generatePassword rejected`);
+            showErrorMessage('generatePassword rejected');
         }
 
         return password;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: generatePassword failed: ${err}`);
+        showErrorMessage(`generatePassword failed: ${err}`);
         return [];
     }
 };
@@ -252,7 +253,7 @@ keepass.associate = async function(tab) {
         keepass.handleError(tab, kpErrors.ASSOCIATION_FAILED);
         return AssociatedAction.NOT_ASSOCIATED;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: associate failed: ${err}`);
+        showErrorMessage(`associate failed: ${err}`);
     }
 
     return AssociatedAction.NOT_ASSOCIATED;
@@ -321,7 +322,7 @@ keepass.testAssociation = async function(tab, args = []) {
 
         return keepass.isAssociated();
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: testAssociation failed: ${err}`);
+        showErrorMessage(`testAssociation failed: ${err}`);
         return false;
     }
 };
@@ -403,7 +404,7 @@ keepass.getDatabaseHash = async function(tab, args = []) {
         }
         return keepass.databaseHash;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: getDatabaseHash failed: ${err}`);
+        showErrorMessage(`getDatabaseHash failed: ${err}`);
         return keepass.databaseHash;
     }
 };
@@ -443,7 +444,7 @@ keepass.changePublicKeys = async function(tab, enableTimeout = false, connection
         console.log(`${EXTENSION_NAME}: Server public key: ${nacl.util.encodeBase64(keepass.serverPublicKey)}`);
         return true;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: changePublicKeys failed: ${err}`);
+        showErrorMessage(`changePublicKeys failed: ${err}`);
         return false;
     }
 };
@@ -477,7 +478,7 @@ keepass.lockDatabase = async function(tab) {
 
         return false;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: lockDatabase failed: ${err}`);
+        showErrorMessage(`ockDatabase failed: ${err}`);
         return false;
     }
 };
@@ -518,7 +519,7 @@ keepass.getDatabaseGroups = async function(tab) {
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: getDatabaseGroups failed: ${err}`);
+        showErrorMessage(`getDatabaseGroups failed: ${err}`);
         return [];
     }
 };
@@ -553,13 +554,13 @@ keepass.createNewGroup = async function(tab, args = []) {
             keepass.updateLastUsed(keepass.databaseHash);
             return response;
         } else {
-            console.log(`${EXTENSION_NAME}: getDatabaseGroups rejected`);
+            showErrorMessage(`getDatabaseGroups rejected`);
         }
 
         browserAction.showDefault(tab);
         return [];
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: createNewGroup failed: ${err}`);
+        showErrorMessage(`createNewGroup failed: ${err}`);
         return [];
     }
 };
@@ -592,7 +593,7 @@ keepass.getTotp = async function(tab, args = []) {
 
         return;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: getTotp failed: ${err}`);
+        showErrorMessage(`getTotp failed: ${err}`);
     }
 };
 
@@ -615,7 +616,7 @@ keepass.requestAutotype = async function(tab, args = []) {
         const response = await keepassClient.sendMessage(kpAction, tab, messageData, nonce);
         return response;
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: requestAutotype failed: ${err}`);
+        showErrorMessage(`requestAutotype failed: ${err}`);
         return false;
     }
 };
@@ -774,7 +775,6 @@ keepass.reconnect = async function(tab, connectionTimeout) {
 
 keepass.generateNewKeyPair = function() {
     keepass.keyPair = nacl.box.keyPair();
-    //console.log(nacl.util.encodeBase64(keepass.keyPair.publicKey) + ' ' + nacl.util.encodeBase64(keepass.keyPair.secretKey));
 };
 
 keepass.isConfigured = async function() {
@@ -833,14 +833,14 @@ keepass.checkForNewKeePassXCVersion = function() {
     };
 
     xhr.onerror = function(err) {
-        console.log(`${EXTENSION_NAME}: checkForNewKeePassXCVersion error: ${err}`);
+        showErrorMessage(`checkForNewKeePassXCVersion error: ${err}`);
     };
 
     try {
         xhr.open('GET', keepass.latestVersionUrl, true);
         xhr.send();
     } catch (ex) {
-        console.log(ex);
+        showErrorMessage(ex);
     }
     keepass.latestKeePassXC.lastChecked = new Date().valueOf();
 };
@@ -849,7 +849,7 @@ keepass.handleError = function(tab, errorCode, errorMessage = '') {
     if (errorMessage.length === 0) {
         errorMessage = kpErrors.getError(errorCode);
     }
-    console.log(`${EXTENSION_NAME}: Error ${errorCode}: ${errorMessage}`);
+    showErrorMessage(`${errorCode}: ${errorMessage}`);
     if (tab && page.tabs[tab.id]) {
         page.tabs[tab.id].errorMessage = errorMessage;
     }
@@ -884,12 +884,12 @@ keepass.updateDatabaseHashToContent = async function() {
                 hash: { old: keepass.previousDatabaseHash, new: keepass.databaseHash },
                 connected: keepass.isKeePassXCAvailable
             }).catch((err) => {
-                console.log(`${EXTENSION_NAME}: Error. No content script available for this tab.`);
+                showErrorMessage(`No content script available for this tab.`);
             });
             keepass.previousDatabaseHash = keepass.databaseHash;
         }
     } catch (err) {
-        console.log(`${EXTENSION_NAME}: updateDatabaseHashToContent failed: ${err}`);
+        showErrorMessage(`updateDatabaseHashToContent failed: ${err}`);
     }
 };
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -12,6 +12,7 @@ const defaultSettings = {
     clearCredentialsTimeout: 10,
     colorTheme: 'system',
     credentialSorting: SORT_BY_GROUP_AND_TITLE,
+    debugLogging: false,
     defaultGroup: '',
     defaultGroupAlwaysAsk: false,
     downloadFaviconAfterSave: false,
@@ -91,6 +92,10 @@ page.initSettings = async function() {
 
         if (!('credentialSorting' in page.settings)) {
             page.settings.credentialSorting = defaultSettings.credentialSorting;
+        }
+
+        if (!('debugLogging' in page.settings)) {
+            page.settings.debugLogging = defaultSettings.debugLogging;
         }
 
         if (!('defaultGroup' in page.settings)) {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -153,7 +153,7 @@ page.initSettings = async function() {
         await browser.storage.local.set({ 'settings': page.settings });
         return page.settings;
     } catch (err) {
-        console.log('page.initSettings error: ' + err);
+        showErrorMessage('page.initSettings error: ' + err);
         return Promise.reject();
     }
 };
@@ -174,7 +174,7 @@ page.initOpenedTabs = async function() {
         page.currentTabId = currentTabs[0].id;
         browserAction.showDefault(currentTabs[0]);
     } catch (err) {
-        console.log('page.initOpenedTabs error: ' + err);
+        showErrorMessage('page.initOpenedTabs error: ' + err);
         return Promise.reject();
     }
 };
@@ -210,7 +210,7 @@ page.switchTab = async function(tab) {
 
     browserAction.showDefault(tab);
     browser.tabs.sendMessage(tab.id, { action: 'activated_tab' }).catch((e) => {
-        console.log('Cannot send activated_tab message: ', e);
+        showErrorMessage('Cannot send activated_tab message: ' + e.message);
     });
 };
 
@@ -377,9 +377,15 @@ const createContextMenuItem = function({action, args, ...options}) {
                 action: action,
                 args: args
             }).catch((err) => {
-                console.log(err);
+                showErrorMessage(err);
             });
         },
         ...options
     });
+};
+
+const debugLog = function(message, extra) {
+    if (page.settings.debugLogging) {
+        showDebugMessage(message, extra);
+    }
 };

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -153,7 +153,7 @@ page.initSettings = async function() {
         await browser.storage.local.set({ 'settings': page.settings });
         return page.settings;
     } catch (err) {
-        showErrorMessage('page.initSettings error: ' + err);
+        logError('page.initSettings error: ' + err);
         return Promise.reject();
     }
 };
@@ -174,7 +174,7 @@ page.initOpenedTabs = async function() {
         page.currentTabId = currentTabs[0].id;
         browserAction.showDefault(currentTabs[0]);
     } catch (err) {
-        showErrorMessage('page.initOpenedTabs error: ' + err);
+        logError('page.initOpenedTabs error: ' + err);
         return Promise.reject();
     }
 };
@@ -210,7 +210,7 @@ page.switchTab = async function(tab) {
 
     browserAction.showDefault(tab);
     browser.tabs.sendMessage(tab.id, { action: 'activated_tab' }).catch((e) => {
-        showErrorMessage('Cannot send activated_tab message: ' + e.message);
+        logError('Cannot send activated_tab message: ' + e.message);
     });
 };
 
@@ -377,15 +377,15 @@ const createContextMenuItem = function({action, args, ...options}) {
                 action: action,
                 args: args
             }).catch((err) => {
-                showErrorMessage(err);
+                logError(err);
             });
         },
         ...options
     });
 };
 
-const debugLog = function(message, extra) {
+const logDebug = function(message, extra) {
     if (page.settings.debugLogging) {
-        showDebugMessage(message, extra);
+        debugLogMessage(message, extra);
     }
 };

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -164,14 +164,14 @@ const trimURL = function(url) {
     return url.indexOf('?') !== -1 ? url.split('?')[0] : url;
 };
 
-const showDebugMessage = function(message, extra) {
-    console.log(`${EXTENSION_NAME} - ${message}`);
+const debugLogMessage = function(message, extra) {
+    console.log(`[Debug] ${EXTENSION_NAME} - ${message}`);
 
     if (extra) {
         console.log(extra);
     }
 };
 
-const showErrorMessage = function(message) {
+const logError = function(message) {
     console.log(`${EXTENSION_NAME} Error: ${message}`);
 };

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -163,3 +163,15 @@ function tr(key, params) {
 const trimURL = function(url) {
     return url.indexOf('?') !== -1 ? url.split('?')[0] : url;
 };
+
+const showDebugMessage = function(message, extra) {
+    console.log(`${EXTENSION_NAME} - ${message}`);
+
+    if (extra) {
+        console.log(extra);
+    }
+};
+
+const showErrorMessage = function(message) {
+    console.log(`${EXTENSION_NAME} Error: ${message}`);
+};

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -165,7 +165,7 @@ const trimURL = function(url) {
 };
 
 const debugLogMessage = function(message, extra) {
-    console.log(`[Debug] ${EXTENSION_NAME} - ${message}`);
+    console.log(`[Debug ${getFileAndLine()}] ${EXTENSION_NAME} - ${message}`);
 
     if (extra) {
         console.log(extra);
@@ -173,5 +173,14 @@ const debugLogMessage = function(message, extra) {
 };
 
 const logError = function(message) {
-    console.log(`${EXTENSION_NAME} Error: ${message}`);
+    console.log(`[Error ${getFileAndLine()}] ${EXTENSION_NAME} - ${message}`);
+};
+
+// Returns file name and line number from error stack
+const getFileAndLine = function() {
+    const err = new Error().stack.split('\n');
+    const line = err[4] ?? err[err.length - 1];
+    const result = line.substring(line.lastIndexOf('/') + 1, line.lastIndexOf(':'));
+
+    return result;
 };

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -149,7 +149,7 @@ kpxcBanner.saveNewCredentials = async function(credentials = {}) {
 
     const result = await sendMessage('get_database_groups');
     if (!result || !result.groups) {
-        console.log('Error: Empty result from get_database_groups');
+        showErrorMessage('Empty result from get_database_groups');
         await saveToDefaultGroup(credentials);
         return;
     }

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -149,7 +149,7 @@ kpxcBanner.saveNewCredentials = async function(credentials = {}) {
 
     const result = await sendMessage('get_database_groups');
     if (!result || !result.groups) {
-        showErrorMessage('Empty result from get_database_groups');
+        logError('Empty result from get_database_groups');
         await saveToDefaultGroup(credentials);
         return;
     }

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -24,6 +24,7 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 // Fill requested from the context menu. Active element is used for combination detection
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
     if (kpxc.credentials.length === 0) {
+        debugLog('Error: Credential list is empty.');
         return;
     }
 
@@ -32,11 +33,13 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
             ? kpxc.combinations.find(c => c.password)
             : kpxc.combinations.find(c => c.username);
         if (!combination) {
+            debugLog('Error: No combination found.');
             return;
         }
 
         const field = passOnly ? combination.password : combination.username;
         if (!field) {
+            debugLog('Error: No input field found.');
             return;
         }
 
@@ -79,6 +82,7 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
 // Fill requested by Auto-Fill
 kpxcFill.fillFromAutofill = async function() {
     if (kpxc.credentials.length !== 1 || kpxc.combinations.length === 0) {
+        debugLog('Error: Credential list is empty or contains more than one entry.');
         return;
     }
 
@@ -93,13 +97,14 @@ kpxcFill.fillFromAutofill = async function() {
 // Fill requested by selecting credentials from the popup
 kpxcFill.fillFromPopup = async function(id, uuid) {
     if (!kpxc.credentials.length === 0 || !kpxc.credentials[id] || kpxc.combinations.length === 0) {
+        debugLog('Error: Credential list is empty.');
         return;
     }
 
     await sendMessage('page_set_login_id', uuid);
     const selectedCredentials = kpxc.credentials.find(c => c.uuid === uuid);
     if (!selectedCredentials) {
-        console.log('Error: Uuid not found: ', uuid);
+        showErrorMessage('Uuid not found: ', uuid);
         return;
     }
 
@@ -135,11 +140,13 @@ kpxcFill.fillFromTOTP = async function(target) {
 // Fill TOTP with matching uuid
 kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
     if (!el || !uuid) {
+        debugLog('Error: Element or uuid is empty');
         return;
     }
 
     const user = kpxc.credentials.find(c => c.uuid === uuid);
     if (!user) {
+        debugLog('Error: No user found with uuid: ' + uuid);
         return;
     }
 
@@ -166,6 +173,7 @@ kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
 // Set normal or segmented TOTP value
 kpxcFill.setTOTPValue = function(elem, val) {
     if (kpxc.combinations.length === 0) {
+        debugLog('Error: Credential list is empty.');
         return;
     }
 
@@ -194,6 +202,7 @@ kpxcFill.fillSegmentedTotp = function(elem, val, totpInputs) {
 kpxcFill.fillFromUsernameIcon = async function(combination) {
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
+        debugLog('Error: Credential list is empty.');
         return;
     } else if (kpxc.credentials.length > 1 && kpxc.settings.autoCompleteUsernames) {
         kpxcUserAutocomplete.showList(combination.username || combination.password);
@@ -218,6 +227,7 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     }
 
     if (!combination || (!combination.username && !combination.password)) {
+        debugLog('Error: Empty login combination.');
         return;
     }
 
@@ -231,7 +241,7 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     // Find the correct credentials
     const selectedCredentials = kpxc.credentials.find(c => c.uuid === uuid);
     if (!selectedCredentials) {
-        console.log('Error: Uuid not found: ', uuid);
+        showErrorMessage('Uuid not found: ' + uuid);
         return;
     }
 

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -146,7 +146,7 @@ kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
 
     const user = kpxc.credentials.find(c => c.uuid === uuid);
     if (!user) {
-        logDebug('Error: No user found with uuid: ' + uuid);
+        logDebug('Error: No entry found with uuid: ' + uuid);
         return;
     }
 

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -24,7 +24,7 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 // Fill requested from the context menu. Active element is used for combination detection
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
     if (kpxc.credentials.length === 0) {
-        debugLog('Error: Credential list is empty.');
+        logDebug('Error: Credential list is empty.');
         return;
     }
 
@@ -33,13 +33,13 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
             ? kpxc.combinations.find(c => c.password)
             : kpxc.combinations.find(c => c.username);
         if (!combination) {
-            debugLog('Error: No combination found.');
+            logDebug('Error: No combination found.');
             return;
         }
 
         const field = passOnly ? combination.password : combination.username;
         if (!field) {
-            debugLog('Error: No input field found.');
+            logDebug('Error: No input field found.');
             return;
         }
 
@@ -82,7 +82,7 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
 // Fill requested by Auto-Fill
 kpxcFill.fillFromAutofill = async function() {
     if (kpxc.credentials.length !== 1 || kpxc.combinations.length === 0) {
-        debugLog('Error: Credential list is empty or contains more than one entry.');
+        logDebug('Error: Credential list is empty or contains more than one entry.');
         return;
     }
 
@@ -97,14 +97,14 @@ kpxcFill.fillFromAutofill = async function() {
 // Fill requested by selecting credentials from the popup
 kpxcFill.fillFromPopup = async function(id, uuid) {
     if (!kpxc.credentials.length === 0 || !kpxc.credentials[id] || kpxc.combinations.length === 0) {
-        debugLog('Error: Credential list is empty.');
+        logDebug('Error: Credential list is empty.');
         return;
     }
 
     await sendMessage('page_set_login_id', uuid);
     const selectedCredentials = kpxc.credentials.find(c => c.uuid === uuid);
     if (!selectedCredentials) {
-        showErrorMessage('Uuid not found: ', uuid);
+        logError('Uuid not found: ', uuid);
         return;
     }
 
@@ -140,13 +140,13 @@ kpxcFill.fillFromTOTP = async function(target) {
 // Fill TOTP with matching uuid
 kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
     if (!el || !uuid) {
-        debugLog('Error: Element or uuid is empty');
+        logDebug('Error: Element or uuid is empty');
         return;
     }
 
     const user = kpxc.credentials.find(c => c.uuid === uuid);
     if (!user) {
-        debugLog('Error: No user found with uuid: ' + uuid);
+        logDebug('Error: No user found with uuid: ' + uuid);
         return;
     }
 
@@ -173,7 +173,7 @@ kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
 // Set normal or segmented TOTP value
 kpxcFill.setTOTPValue = function(elem, val) {
     if (kpxc.combinations.length === 0) {
-        debugLog('Error: Credential list is empty.');
+        logDebug('Error: Credential list is empty.');
         return;
     }
 
@@ -202,7 +202,7 @@ kpxcFill.fillSegmentedTotp = function(elem, val, totpInputs) {
 kpxcFill.fillFromUsernameIcon = async function(combination) {
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
-        debugLog('Error: Credential list is empty.');
+        logDebug('Error: Credential list is empty.');
         return;
     } else if (kpxc.credentials.length > 1 && kpxc.settings.autoCompleteUsernames) {
         kpxcUserAutocomplete.showList(combination.username || combination.password);
@@ -227,7 +227,7 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     }
 
     if (!combination || (!combination.username && !combination.password)) {
-        debugLog('Error: Empty login combination.');
+        logDebug('Error: Empty login combination.');
         return;
     }
 
@@ -241,7 +241,7 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     // Find the correct credentials
     const selectedCredentials = kpxc.credentials.find(c => c.uuid === uuid);
     if (!selectedCredentials) {
-        showErrorMessage('Uuid not found: ' + uuid);
+        logError('Uuid not found: ' + uuid);
         return;
     }
 

--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -61,12 +61,14 @@ kpxcForm.getFormSubmitButton = function(form) {
         }
     }
 
+    debugLog('No form submit button found.');
     return undefined;
 };
 
 // Retrieve new password from a form with three elements: Current, New, Repeat New
 kpxcForm.getNewPassword = function(passwordInputs = []) {
     if (passwordInputs.length < 2) {
+        debugLog('Error: Not enough input fields to detect possible new password.')
         return '';
     }
 
@@ -85,12 +87,14 @@ kpxcForm.getNewPassword = function(passwordInputs = []) {
         return newPass;
     }
 
+    debugLog('Error: No valid new password found.');
     return '';
 };
 
 // Initializes form and attaches the submit button to our own callback
 kpxcForm.init = function(form, credentialFields) {
     if (!form.action || typeof form.action !== 'string') {
+        debugLog('Error: Form action is not found.');
         return;
     }
 
@@ -132,6 +136,7 @@ kpxcForm.onSubmit = async function(e) {
     }
 
     if (!form) {
+        debugLog('Error: No form found for submit detection.');
         return;
     }
 

--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -61,14 +61,14 @@ kpxcForm.getFormSubmitButton = function(form) {
         }
     }
 
-    debugLog('No form submit button found.');
+    logDebug('No form submit button found.');
     return undefined;
 };
 
 // Retrieve new password from a form with three elements: Current, New, Repeat New
 kpxcForm.getNewPassword = function(passwordInputs = []) {
     if (passwordInputs.length < 2) {
-        debugLog('Error: Not enough input fields to detect possible new password.')
+        logDebug('Error: Not enough input fields to detect possible new password.')
         return '';
     }
 
@@ -87,14 +87,14 @@ kpxcForm.getNewPassword = function(passwordInputs = []) {
         return newPass;
     }
 
-    debugLog('Error: No valid new password found.');
+    logDebug('Error: No valid new password found.');
     return '';
 };
 
 // Initializes form and attaches the submit button to our own callback
 kpxcForm.init = function(form, credentialFields) {
     if (!form.action || typeof form.action !== 'string') {
-        debugLog('Error: Form action is not found.');
+        logDebug('Error: Form action is not found.');
         return;
     }
 
@@ -136,7 +136,7 @@ kpxcForm.onSubmit = async function(e) {
     }
 
     if (!form) {
-        debugLog('Error: No form found for submit detection.');
+        logDebug('Error: No form found for submit detection.');
         return;
     }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -279,7 +279,7 @@ kpxc.initCombinations = async function(inputs = []) {
         }
     }
 
-    debugLog('Login field combinations identified:', combinations);
+    logDebug('Login field combinations identified:', combinations);
     return combinations;
 };
 
@@ -431,7 +431,7 @@ kpxc.passwordFilledWithExceptions = async function(currentForm) {
 // Prepares autocomplete and login popup ready for user interaction
 kpxc.prepareCredentials = async function() {
     if (kpxc.credentials.length === 0) {
-        debugLog('Error: No combination found.');
+        logDebug('Error: No combination found.');
         return;
     }
 
@@ -455,7 +455,7 @@ kpxc.prepareCredentials = async function() {
 kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue, oldCredentials, useBanner = true) {
     const credentials = (oldCredentials !== undefined && oldCredentials.length > 0) ? oldCredentials : kpxc.credentials;
     if (passwordValue === '') {
-        debugLog('Error: Empty password.');
+        logDebug('Error: Empty password.');
         return undefined;
     }
 
@@ -534,7 +534,7 @@ kpxc.rememberCredentialsFromContextMenu = async function() {
     const type = el.getAttribute('type');
     const combination = await kpxcFields.getCombination(el, (type === 'password' ? type : 'username'));
     if (!combination) {
-        debugLog('Error: No combination found.');
+        logDebug('Error: No combination found.');
         return;
     }
 
@@ -595,7 +595,7 @@ kpxc.receiveCredentialsIfNecessary = async function() {
         // Sets triggerUnlock to true
         const credentials = await sendMessage('retrieve_credentials', [ kpxc.url, kpxc.submitUrl, true ]);
         if (credentials.length === 0) {
-            debugLog('Error: No credentials found.');
+            logDebug('Error: No credentials found.');
             return [];
         }
 
@@ -706,7 +706,7 @@ kpxc.updateTOTPList = async function() {
     let uuid = await sendMessage('page_get_login_id');
     if (uuid === undefined || kpxc.credentials.length === 0) {
         // Credential haven't been selected
-        debugLog('Error: No credentials selected for TOTP.');
+        logDebug('Error: No credentials selected for TOTP.');
         return;
     }
 
@@ -740,14 +740,14 @@ const initContentScript = async function() {
     try {
         const settings = await sendMessage('load_settings');
         if (!settings) {
-            showErrorMessage('Error: Cannot load extension settings');
+            logError('Error: Cannot load extension settings');
             return;
         }
 
         kpxc.settings = settings;
 
         if (await kpxc.siteIgnored()) {
-            debugLog('This site is ignored in Site Preferences.');
+            logDebug('This site is ignored in Site Preferences.');
             return;
         }
 
@@ -777,7 +777,7 @@ const initContentScript = async function() {
             kpxc.rememberCredentials(creds.username, creds.password, creds.url, creds.oldCredentials);
         }
     } catch (err) {
-        showErrorMessage('initContentScript error: ' + err);
+        logError('initContentScript error: ' + err);
     }
 };
 
@@ -792,7 +792,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
     if ('action' in req) {
         // Don't allow any actions if the site is ignored
         if (await kpxc.siteIgnored()) {
-            debugLog('This site is ignored in Site Preferences.');
+            logDebug('This site is ignored in Site Preferences.');
             return;
         }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -279,6 +279,7 @@ kpxc.initCombinations = async function(inputs = []) {
         }
     }
 
+    debugLog('Login field combinations identified:', combinations);
     return combinations;
 };
 
@@ -430,6 +431,7 @@ kpxc.passwordFilledWithExceptions = async function(currentForm) {
 // Prepares autocomplete and login popup ready for user interaction
 kpxc.prepareCredentials = async function() {
     if (kpxc.credentials.length === 0) {
+        debugLog('Error: No combination found.');
         return;
     }
 
@@ -453,6 +455,7 @@ kpxc.prepareCredentials = async function() {
 kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue, oldCredentials, useBanner = true) {
     const credentials = (oldCredentials !== undefined && oldCredentials.length > 0) ? oldCredentials : kpxc.credentials;
     if (passwordValue === '') {
+        debugLog('Error: Empty password.');
         return undefined;
     }
 
@@ -531,6 +534,7 @@ kpxc.rememberCredentialsFromContextMenu = async function() {
     const type = el.getAttribute('type');
     const combination = await kpxcFields.getCombination(el, (type === 'password' ? type : 'username'));
     if (!combination) {
+        debugLog('Error: No combination found.');
         return;
     }
 
@@ -591,6 +595,7 @@ kpxc.receiveCredentialsIfNecessary = async function() {
         // Sets triggerUnlock to true
         const credentials = await sendMessage('retrieve_credentials', [ kpxc.url, kpxc.submitUrl, true ]);
         if (credentials.length === 0) {
+            debugLog('Error: No credentials found.');
             return [];
         }
 
@@ -701,6 +706,7 @@ kpxc.updateTOTPList = async function() {
     let uuid = await sendMessage('page_get_login_id');
     if (uuid === undefined || kpxc.credentials.length === 0) {
         // Credential haven't been selected
+        debugLog('Error: No credentials selected for TOTP.');
         return;
     }
 
@@ -734,13 +740,14 @@ const initContentScript = async function() {
     try {
         const settings = await sendMessage('load_settings');
         if (!settings) {
-            console.log('Error: Cannot load extension settings');
+            showErrorMessage('Error: Cannot load extension settings');
             return;
         }
 
         kpxc.settings = settings;
 
         if (await kpxc.siteIgnored()) {
+            debugLog('This site is ignored in Site Preferences.');
             return;
         }
 
@@ -770,7 +777,7 @@ const initContentScript = async function() {
             kpxc.rememberCredentials(creds.username, creds.password, creds.url, creds.oldCredentials);
         }
     } catch (err) {
-        console.log('initContentScript error: ', err);
+        showErrorMessage('initContentScript error: ' + err);
     }
 };
 
@@ -785,6 +792,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
     if ('action' in req) {
         // Don't allow any actions if the site is ignored
         if (await kpxc.siteIgnored()) {
+            debugLog('This site is ignored in Site Preferences.');
             return;
         }
 

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -181,6 +181,7 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
         }
     }
 
+    debugLog('Input fields found:', inputs);
     return inputs;
 };
 

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -181,7 +181,7 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
         }
     }
 
-    debugLog('Input fields found:', inputs);
+    logDebug('Input fields found:', inputs);
     return inputs;
 };
 

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -75,6 +75,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
             || field.placeholder.match(ignoreRegex)
             || field.readOnly
             || field.inputMode === 'email') {
+            debugLog('Error: TOTP field found but it is not valid:', field);
             return false;
         }
     } else {

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -75,7 +75,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
             || field.placeholder.match(ignoreRegex)
             || field.readOnly
             || field.inputMode === 'email') {
-            debugLog('Error: TOTP field found but it is not valid:', field);
+            logDebug('Error: TOTP field found but it is not valid:', field);
             return false;
         }
     } else {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -40,7 +40,7 @@ class Icon {
                 kpxcUI.updateFromIntersectionObserver(this, entries);
             });
         } catch (err) {
-            showErrorMessage(err);
+            logError(err);
         }
     }
 
@@ -210,7 +210,7 @@ kpxcUI.createNotification = function(type, message) {
         return;
     }
 
-    debugLog(message);
+    logDebug(message);
 
     const notification = kpxcUI.createElement('div', 'kpxc-notification kpxc-notification-' + type, {});
     type = type.charAt(0).toUpperCase() + type.slice(1) + '!';
@@ -274,9 +274,9 @@ const createStylesheet = function(file) {
     return stylesheet;
 };
 
-const debugLog = function(message, extra) {
+const logDebug = function(message, extra) {
     if (kpxc.settings.debugLogging) {
-        showDebugMessage(message, extra);
+        debugLogMessage(message, extra);
     }
 };
 
@@ -340,7 +340,7 @@ Element.prototype.attachShadow = function () {
     try {
         return this._attachShadow({ mode: 'closed' });
     } catch (e) {
-        showErrorMessage(e);
+        logError(e);
     }
 };
 

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -40,7 +40,7 @@ class Icon {
                 kpxcUI.updateFromIntersectionObserver(this, entries);
             });
         } catch (err) {
-            console.log(err);
+            showErrorMessage(err);
         }
     }
 
@@ -210,6 +210,8 @@ kpxcUI.createNotification = function(type, message) {
         return;
     }
 
+    debugLog(message);
+
     const notification = kpxcUI.createElement('div', 'kpxc-notification kpxc-notification-' + type, {});
     type = type.charAt(0).toUpperCase() + type.slice(1) + '!';
 
@@ -272,6 +274,12 @@ const createStylesheet = function(file) {
     return stylesheet;
 };
 
+const debugLog = function(message, extra) {
+    if (kpxc.settings.debugLogging) {
+        showDebugMessage(message, extra);
+    }
+};
+
 // Enables dragging
 document.addEventListener('mousemove', function(e) {
     if (!kpxcUI.mouseDown) {
@@ -332,7 +340,7 @@ Element.prototype.attachShadow = function () {
     try {
         return this._attachShadow({ mode: 'closed' });
     } catch (e) {
-        console.log('Error: ', e);
+        showErrorMessage(e);
     }
 };
 

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -43,7 +43,7 @@
               <li class="nav-item"><a class="nav-link text-light rounded-sm" href="#about" tabindex="5"><i class="fa fa-info-circle fa-lg pr-2" aria-hidden="true"></i><span data-i18n="optionsMenuAbout"></span></a></li>
             </ul>
             <footer class="d-none d-md-flex px-3 mt-4 mb-1 text-uppercase position-absolute small text-muted">
-              (C) 2017-2021 - KeePassXC Team
+              (C) 2017-2022 - KeePassXC Team
             </footer>
           </div>
         </nav>
@@ -381,11 +381,21 @@
                   <!-- Clear credential timeout -->
                   <div class="form-group">
                     <form>
-                    <label for="clearCredentialTimeout" data-i18n="optionsClearCredentialsTimeout"></label>
-                    <br />
-                    <input class="form-input" type="number" id="clearCredentialTimeout" min="0" max="3600" required/>
-                    <span class="form-text text-muted" data-i18n="optionsClearCredentialsTimeoutHelpText"></span>
-                  </form>
+                      <label for="clearCredentialTimeout" data-i18n="optionsClearCredentialsTimeout"></label>
+                      <div class="form-check">
+                        <input class="form-input" type="number" id="clearCredentialTimeout" min="0" max="3600" required/>
+                        <span class="form-text text-muted" data-i18n="optionsClearCredentialsTimeoutHelpText"></span>
+                      </div>
+                    </form>
+                  </div>
+
+                  <!-- Debug logging -->
+                  <div class="form-group">
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" name="debugLogging" id="debugLogging" value="false" />
+                      <label class="form-check-label" for="debugLogging" data-i18n="optionsDebugLogging"></label>
+                      <span class="form-text text-muted" data-i18n="optionsDebugLoggingHelpText"></span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -109,6 +109,6 @@ $(async () => {
     statusResponse(await browser.runtime.sendMessage({
         action: 'get_status'
     }).catch((err) => {
-        showErrorMessage('Could not get status: ' + err);
+        logError('Could not get status: ' + err);
     }));
 });

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -109,6 +109,6 @@ $(async () => {
     statusResponse(await browser.runtime.sendMessage({
         action: 'get_status'
     }).catch((err) => {
-        console.log('Error: Could not get status: ' + err);
+        showErrorMessage('Could not get status: ' + err);
     }));
 });


### PR DESCRIPTION
Adds debug logging to the extension, mainly focusing on additional information on content scripts. Debug info contains all input fields detected on the page, plus the combinations sorted by the extension.

Option is disabled by default.