### PR TITLE
Fix setting a global icon on database lock/unlock

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -56,7 +56,6 @@ browserAction.updateIcon = async function(tab, iconType) {
     }
 
     browser.browserAction.setIcon({
-        tabId: tab.id,
         path: browserAction.generateIconName(iconType)
     });
 };


### PR DESCRIPTION
When database was locked or unlocked, the `setIcon()` was using the tab's ID, overriding the global icon that is set when switching tabs. This caused the icon state to be invalid on these tabs where the database status change happened.

Fixes #1689.