### PR TITLE
Fix reconnecting from username icon

### DIFF
--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -123,10 +123,14 @@ const iconClicked = async function(field, icon) {
         return;
     }
 
+    // Try to reconnect if KeePassXC is not currently connected
     const connected = await sendMessage('is_connected');
     if (!connected) {
-        kpxcUI.createNotification('error', tr('errorNotConnected'));
-        return;
+        const reconnectResponse = await sendMessage('reconnect');
+        if (!reconnectResponse.keePassXCAvailable) {
+            kpxcUI.createNotification('error', tr('errorNotConnected'));
+            return;
+        }
     }
 
     const databaseHash = await sendMessage('check_database_hash');


### PR DESCRIPTION
Disabling the Automatic Reconnect for 1.8.0 broke this feature. Now an extra step is added for reconnecting the extension.

Fixes #1675.