### PR TITLE
Fix icon position at transitionend event

### DIFF
--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -105,6 +105,12 @@ kpxcUI.monitorIconPosition = function(iconClass) {
     window.addEventListener('scroll', function(e) {
         kpxcUI.updateIconPosition(iconClass);
     });
+
+    window.addEventListener('transitionend', function(e) {
+        if (e.target && (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA')) {
+            kpxcUI.updateIconPosition(iconClass);
+        }
+    });
 };
 
 kpxcUI.updateIconPosition = function(iconClass) {


### PR DESCRIPTION
Checks `transitionend` event for `input` and `textarea` to update/hide the icons when needed. For performance reasons it's not necessary to check every element that receives the event.

Fixes #1478.