### PR TITLE
Fix Username Icon position on Apple login page

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -183,9 +183,8 @@ kpxcSites.popupExceptionFound = function(combinations) {
  * @param {number} iconSize Size of the icon
  * @returns {array}         New left and top values as an Array
  */
-kpxcSites.iconExceptionFound = function(left, top, iconSize) {
-    if (document.location.hostname.includes('idmsa.apple.com'))
-    {
+kpxcSites.iconOffset = function(left, top, iconSize) {
+    if (document.location.hostname.includes('idmsa.apple.com')) {
         return [ left - (iconSize + 10), top + 3 ];
     }
 

--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -175,3 +175,19 @@ kpxcSites.popupExceptionFound = function(combinations) {
 
     return false;
 };
+
+/**
+ * Handles a few exceptions for certain sites where Username Icon is not placed properly.
+ * @param {number} left     Absolute left position of the icon
+ * @param {number} top      Absolute top position of the icon
+ * @param {number} iconSize Size of the icon
+ * @returns {array}         New left and top values as an Array
+ */
+kpxcSites.iconExceptionFound = function(left, top, iconSize) {
+    if (document.location.hostname.includes('idmsa.apple.com'))
+    {
+        return [ left - (iconSize + 10), top + 3 ];
+    }
+
+    return undefined;
+};

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -130,10 +130,11 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         left += size + 10;
     }
 
-    const iconException = kpxcSites.iconExceptionFound(left, top, size);
-    if (iconException) {
-        left = iconException[0];
-        top = iconException[1];
+    // Adjusts the icon offset for certain sites
+    const iconOffset = kpxcSites.iconOffset(left, top, size);
+    if (iconOffset) {
+        left = iconOffset[0];
+        top = iconOffset[1];
     }
 
     const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -123,11 +123,17 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
     const size = Number(icon.getAttribute('size'));
     const offset = kpxcUI.calculateIconOffset(field, size);
     let left = kpxcUI.bodyStyle.position.toLowerCase() === 'relative' ? rect.left - kpxcUI.bodyRect.left : rect.left;
-    const top = kpxcUI.bodyStyle.position.toLowerCase() === 'relative' ? rect.top - kpxcUI.bodyRect.top : rect.top;
+    let top = kpxcUI.bodyStyle.position.toLowerCase() === 'relative' ? rect.top - kpxcUI.bodyRect.top : rect.top;
 
     // Add more space for the icon to show it at the right side of the field if TOTP fields are segmented
     if (segmented) {
         left += size + 10;
+    }
+
+    const iconException = kpxcSites.iconExceptionFound(left, top, size);
+    if (iconException) {
+        left = iconException[0];
+        top = iconException[1];
     }
 
     const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;


### PR DESCRIPTION
Adds a new exception check in `sites.js` for icon position. Allows us making exceptions for other sites too when needed.

On Apple login page, their submit icon is directly under the extension Username Icon. This moves the icon a little bit so both are accessible.