### PR TITLE
Allow filling TOTP without a combination

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -169,7 +169,7 @@ kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
 
 // Set normal or segmented TOTP value
 kpxcFill.setTOTPValue = function(elem, val) {
-    if (kpxc.combinations.length === 0) {
+    if (kpxc.credentials.length === 0) {
         logDebug('Error: Credential list is empty.');
         return;
     }


### PR DESCRIPTION
At some pages there's no combination detected for the TOTP. It should still be able to fill using the context menu.

Fixes #1649.