### PR TITLE
Fix filling TOTP to fields not in combinations

### DIFF
--- a/keepassxc-browser/content/totp-autocomplete.js
+++ b/keepassxc-browser/content/totp-autocomplete.js
@@ -16,7 +16,7 @@ TOTPAutocomplete.prototype.itemClick = async function(e, input, uuid) {
     }
 
     const index = Array.prototype.indexOf.call(e.currentTarget.parentElement.childNodes, e.currentTarget);
-    this.fillTotp(index, uuid);
+    await this.fillTotp(index, uuid, input);
 
     this.closeList();
     input.focus();
@@ -26,11 +26,14 @@ TOTPAutocomplete.prototype.itemEnter = async function(index, elements) {
     this.fillTotp(index, elements[index].uuid);
 };
 
-TOTPAutocomplete.prototype.fillTotp = async function(index, uuid) {
+TOTPAutocomplete.prototype.fillTotp = async function(index, uuid, currentInput) {
     const combination = await kpxcFields.getCombination(this.input, 'totp')
                      || await kpxcFields.getCombination(this.input, 'totpInputs');
-    combination.loginId = index;
-    kpxcFill.fillTOTPFromUuid(this.input, uuid);
+    if (combination) {
+        combination.loginId = index;
+    }
+
+    kpxcFill.fillTOTPFromUuid(this.input || currentInput, uuid);
 };
 
 const kpxcTOTPAutocomplete = new TOTPAutocomplete();


### PR DESCRIPTION
Found a bug where filling TOTP might not work in cases where the field is not regognized as a part of any current input field combination. In these cases the current input field is used.
This fix should allow filling TOTP to the field user has selected. Also, `await` was missing from the fill call causing `this.input` to be undefined in some cases.

Fixes.. probably a few TOTP bugs.