### PR TITLE
Fix setting icon to all tabs

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -10,7 +10,6 @@ browserAction.show = function(tab, popupData) {
     page.popupData = popupData;
 
     browser.browserAction.setIcon({
-        tabId: tab.id,
         path: browserAction.generateIconName(popupData.iconType)
     });
 


### PR DESCRIPTION
Set icon to all tabs at once, preventing a flash from a previous/default state.

Fixes #1106.