### PR TITLE
Fix checkbox colors on light theme

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+1.8.3 (24-10-2022)
+=========================
+- Fix filling TOTP without detecting a input field combination [#1726]
+- Fix saving Custom Login Fields with iframes [#1731]
+- Fix options page checkbox colors [#1722]
+- Fix options page hamburger menu with small resolutions [#1735]
+- Fix hiding a duplicate TOTP entry [#1724]
+- Fix detecting submit button on Microsoft Login page [#1741]
+
 1.8.2.2 (11-09-2022)
 =========================
 - Add support for new Access Confirm Dialog with KeePassXC 2.7.2 [#1719]

--- a/keepassxc-browser/css/colors.css
+++ b/keepassxc-browser/css/colors.css
@@ -4,6 +4,7 @@
     --kpxc-card-border-color: rgba(0,0,0,.125);
     --kpxc-card-header-color: #fafafa;
     --kpxc-checkbox-color: #5b5b5d;
+    --kpxc-checkbox-background-color: #2b2a2a;
     --kpxc-container-border: 1px solid #ccc;
     --kpxc-input-active-border-color: #2b4d1a;
     --kpxc-input-background-color: #fff;
@@ -26,6 +27,7 @@
         --kpxc-card-border-color: #292a2a;
         --kpxc-card-header-color: #27272a;
         --kpxc-checkbox-color: #3b3b3d;
+        --kpxc-checkbox-background-color: #5b5b5d;
         --kpxc-container-border: 1px solid #000;
         --kpxc-input-active-border-color: #2b4d1a;
         --kpxc-input-background-color: #27272a;
@@ -48,6 +50,7 @@
     --kpxc-card-border-color: #292a2a;
     --kpxc-card-header-color: #27272a;
     --kpxc-checkbox-color: #3b3b3d;
+    --kpxc-checkbox-background-color: #2b2a2a;
     --kpxc-container-border: 1px solid #000;
     --kpxc-input-active-border-color: #2b4d1a;
     --kpxc-input-background-color: #27272a;
@@ -68,6 +71,7 @@
     --kpxc-card-border-color: rgba(0,0,0,.125);
     --kpxc-card-header-color: #fafafa;
     --kpxc-checkbox-color: #5b5b5d;
+    --kpxc-checkbox-background-color: #5b5b5d;
     --kpxc-container-border: 1px solid #ccc;
     --kpxc-input-active-border-color: #2b4d1a;
     --kpxc-input-background-color: #fff;

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.8.2.2",
-    "version_name": "1.8.2.2",
+    "version": "1.8.3",
+    "version_name": "1.8.3",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/options/options.css
+++ b/keepassxc-browser/options/options.css
@@ -102,6 +102,10 @@ tbody {
     color: var(--kpxc-text-color) !important;
 }
 
+.table-striped > tbody > tr:nth-of-type(odd) .form-check-input:checked {
+    background-color: var(--kpxc-checkbox-background-color) !important;
+}
+
 .table tbody td {
     vertical-align: middle;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.2.2",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "KeePassXC-Browser",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.2.2",
+  "version": "1.8.3",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
On light theme checkbox background is set to a value that hides the checked/unchecked state on odd table rows. A new CSS variable is added to fix this.

Fixes #1720.