### PR TITLE
Automatically reconnect on keyboard shortcuts

### DIFF
--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -194,18 +194,3 @@ HTMLElement.prototype.show = function() {
 HTMLElement.prototype.hide = function() {
     this.style.display = 'none';
 };
-
-// automatically reconnect to KeePassXC
-// returns true if reconnected
-async function reconnect() {
-    // Try to reconnect if KeePassXC is not currently connected
-    const connected = await sendMessage('is_connected');
-    if (!connected) {
-        const reconnectResponse = await sendMessage('reconnect');
-        if (!reconnectResponse.keePassXCAvailable) {
-            kpxcUI.createNotification('error', tr('errorNotConnected'));
-            return false;
-        }
-    }
-    return true;
-}

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -194,3 +194,18 @@ HTMLElement.prototype.show = function() {
 HTMLElement.prototype.hide = function() {
     this.style.display = 'none';
 };
+
+// automatically reconnect to KeePassXC
+// returns true if reconnected
+async function reconnect() {
+    // Try to reconnect if KeePassXC is not currently connected
+    const connected = await sendMessage('is_connected');
+    if (!connected) {
+        const reconnectResponse = await sendMessage('reconnect');
+        if (!reconnectResponse.keePassXCAvailable) {
+            kpxcUI.createNotification('error', tr('errorNotConnected'));
+            return false;
+        }
+    }
+    return true;
+}

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -833,28 +833,20 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
         } else if (req.action === 'clear_credentials') {
             kpxc.clearAllFromPage();
         } else if (req.action === 'fill_user_pass_with_specific_login') {
-            try {
-                await kpxc.reconnect();
-            } catch (_) {}
+            await kpxc.reconnect();
             kpxcFill.fillFromPopup(req.id, req.uuid);
         } else if (req.action === 'fill_username_password') {
-            try {
-                await kpxc.reconnect();
-            } catch (_) {}
+            await kpxc.reconnect();
             sendMessage('page_set_manual_fill', ManualFill.BOTH);
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillInFromActiveElement();
         } else if (req.action === 'fill_password') {
-            try {
-                await kpxc.reconnect();
-            } catch (_) {}
+            await kpxc.reconnect();
             sendMessage('page_set_manual_fill', ManualFill.PASSWORD);
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillInFromActiveElement(true); // passOnly to true
         } else if (req.action === 'fill_totp') {
-            try {
-                await kpxc.reconnect();
-            } catch (_) {}
+            await kpxc.reconnect();
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillFromTOTP();
         } else if (req.action === 'fill_attribute' && req.args) {
@@ -883,7 +875,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
 });
 
 // automatically reconnect to KeePassXC
-// returns true if reconnected
+// returns true if connected afterwards
 kpxc.reconnect = async function() {
     // Try to reconnect if KeePassXC is not currently connected
     const connected = await sendMessage('is_connected');
@@ -891,9 +883,7 @@ kpxc.reconnect = async function() {
         const reconnectResponse = await sendMessage('reconnect');
         if (!reconnectResponse.keePassXCAvailable) {
             kpxcUI.createNotification('error', tr('errorNotConnected'));
-            throw "not connected";
         }
-        return true;
     }
-    return false;
-}
+    return await sendMessage('is_connected');
+};

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -833,16 +833,20 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
         } else if (req.action === 'clear_credentials') {
             kpxc.clearAllFromPage();
         } else if (req.action === 'fill_user_pass_with_specific_login') {
+            await reconnect();
             kpxcFill.fillFromPopup(req.id, req.uuid);
         } else if (req.action === 'fill_username_password') {
+            await reconnect();
             sendMessage('page_set_manual_fill', ManualFill.BOTH);
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillInFromActiveElement();
         } else if (req.action === 'fill_password') {
+            await reconnect();
             sendMessage('page_set_manual_fill', ManualFill.PASSWORD);
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillInFromActiveElement(true); // passOnly to true
         } else if (req.action === 'fill_totp') {
+            await reconnect();
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillFromTOTP();
         } else if (req.action === 'fill_attribute' && req.args) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -874,7 +874,7 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
     }
 });
 
