### PR TITLE
Hide Automatic Reconnect option

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -366,7 +366,7 @@
                   </div>
 
                   <!-- Automatic reconnect -->
-                  <div class="form-group">
+                  <div class="form-group" hidden>
                     <div class="form-check">
                       <input class="form-check-input" type="checkbox" name="autoReconnect" id="autoReconnect" value="true" />
                       <label class="form-check-label" for="autoReconnect" data-i18n="optionsCheckboxAutomaticReconnect"></label>


### PR DESCRIPTION
This option should be hidden for now. It causes more problems than actually solves.
Those who are unaware: the reconnect should happen in the proxy instead. However, mixing threads/signals and sockets causes the proxy to crash, and for now there's no good solution for it. The problem needs to be investigated further.