### PR TITLE
Fix password generator with KeePassXC version 2.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.7.12 (07-04-2022)
+=========================
+- Add support for the new password generator with KeePassXC 2.7.0.
+
 1.7.11 (11-12-2021)
 =========================
 - Add new Predefined Sites (FNAC, HP) [#1469]

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -334,11 +334,15 @@ keepass.generatePassword = async function(tab) {
         const kpAction = kpActions.GENERATE_PASSWORD;
         const [ nonce, incrementedNonce ] = keepass.getNonces();
 
-        const request = {
+        const messageData = {
             action: kpAction,
             nonce: nonce,
-            clientID: keepass.clientID
+            clientID: keepass.clientID,
+            requestID: keepass.getRequestId(),
         };
+
+        const request = keepass.buildRequest(kpAction, keepass.encrypt(messageData, nonce), nonce, messageData.clientID);
+        request["requestID"] = messageData.requestID;
 
         const response = await keepass.sendNativeMessage(request);
         if (response.message && response.nonce) {
@@ -900,6 +904,11 @@ keepass.requestAutotype = async function(tab, args = []) {
 keepass.generateNewKeyPair = function() {
     keepass.keyPair = nacl.box.keyPair();
     //console.log(nacl.util.encodeBase64(keepass.keyPair.publicKey) + ' ' + nacl.util.encodeBase64(keepass.keyPair.secretKey));
+};
+
+// Creates a random 8 character string for Request ID
+keepass.getRequestId = function() {
+    return Math.random().toString(16).substring(2, 10);
 };
 
 keepass.isConfigured = async function() {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.7.11",
-    "version_name": "1.7.11",
+    "version": "1.7.12",
+    "version_name": "1.7.12",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
The current extension version does not support launching the password generator with KeePassXC 2.7.0. This fix should support both KeePassXC 2.7.0 and older versions. With 2.6.6 and older, the extension's password generator should be shown instead.

Fixes #1586.