### PR TITLE
Prevent Cross-Origin requests to KeePassXC

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -588,6 +588,14 @@ kpxc.retrieveCredentialsCallback = async function(credentials) {
 // If credentials are not received, request them again
 kpxc.receiveCredentialsIfNecessary = async function() {
     if (kpxc.credentials.length === 0 && !_called.retrieveCredentials) {
+        // Check for Cross-domain security error when inspecting window.top.location.href. We should ignore these requests.
+        try {
+            const currentLocation = window.top.location.href;
+        } catch (err) {
+            logDebug('Error: Credential request ignored from another domain: ', window.self.location.host);
+            return [];
+        }
+
         if (!kpxc.url) {
             kpxc.url = document.location.href;
         }


### PR DESCRIPTION
We are passing credentials requests from another domains to KeePassXC even if the content scripts are not allowed to work inside those frames. This can cause Access Confirmation requests to Google accounts, and can confuse users.

An excellent site to test this is https://twitter.com/ that loads a Google login button to the front page. Without the fix, a confirmation dialog for Google account should trigger when trying to fill username from the extension context menu.