### PR TITLE
Allow filling password for non-detected fields and combinations

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -23,6 +23,7 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 
 // Fill requested from the context menu. Active element is used for combination detection
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
+    await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
         logDebug('Error: Credential list is empty.');
         return;
@@ -37,13 +38,7 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
 
     // No previous combinations detected. Create a new one from active element
     const el = document.activeElement;
-    const combination = await kpxc.createCombination(el);
-
-    // Do not allow filling password to a non-password field
-    if (passOnly && combination && !combination.password) {
-        kpxcUI.createNotification('warning', tr('fieldsNoPasswordField'));
-        return;
-    }
+    const combination = await kpxc.createCombination(el, passOnly);
 
     await sendMessage('page_set_login_id', kpxc.credentials[0].uuid);
     kpxcFill.fillInCredentials(combination, kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -72,15 +72,21 @@ kpxc.clearAllFromPage = function() {
 };
 
 // Creates a new combination manually from active element
-kpxc.createCombination = async function(activeElement) {
+kpxc.createCombination = async function(activeElement, passOnly) {
     const combination = {
         username: null,
         password: null,
         passwordInputs: [],
-        form: activeElement.form
+        form: null
     };
 
-    if (activeElement.getLowerCaseAttribute('type') === 'password') {
+    if (!activeElement) {
+        return combination;
+    }
+
+    combination.form = activeElement.form;
+
+    if (passOnly || activeElement.getLowerCaseAttribute('type') === 'password') {
         combination.password = activeElement;
     } else {
         combination.username = activeElement;


### PR DESCRIPTION
Allows filling password manually from context menu or keyboard shortcut to an input field even if it's not part of any previously detected combination.

Looking at the source, there has to be some logical error in the implementation when filling using a combination. It returns the whole function if a combination is not found and never goes to line 62. Now the function for filling combinations is a separate one, which allows the function to continue even if combination detection fails.

Fixes #1574.