### PR TITLE
Check that maxLength is above zero

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -254,7 +254,9 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     // Fill password
     if (combination.password) {
         // Show a notification if password length exceeds the length defined in input
-        if (combination.password.maxLength && selectedCredentials.password.length > combination.password.maxLength) {
+        if (combination.password.maxLength
+            && combination.password.maxLength > 0
+            && selectedCredentials.password.length > combination.password.maxLength) {
             kpxcUI.createNotification('error', tr('errorMessagePaswordLengthExceeded'));
         }
 


### PR DESCRIPTION
Additional fix to #1596. Input field's `maxLength` can be `-1` in some cases, which passes the current check and gives an incorrect notification.