### PR TITLE
Hide duplicate TOTP entry

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -388,6 +388,14 @@ kpxc.initLoginPopup = function() {
     const loginItems = [];
     for (let i = 0; i < kpxc.credentials.length; i++) {
         const loginItem = getLoginItem(kpxc.credentials[i], showGroupNameInAutocomplete, i);
+
+        // Ignore a duplicate entry if the password is empty, but there's already a similar entry with a password.
+        // An usual use case with TOTP in a separate database.
+        const similarEntryFound = kpxc.credentials.some(c => c.password !== '' && c.login === loginItem.login);
+        if (kpxc.credentials[i].password === '' && similarEntryFound) {
+            continue;
+        }
+
         loginItems.push(loginItem);
     }
 


### PR DESCRIPTION
In a use case where TOTP is retrieved from another database and credentials are "linked" during the fill, Autocomplete Menu on username field can show duplicate credentials, but the first one is with an empty password.

The fix makes sure the entry with an empty password is hidden if another entry with identical username is already found with a password.