-// automatically reconnect to KeePassXC
+// Automatically reconnect to KeePassXC
 // returns true if connected afterwards
 kpxc.reconnect = async function() {
     // Try to reconnect if KeePassXC is not currently connected

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -883,7 +883,8 @@ kpxc.reconnect = async function() {
         const reconnectResponse = await sendMessage('reconnect');
         if (!reconnectResponse.keePassXCAvailable) {
             kpxcUI.createNotification('error', tr('errorNotConnected'));
+            return false;
         }
     }
-    return await sendMessage('is_connected');
+    return true;
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -137,7 +137,7 @@ const iconClicked = async function(field, icon) {
         field.focus();
     }
 
-    if (icon.className.includes('unlock') || connected) {
+    if (icon.className.includes('unlock')) {
         fillCredentials(field);
     }
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -123,11 +123,9 @@ const iconClicked = async function(field, icon) {
         return;
     }
 
-    // Try to reconnect if KeePassXC is not currently connected
-    let reconnected = false;
-    try {
-        reconnected = await kpxc.reconnect();
-    } catch (_) {
+    // Try to reconnect if KeePassXC for the case we're not currently connected
+    const connected = await kpxc.reconnect();
+    if (!connected) {
         return;
     }
 
@@ -139,7 +137,7 @@ const iconClicked = async function(field, icon) {
         field.focus();
     }
 
-    if (icon.className.includes('unlock') || reconnected) {
+    if (icon.className.includes('unlock') || connected) {
         fillCredentials(field);
     }
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -123,19 +123,8 @@ const iconClicked = async function(field, icon) {
         return;
     }
 
-    let reconnected = false;
-
     // Try to reconnect if KeePassXC is not currently connected
-    const connected = await sendMessage('is_connected');
-    if (!connected) {
-        const reconnectResponse = await sendMessage('reconnect');
-        if (!reconnectResponse.keePassXCAvailable) {
-            kpxcUI.createNotification('error', tr('errorNotConnected'));
-            return;
-        }
-
-        reconnected = true;
-    }
+    let reconnected = await reconnect();
 
     const databaseHash = await sendMessage('check_database_hash');
     if (databaseHash === '') {

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -119,7 +119,7 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
 const iconClicked = async function(field, icon) {
     if (!kpxcFields.isCustomLoginFieldsUsed() && !kpxcFields.isVisible(field)) {
         icon.parentNode.removeChild(icon);
-        field.removeAttribute("kpxc-username-field");
+        field.removeAttribute('kpxc-username-field');
         return;
     }
 
@@ -131,15 +131,15 @@ const iconClicked = async function(field, icon) {
         return;
     }
 
-    const databaseHash = await sendMessage("check_database_hash");
-    if (databaseHash === "") {
+    const databaseHash = await sendMessage('check_database_hash');
+    if (databaseHash === '') {
         // Triggers database unlock
-        await sendMessage("page_set_manual_fill", ManualFill.BOTH);
-        await sendMessage("get_database_hash", [false, true]); // Set triggerUnlock to true
+        await sendMessage('page_set_manual_fill', ManualFill.BOTH);
+        await sendMessage('get_database_hash', [ false, true ]); // Set triggerUnlock to true
         field.focus();
     }
 
-    if (icon.className.includes("unlock") || reconnected) {
+    if (icon.className.includes('unlock') || reconnected) {
         fillCredentials(field);
     }
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -119,22 +119,27 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
 const iconClicked = async function(field, icon) {
     if (!kpxcFields.isCustomLoginFieldsUsed() && !kpxcFields.isVisible(field)) {
         icon.parentNode.removeChild(icon);
-        field.removeAttribute('kpxc-username-field');
+        field.removeAttribute("kpxc-username-field");
         return;
     }
 
     // Try to reconnect if KeePassXC is not currently connected
-    let reconnected = await reconnect();
+    let reconnected = false;
+    try {
+        reconnected = await kpxc.reconnect();
+    } catch (_) {
+        return;
+    }
 
-    const databaseHash = await sendMessage('check_database_hash');
-    if (databaseHash === '') {
+    const databaseHash = await sendMessage("check_database_hash");
+    if (databaseHash === "") {
         // Triggers database unlock
-        await sendMessage('page_set_manual_fill', ManualFill.BOTH);
-        await sendMessage('get_database_hash', [ false, true ]); // Set triggerUnlock to true
+        await sendMessage("page_set_manual_fill", ManualFill.BOTH);
+        await sendMessage("get_database_hash", [false, true]); // Set triggerUnlock to true
         field.focus();
     }
 
-    if (icon.className.includes('unlock') || reconnected) {
+    if (icon.className.includes("unlock") || reconnected) {
         fillCredentials(field);
     }
 };


### PR DESCRIPTION
Relevant issue #1727 

This PR adds calls to a `reconnect()` function when the following actions are fired

- `fill_user_pass_with_specific_login`
- `fill_username_password`
- `fill_password`
- `fill_totp`

The logic for `reconnect()` is identical to that which is used for the onClick listener on the username icon.
