### PR TITLE
Fix saving Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -323,39 +323,41 @@ kpxcCustomLoginFieldsBanner.confirm = async function() {
     const location = kpxc.getDocumentLocation();
     const currentSettings = kpxc.settings[DEFINED_CUSTOM_FIELDS][location];
 
-    if (currentSettings) {
-        // Update the single selection to current settings
-        if (usernamePath) {
-            clearIdenticalField(usernamePath, location);
-            kpxc.settings[DEFINED_CUSTOM_FIELDS][location].username = usernamePath;
+    if (usernamePath || passwordPath || totpPath || stringFieldsPaths.length > 0) {
+        if (currentSettings) {
+            // Update the single selection to current settings
+            if (usernamePath) {
+                clearIdenticalField(usernamePath, location);
+                kpxc.settings[DEFINED_CUSTOM_FIELDS][location].username = usernamePath;
+            }
+
+            if (passwordPath) {
+                clearIdenticalField(passwordPath, location);
+                kpxc.settings[DEFINED_CUSTOM_FIELDS][location].password = passwordPath;
+            }
+
+            if (totpPath) {
+                clearIdenticalField(totpPath, location);
+                kpxc.settings[DEFINED_CUSTOM_FIELDS][location].totp = totpPath;
+            }
+
+            if (stringFieldsPaths.length > 0) {
+                kpxc.settings[DEFINED_CUSTOM_FIELDS][location].fields = stringFieldsPaths;
+            }
+        } else {
+            // Override all fields (default, because there's no currentSettings available)
+            kpxc.settings[DEFINED_CUSTOM_FIELDS][location] = {
+                username: usernamePath,
+                password: passwordPath,
+                totp: totpPath,
+                fields: stringFieldsPaths
+            };
         }
 
-        if (passwordPath) {
-            clearIdenticalField(passwordPath, location);
-            kpxc.settings[DEFINED_CUSTOM_FIELDS][location].password = passwordPath;
-        }
-
-        if (totpPath) {
-            clearIdenticalField(totpPath, location);
-            kpxc.settings[DEFINED_CUSTOM_FIELDS][location].totp = totpPath;
-        }
-
-        if (stringFieldsPaths.length > 0) {
-            kpxc.settings[DEFINED_CUSTOM_FIELDS][location].fields = stringFieldsPaths;
-        }
-    } else {
-        // Override all fields (default)
-        kpxc.settings[DEFINED_CUSTOM_FIELDS][location] = {
-            username: usernamePath,
-            password: passwordPath,
-            totp: totpPath,
-            fields: stringFieldsPaths
-        };
+        await sendMessage('save_settings', kpxc.settings);
     }
 
-    await sendMessage('save_settings', kpxc.settings);
     kpxcCustomLoginFieldsBanner.destroy();
-
     sendMessageToFrames('confirm_button_clicked');
 };
 
@@ -511,7 +513,6 @@ kpxcCustomLoginFieldsBanner.selectStringFields = function() {
 };
 
 kpxcCustomLoginFieldsBanner.markFields = function() {
-    let index = 1;
     let firstInput;
     const inputs = document.querySelectorAll(kpxcCustomLoginFieldsBanner.inputQueryPattern);
 
@@ -567,7 +568,6 @@ kpxcCustomLoginFieldsBanner.markFields = function() {
 
             kpxcCustomLoginFieldsBanner.chooser.append(field);
             firstInput = field;
-            ++index;
         }
     }
 


### PR DESCRIPTION
In some cases other iframes are overriding the current field selection(s) during confirm.

Site for testing: https://www.aa.com/loyalty/login?uri=%2floyalty%2flogin&previousPage=%2fhomePage.do&bookingPathStateId=&marketId=

- When choosing only Username and Password fields, other iframe overrides the changes with empty values -> extension show's a warning that no Custom Login Fields are found.
- After fixing that Username and Password fields could be selected, but if a String Field is selected afterwards, it is overriden by an empty value -> only Username and Password fields are found from Custom Login Fields.

The fix makes sure there must be values before saving anything. Also removed an unused variable.

Fixes #1601.