### PR TITLE
Fix PayPal TOTP

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -115,11 +115,31 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         }
     };
 
+    const formLengthMatches = function(currentForm) {
+        if (!currentForm) {
+            return false;
+        }
+
+        // Accept 6 inputs directly
+        if (currentForm.length === 6) {
+            return true;
+        }
+
+        // 7 inputs with a button as the last one (e.g. PayPal uses this)
+        if (currentForm.length === 7
+            && (currentForm.lastChild.nodeName === 'BUTTON'
+                || (currentForm.lastChild.nodeName === 'INPUT' && currentForm.lastChild.type === 'button'))) {
+            return true;
+        }
+
+        return false;
+    };
+
     const form = inputs.length > 0 ? inputs[0].form : undefined;
     if (form && (acceptedOTPFields.some(f => (form.className && form.className.includes(f))
         || (form.id && typeof(form.id) === 'string' && form.id.includes(f))
         || (form.name && typeof(form.name) === 'string' && form.name.includes(f))
-        || form.length === 6))) {
+        || formLengthMatches(form)))) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements);
     } else if (inputs.length === 6 && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.8.1",
-    "version_name": "1.8.1",
+    "version": "1.8.2",
+    "version_name": "1.8.2",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "KeePassXC-Browser",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
PayPal recently changed their 2FA page to a segmented fields. The form has six inputs plus a button as the last element. This is not currently supported.

Fix also bumps the version number.

Fixes #1703.