### PR TITLE
Remove request ID for backwards compatibility

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -137,8 +137,7 @@ keepass.retrieveCredentials = async function(tab, args = []) {
             action: kpAction,
             id: dbid,
             url: url,
-            keys: keys,
-            requestID: keepassClient.getRequestId()
+            keys: keys
         };
 
         if (submiturl) {


### PR DESCRIPTION
Adding the new `requestID` is not reliable enough with older versions of KeePassXC. Sometimes the message sync just breaks. This needs to be added back with a version check after https://github.com/keepassxreboot/keepassxc/pull/8273 is merged.

If we have plans to merge that PR for 2.7.2, I'll add a version check already to this fix.

Fixes #1713.