### PR TITLE
Fix disabled OTP icons - they are never added

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -64,6 +64,9 @@ kpxcFields.getAllCombinations = async function(inputs) {
 
 // Adds segmented TOTP fields to the combination if found
 kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
+    if (!kpxc.settings.showOTPIcon) {
+        return;
+    }
     const addTotpFieldsToCombination = function(inputFields) {
         const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password');
         if (totpInputs.length === 6) {


### PR DESCRIPTION
When the checkbox **Activate 2FA/OTP field icons.** in settings is deactivated, there are some cases, when green TOTP icon with bubble shows up. This fixes that behaviour.
There may be better places to put this check, but this works fine (although change in settings needs page refresh for TOTP bubble to show up).