### PR TITLE
Add a notification when filled password length exceeds field's max length

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -103,6 +103,10 @@
         "message": "No logins found.",
         "description": "No logins found."
     },
+    "errorMessagePaswordLengthExceeded": {
+        "message": "Filled password is longer than field's allowed max length.",
+        "description": "Error notification text shown when filled password is longer than defined maxLength of the input field."
+    },
     "errorNotConnected": {
         "message": "Not connected to KeePassXC.",
         "description": "Error notification shown when not connected to KeePassXC"

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -253,6 +253,11 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
 
     // Fill password
     if (combination.password) {
+        // Show a notification if password length exceeds the length defined in input
+        if (combination.password.maxLength && selectedCredentials.password.length > combination.password.maxLength) {
+            kpxcUI.createNotification('error', tr('errorMessagePaswordLengthExceeded'));
+        }
+
         kpxc.setValueWithChange(combination.password, selectedCredentials.password);
         await kpxc.setPasswordFilled(true);
     }


### PR DESCRIPTION
User should be notified when the filled password is longer than the input field actually accepts.