### PR TITLE
Force text-align with Autocomplete Menu items

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -21,6 +21,7 @@
     letter-spacing: normal !important;
     word-spacing: normal !important;
     text-rendering: auto !important;
+    text-align: start !important;
 }
 
 .kpxcAutocomplete-items div:last-child {


### PR DESCRIPTION
Can be reproduced with Apple login page https://appleid.apple.com/#!&page=signin where Autocomplete Menu items are a actually centered because of the global `body` style.
`text-align` is set to `start` so it's compatible with RTL.