### PR TITLE
Fixes a bug in Firefox where the Firefox version wasn't being correctly parsed

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -662,7 +662,7 @@ options.initAbout = function() {
     $('#tab-about span.kpxcbrBrowser').textContent = getBrowserId();
 
     // Hides keyboard shortcut configure button if Firefox version is < 60 (API is not compatible)
-    if (isFirefox() && Number(navigator.userAgent.substr(navigator.userAgent.lastIndexOf('/') + 1, 2)) < 60) {
+    if (isFirefox() && Number(navigator.userAgent.substring(navigator.userAgent.lastIndexOf('/') + 1)) < 60) {
         $('#chrome-only').remove();
     }
 };

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -660,11 +660,6 @@ options.initAbout = function() {
     $('#tab-about span.kpxcbrVersion').textContent = version;
     $('#tab-about span.kpxcbrOS').textContent = platform;
     $('#tab-about span.kpxcbrBrowser').textContent = getBrowserId();
-
-    // Hides keyboard shortcut configure button if Firefox version is < 60 (API is not compatible)
-    if (isFirefox() && Number(navigator.userAgent.substring(navigator.userAgent.lastIndexOf('/') + 1)) < 60) {
-        $('#chrome-only').remove();
-    }
 };
 
 options.initTheme = function() {


### PR DESCRIPTION
In Firefox 102.0, the version number was being incorrectly parsed as 10 rather than 102 because only 2 digits were being selected after the final "/"; so the button that enables navigation to the keyboard shortcuts page was being removed. This PR fixes that small bug.