### PR TITLE
Prevent multiple simultaneous submits

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -7,6 +7,7 @@
 const kpxcForm = {};
 kpxcForm.formButtonQuery = 'button[type=button], button[type=submit], input[type=button], input[type=submit], button:not([type]), div[role=button]';
 kpxcForm.savedForms = [];
+kpxcForm.submitTriggered = false;
 
 // Returns true if form has been already saved
 kpxcForm.formIdentified = function(form) {
@@ -116,6 +117,13 @@ kpxcForm.onSubmit = async function(e) {
         return;
     }
 
+    // Prevent multiple simultaneous submits
+    if (!kpxcForm.submitTriggered) {
+        kpxcForm.submitTriggered = true;
+    } else {
+        return;
+    }
+
     const searchForm = f => {
         if (f.nodeName === 'FORM') {
             return f;
@@ -137,6 +145,7 @@ kpxcForm.onSubmit = async function(e) {
 
     if (!form) {
         logDebug('Error: No form found for submit detection.');
+        kpxcForm.submitTriggered = false;
         return;
     }
 
@@ -161,6 +170,7 @@ kpxcForm.onSubmit = async function(e) {
 
     // Return if credentials are already found
     if (kpxc.credentials.some(c => c.login === usernameValue && c.password === passwordValue)) {
+        kpxcForm.submitTriggered = false;
         return;
     }
 
@@ -173,6 +183,7 @@ kpxcForm.onSubmit = async function(e) {
 
     // Show the banner if the page does not reload
     kpxc.rememberCredentials(usernameValue, passwordValue);
+    kpxcForm.submitTriggered = false;
 };
 
 // Save form to Object array

--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -118,11 +118,11 @@ kpxcForm.onSubmit = async function(e) {
     }
 
     // Prevent multiple simultaneous submits
-    if (!kpxcForm.submitTriggered) {
-        kpxcForm.submitTriggered = true;
-    } else {
+    if (kpxcForm.submitTriggered) {
         return;
     }
+
+    kpxcForm.submitTriggered = true;
 
     const searchForm = f => {
         if (f.nodeName === 'FORM') {


### PR DESCRIPTION
With some pages the extension detects both form submit and a submit button. When submit happens, two Credential Banner are created to DOM at the same time, and there's no reliable way to destroy them. The banner cannot be closed and stays on the page unless it's reloaded.

The bug can be reproduced every time when filling credentials to the login fields and pressing Sign On:
https://home.cards.citidirect.com/CommercialCard/login

Fixes #1656.