### PR TITLE
Update build script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -5147,9 +5147,9 @@
       }
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "eslint-plugin-import": "^2.24.2"
   },
   "dependencies": {
-    "file-url": "^3.0.0",
-    "fs-extra": "^8.1.0",
-    "zip-a-folder": "0.0.12"
+    "@npmcli/fs": "^2.1.0",
+    "file-url": "^4.0.0",
+    "zip-a-folder": "^1.1.3"
   },
   "scripts": {
     "build": "node build.js",


### PR DESCRIPTION
Updates the build script:
- Remove dependency to `fs` and `fs-extra`. Use NPM's own `npmcli/fs` instead
- Update package versions. Note that `file-url` is only used for tests.