### PR TITLE
Set currentTabId in remove tab.

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -37,11 +37,16 @@ browser.tabs.onCreated.addListener((tab) => {
  * @param {integer} tabId
  * @param {object} removeInfo
  */
-browser.tabs.onRemoved.addListener((tabId, removeInfo) => {
-    delete page.tabs[tabId];
+browser.tabs.onRemoved.addListener(async function(tabId, removeInfo) {
     if (page.currentTabId === tabId) {
-        page.currentTabId = -1;
+        const activeTabs = await browser.tabs.query({ active: true, currentWindow: true });
+        if (activeTabs.length > 0) {
+            page.currentTabId = activeTabs[0].id;
+        } else {
+            page.currentTabId = -1;
+        }
     }
+    delete page.tabs[tabId];
 });
 
 /**


### PR DESCRIPTION
This fixes a bug where two windows of the browser open and a user closes the last tab of a window. This sets the currentTabId to -1. Since the active tab of the remaining window does not change, neither onTabActivated nor onTabUpdated get called such that currentTabId stays at -1. This in turn causes `get_status` messages to fail such that the popup is not initialized properly (see attached screenshot).

![Incorrect popup](https://user-images.githubusercontent.com/42714034/172942654-370c5b29-f680-43fc-b9c8-1fe10beaf5a9.png)

I believe a better fix would to add `await browser.tabs.query({active: true, currentWindow: true})` to https://github.com/keepassxreboot/keepassxc-browser/blob/8beab0e7e8f1b9b8895bc83a9e4e08ee3728c5f1/keepassxc-browser/popups/popup.js#L153 and get rid of page.currentTabId entirely. Please correct me if im wrong, but from what i could tell so far it could be substituted with same approach in the rest of the codebase (https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/background/event.js#L114, https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/background/event.js#L144, and https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/background/client.js#L334). By the way, why does disconnecting clear only the credentials of the *current* tab? Should it not clear all cached credentials?