### PR TITLE
Fix Steam TOTP

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -139,6 +139,23 @@ kpxcSites.totpExceptionFound = function(field) {
     return false;
 };
 
+/**
+ * Handles a few exceptions for certain sites where segmented 2FA fields are not regognized properly.
+ * @param {object} form     Form Element
+ * @returns {boolean}       True if an Element has a match with the needed indentfifiers and document location
+ */
+kpxcSites.segmentedTotpExceptionFound = function(form) {
+    if (!form || form.nodeName !== 'FORM') {
+        return false;
+    }
+
+    if (document.location.href.startsWith('https://store.steampowered.com') && form.length === 5) {
+        return true;
+    }
+
+    return false;
+};
+
 kpxcSites.expectedTOTPMaxLength = function() {
     if (document.location.origin.startsWith('https://www.amazon')
         && document.location.href.includes('/ap/mfa')) {

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const DEFAULT_SEGMENTED_TOTP_FIELDS = 6;
+
 /**
  * @Object kpxcFields
  * Provides methods for input field handling.
@@ -97,7 +99,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
 
     const addTotpFieldsToCombination = function(inputFields, ignoreLength = false) {
         const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden');
-        if (totpInputs.length === 6 || ignoreLength) {
+        if (totpInputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS || ignoreLength) {
             const combination = {
                 form: form,
                 totpInputs: totpInputs,
@@ -124,7 +126,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         }
 
         // Accept 6 inputs directly
-        if (currentForm.length === 6) {
+        if (currentForm.length === DEFAULT_SEGMENTED_TOTP_FIELDS) {
             return true;
         }
 
@@ -151,7 +153,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         || formLengthMatches(form)))) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements, exceptionFound);
-    } else if (inputs.length === 6 && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
+    } else if (inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
                 || (i.type === 'text' && i.maxLength === 1)
                 || i.type === 'tel')) {
         // No form is found, but input fields are possibly segmented TOTP fields

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -92,9 +92,12 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
     if (!kpxc.settings.showOTPIcon) {
         return;
     }
-    const addTotpFieldsToCombination = function(inputFields) {
+
+    let exceptionFound = false;
+
+    const addTotpFieldsToCombination = function(inputFields, ignoreLength = false) {
         const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden');
-        if (totpInputs.length === 6) {
+        if (totpInputs.length === 6 || ignoreLength) {
             const combination = {
                 form: form,
                 totpInputs: totpInputs,
@@ -132,6 +135,12 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
             return true;
         }
 
+        // Accept any other site-specific exceptions
+        if (kpxcSites.segmentedTotpExceptionFound(currentForm)) {
+            exceptionFound = true;
+            return true;
+        }
+
         return false;
     };
 
@@ -141,7 +150,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         || (form.name && typeof(form.name) === 'string' && form.name.includes(f))
         || formLengthMatches(form)))) {
         // Use the form's elements
-        addTotpFieldsToCombination(form.elements);
+        addTotpFieldsToCombination(form.elements, exceptionFound);
     } else if (inputs.length === 6 && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
                 || (i.type === 'text' && i.maxLength === 1)
                 || i.type === 'tel')) {

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -175,7 +175,7 @@ kpxcFill.setTOTPValue = function(elem, val) {
     }
 
     for (const comb of kpxc.combinations) {
-        if (comb.totpInputs && comb.totpInputs.length === 6) {
+        if (comb.totpInputs && comb.totpInputs.length > 0) {
             kpxcFill.fillSegmentedTotp(elem, val, comb.totpInputs);
             return;
         }
@@ -186,11 +186,11 @@ kpxcFill.setTOTPValue = function(elem, val) {
 
 // Fill TOTP in parts
 kpxcFill.fillSegmentedTotp = function(elem, val, totpInputs) {
-    if (!totpInputs.includes(elem)) {
+    if (!totpInputs.includes(elem) || val.length < totpInputs.length) {
         return;
     }
 
-    for (let i = 0; i < 6; ++i) {
+    for (let i = 0; i < totpInputs.length; ++i) {
         kpxc.setValue(totpInputs[i], val[i]);
     }
 };


### PR DESCRIPTION
Steam also uses a segmented 2FA, but with five alphanumerics instead of six numbers. Some hard-coded requirements for the six char length is changed to a more dynamic implementation when doing the fill.

Needs to be tested properly. Steam locked my account temporarily when making the fix..

Fixes #1710.