### PR TITLE
fix "Reload" button unaccessible from pinned popup

### DIFF
--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -30,12 +30,12 @@
       </div>
 
       <div id="initial-state">
-        <div class="loader"></div> <span data-i18n="popupCheckingStatus"></span>
+         <div class="loader"></div> <span data-i18n="popupCheckingStatus"></span>
       </div>
 
       <div id="not-configured" style="display: none">
         <p data-i18n="popupNotConfigured"></p>
-        <div style="text-align: right">
+        <div>
           <button id="connect-button" class="btn btn-sm btn-primary"><i class="fa fa-link" aria-hidden="true"></i> <span data-i18n="popupConnectButton"></span></button>
         </div>
       </div>
@@ -46,7 +46,7 @@
           <code id="need-reconfigure-message"></code>
         </p>
         <p data-i18n="popupNeedReconfigureMessage"></p>
-        <div style="text-align: right">
+        <div>
           <button id="reconnect-button" class="btn btn-sm btn-primary"><i class="fa fa-refresh" aria-hidden="true"></i> <span data-i18n="popupReconnectButton"></span></button>
         </div>
       </div>
@@ -57,7 +57,7 @@
 
       <div id="configured-and-associated" style="display: none">
         <p data-i18n="popupConfiguredAndAssociated" i18n-placeholder="<span class='bg-success' id='associated-identifier'></span>"></p>
-        <div style="text-align: right">
+        <div>
           <button id="redetect-fields-button" class="btn btn-sm btn-primary"><i class="fa fa-list-alt" aria-hidden="true"></i> <span data-i18n="popupRedetectButton"></span></button>
         </div>
       </div>
@@ -67,7 +67,7 @@
         <p style="margin-left: 1em">
           <code id="error-message"></code>
         </p>
-        <div style="text-align: right">
+        <div>
           <button id="reload-status-button" class="btn btn-sm btn-primary"><i class="fa fa-refresh" aria-hidden="true"></i> <span data-i18n="popupReloadButton"></span></button>
         </div>
       </div>
@@ -77,7 +77,7 @@
         <p style="margin-left: 1em">
           <code id="database-error-message"></code>
         </p>
-        <div style="text-align: right">
+        <div>
           <button id="reopen-database-button" class="btn btn-sm btn-primary"><i class="fa fa-lock" aria-hidden="true"></i> <span data-i18n="popupReopenButton"></span></button>
         </div>
       </div>
@@ -85,7 +85,7 @@
       <div id="username-field-detected" style="display: none">
         <hr />
         <p data-i18n="popupUsernameFieldDetected"></p>
-        <div style="text-align: right">
+        <div>
             <button id="username-only-button" class="btn btn-sm btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <span data-i18n="popupUsernameButton"></span></button>
           </div>
       </div>

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -30,7 +30,7 @@
       </div>
 
       <div id="initial-state">
-        <p><div class="loader"></div> <span data-i18n="popupCheckingStatus"/></p>
+        <div class="loader"></div> <span data-i18n="popupCheckingStatus"></span>
       </div>
 
       <div id="not-configured" style="display: none">


### PR DESCRIPTION
## problem
when the extension is "pinned" to the overflow menu – the popup is constrained within the smaller window, hence not all elements on it are even visibly exist, let alone accessible:
![before](https://user-images.githubusercontent.com/59403389/150673292-515c41a9-0545-408e-876c-927d1cb260fd.png)

and only visible+accessible after pressing [Tab]:
![before onKey Tab](https://user-images.githubusercontent.com/59403389/150673368-fcf94217-58b7-46f9-83ea-a01cfd5b27d9.png)

## solution
just **_don't_** align buttons to the right for "esthetic" reasons:

![after](https://user-images.githubusercontent.com/59403389/150673376-8ef508a3-f96f-4eee-9faf-3231e590ec29.png)
