### PR TITLE
Ignore hidden inputs with segmented TOTP fields

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -93,7 +93,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         return;
     }
     const addTotpFieldsToCombination = function(inputFields) {
-        const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password');
+        const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden');
         if (totpInputs.length === 6) {
             const combination = {
                 form: form,


### PR DESCRIPTION
Some webpages has hidden fields inside the segmented TOTP fields. Those should be ignored.

Fixes #1688.