### PR TITLE
Various fixes for 1.8.0 release

### DIFF
--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -331,7 +331,7 @@ function onDisconnected() {
     keepass.associated.hash = null;
     keepass.databaseHash = '';
 
-    page.clearCredentials(page.currentTabId, true);
+    page.clearAllLogins();
     keepass.updatePopup('cross');
     keepass.updateDatabaseHashToContent();
     logError(`Failed to connect: ${(browser.runtime.lastError === null ? 'Unknown error' : browser.runtime.lastError.message)}`);

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -88,7 +88,7 @@ keepass.updateCredentials = async function(tab, args = []) {
         const response = await keepassClient.sendMessage(kpAction, tab, messageData, nonce);
         if (response) {
             // KeePassXC versions lower than 2.5.0 will have an empty parsed.error
-            let successMessage = parsed.error;
+            let successMessage = response.error;
             if (response.error === 'success' || response.error === '') {
                 successMessage = entryId ? 'updated' : 'created';
             }

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -320,13 +320,14 @@ page.retrieveCredentials = async function(tab, args = []) {
 };
 
 page.getLoginId = async function(tab) {
+    const currentTab = page.tabs[tab.id];
+
     // If there's only one credential available and loginId is not set
-    if (page.tabs[tab.id] && !page.tabs[tab.id].loginId
-        && page.tabs[tab.id].credentials.length === 1) {
-        return page.tabs[tab.id].credentials[0].uuid;
+    if (currentTab && !currentTab.loginId && currentTab.credentials.length === 1) {
+        return currentTab.credentials[0].uuid;
     }
 
-    return page.tabs[tab.id] ? page.tabs[tab.id].loginId : undefined;
+    return currentTab ? currentTab.loginId : undefined;
 };
 
 page.setLoginId = async function(tab, loginId) {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -290,7 +290,7 @@ page.createTabEntry = function(tabId) {
         credentials: [],
         errorMessage: null,
         loginList: [],
-        loginId: -1
+        loginId: undefined
     };
 
     page.clearSubmittedCredentials();
@@ -321,10 +321,9 @@ page.retrieveCredentials = async function(tab, args = []) {
 
 page.getLoginId = async function(tab) {
     // If there's only one credential available and loginId is not set
-    if (page.tabs[tab.id] && page.tabs[tab.id].loginId < 0
-        && page.tabs[tab.id]
+    if (page.tabs[tab.id] && !page.tabs[tab.id].loginId
         && page.tabs[tab.id].credentials.length === 1) {
-        return 0; // Index to the first credential
+        return page.tabs[tab.id].credentials[0].uuid;
     }
 
     return page.tabs[tab.id] ? page.tabs[tab.id].loginId : undefined;

--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -34,6 +34,7 @@ const PREDEFINED_SITELIST = [
     'https://idmsa.apple.com/*',
     'https://secure.soundcloud.com/*',
     'https://icloud.com/*',
+    'https://signin.benl.ebay.be/*',
     'https://signin.ebay.de/*',
     'https://signin.ebay.com/*',
     'https://signin.ebay.com.au/*',

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -149,7 +149,8 @@ kpxcFields.getCombination = async function(field, givenType) {
         if (!givenType && Object.values(combination).find(c => c === field)) {
             return combination;
         } else if (givenType && combination[givenType]) {
-            if (combination[givenType] === field || combination[givenType].includes(field)) {
+            if (combination[givenType] === field
+                || (Array.isArray(combination[givenType]) && combination[givenType].includes(field))) {
                 return combination;
             }
         }

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -146,13 +146,14 @@ kpxcFields.getAllPageInputs = async function(previousInputs = []) {
 kpxcFields.getCombination = async function(field, givenType) {
     // If givenType is not set, return the combination that uses the selected field
     for (const combination of kpxc.combinations) {
-        if (!givenType && Object.values(combination).find(c => c === field)) {
-            return combination;
-        } else if (givenType && combination[givenType]) {
-            if (combination[givenType] === field
-                || (Array.isArray(combination[givenType]) && combination[givenType].includes(field))) {
+        if (givenType) {
+            // Strictly search a given type
+            const c = combination[givenType];
+            if (c && (c === field || (Array.isArray(c) && c.includes(field)))) {
                 return combination;
             }
+        } else if (Object.values(combination).find(c => c === field)) {
+            return combination;
         }
     }
 

--- a/keepassxc-browser/content/icons.js
+++ b/keepassxc-browser/content/icons.js
@@ -108,8 +108,10 @@ kpxcIcons.hasIcon = function(field) {
 };
 
 // Sets the icons to corresponding database lock status
-kpxcIcons.switchIcons = function() {
-    kpxcUsernameIcons.switchIcon(kpxc.databaseState);
-    kpxcPasswordIcons.switchIcon(kpxc.databaseState);
-    kpxcTOTPIcons.switchIcon(kpxc.databaseState);
+kpxcIcons.switchIcons = async function() {
+    const uuid = await sendMessage('page_get_login_id');
+
+    kpxcUsernameIcons.switchIcon(kpxc.databaseState, uuid);
+    kpxcPasswordIcons.switchIcon(kpxc.databaseState, uuid);
+    kpxcTOTPIcons.switchIcon(kpxc.databaseState, uuid);
 };

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -696,13 +696,14 @@ kpxc.siteIgnored = async function(condition) {
 // Updates database status and icons when tab is activated again
 kpxc.triggerActivatedTab = async function() {
     await kpxc.updateDatabaseState();
-    kpxcIcons.switchIcons();
 
     if (kpxc.databaseState === DatabaseState.UNLOCKED && kpxc.credentials.length === 0) {
         await kpxc.retrieveCredentials();
     } else if (kpxc.credentials.length > 0) {
         kpxc.initLoginPopup();
     }
+
+    kpxcIcons.switchIcons();
 };
 
 // Updates the database state to the content script

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -139,7 +139,7 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
     }
 
     // Filter out any input fields with type 'hidden' right away
-    const inputFields = [];
+    let inputFields = [];
     Array.from(target.getElementsByTagName('input')).forEach(e => {
         if (e.type !== 'hidden' && !e.disabled && !kpxcObserverHelper.alreadyIdentified(e)) {
             inputFields.push(e);

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -31,8 +31,8 @@ kpxcTOTPIcons.newIcon = function(field, databaseState = DatabaseState.DISCONNECT
     kpxcTOTPIcons.icons.push(new TOTPFieldIcon(field, databaseState, segmented));
 };
 
-kpxcTOTPIcons.switchIcon = function(state) {
-    kpxcTOTPIcons.icons.forEach(u => u.switchIcon(state));
+kpxcTOTPIcons.switchIcon = function(state, uuid) {
+    kpxcTOTPIcons.icons.forEach(u => u.switchIcon(state, uuid));
 };
 
 kpxcTOTPIcons.deleteHiddenIcons = function() {
@@ -127,6 +127,8 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
 
     if (this.databaseState === DatabaseState.DISCONNECTED || this.databaseState === DatabaseState.LOCKED) {
         icon.style.filter = 'saturate(0%)';
+    } else {
+        icon.style.filter = 'saturate(100%)';
     }
 
     icon.addEventListener('click', async function(e) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -44,13 +44,13 @@ class Icon {
         }
     }
 
-    switchIcon(state) {
+    switchIcon(state, uuid) {
         if (!this.icon) {
             return;
         }
 
         if (state === DatabaseState.UNLOCKED) {
-            this.icon.style.filter = kpxc.credentials.length === 0 ? 'saturate(0%)' : 'saturate(100%)';
+            this.icon.style.filter = kpxc.credentials.length === 0 && !uuid ? 'saturate(0%)' : 'saturate(100%)';
         } else {
             this.icon.style.filter = 'saturate(0%)';
         }

--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -122,6 +122,7 @@ code {
 }
 
 #options-button {
+    height: 31px;
     width: 2.5rem;
 }
 


### PR DESCRIPTION
Fixes few minor bugs found on first release test run:
- New upper row popup buttons are different height (Firefox)
- TOTP icon is gray in the second page even when credentials are filled (happened on Mastodon sites). Added a check for previously filled credential UUID. Also fixed UUID returning an integer when it should be string/undefined.
- Icon stayed gray if database was opened on one tab and switched to another tab that has credential. The icon states were updated too soon.

Fixes #1639.