### PR TITLE
Add more PayPal URLs to predefined sites

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -2,7 +2,10 @@
 
 const PREDEFINED_SITELIST = [
     'https://accounts.google.com/*',
-    'https://www.paypal.com/*/signin',
+    'https://www.paypal.com/*/signin*',
+    'https://www.paypal.com/cgi-bin/webscr*',
+    'https://www.paypal.com/checkoutnow*',
+    'https://www.paypal.com/signin*',
     'https://outlook.live.com/*',
     'https://login.live.com/*',
     'https://odc.officeapps.live.com/*',


### PR DESCRIPTION
See #1672

```
https://www.paypal.com/cgi-bin/webscr*
https://www.paypal.com/checkoutnow*
```
Are URLs for checkout and express checkout sites.

`https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=XYZ&LocaleCode=de_XC` is an example express checkout URL

`https://www.paypal.com/checkoutnow?locale.x=de_DE&fundingSource=paypal&sessionID=xyz&buttonSessionID=xyz&env=production&fundingOffered=paypal&logLevel=warn&sdkMeta=xyz&uid=xyz&version=4.0.303&token=xyz&xcomponent=1` is an example regular checkout URL

```
https://www.paypal.com/*/signin*
https://www.paypal.com/signin*
```
Are URLs for regular login sites.

Closes #1672