### PR TITLE
Allow autofill configuration on a per-credential basis

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -446,10 +446,19 @@ kpxc.prepareCredentials = async function() {
         logDebug('Error: No combination found.');
         return;
     }
-
-    if (kpxc.settings.autoFillSingleEntry && kpxc.credentials.length === 1) {
-        kpxcFill.fillFromAutofill();
-        return;
+    
+    if (kpxc.credentials.length === 1) {
+        let autoFillSingle = kpxc.settings.autoFillSingleEntry;
+        for (const f of kpxc.credentials[0].stringFields) {
+            if (f['KPH: kpxc_allow_autofill'] === '1') {
+                autoFillSingle = true;
+            }
+        }
+        
+        if (autoFillSingle) {
+            kpxcFill.fillFromAutofill();
+            return;
+        }
     }
 
     kpxc.initLoginPopup();


### PR DESCRIPTION
Hey, 
I want to add this small bit functionality to allow configuring auto-fill on a per-credential basis. 
Tested it locally and works as expected. This is using the KPH-prefixed advanced fields which is a but ugly, but it works pretty well to make the parameter easily syncable across multiple devices sharing a single db. 