### PR TITLE
Fix options page hamburger menu

### DIFF
--- a/keepassxc-browser/options/options.css
+++ b/keepassxc-browser/options/options.css
@@ -56,6 +56,7 @@ input[disabled] {
 }
 
 footer {
+    display: none;
     bottom: 1rem;
 }
 
@@ -200,10 +201,18 @@ table td:last-of-type {
     .sidebar {
         height: auto;
     }
+
+    footer {
+        display: block;
+    }
 }
 
 @media (min-width: 1440px) {
     .sidebar {
         width: 240px;
+    }
+
+    footer {
+        display: block;
     }
 }

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -29,7 +29,7 @@
     <div class="container-fluid">
       <div class="row">
         <nav class="col-md-3 col-lg-2 sidebar">
-          <button class="navbar-dark navbar-toggler collapsed d-block d-md-none pt-2" type="button" data-toggle="collapse" data-target="#sidebar" aria-controls="sidebar">
+          <button class="navbar-dark navbar-toggler collapsed d-block d-md-none pt-2" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar">
             <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse d-none d-md-block" id="sidebar">
@@ -66,10 +66,10 @@
                 </a>
               </li>
             </ul>
-            <footer class="px-3 mt-4 mb-1 text-uppercase position-absolute small text-muted">
-              © 2017-2022 - KeePassXC Team
-            </footer>
           </div>
+          <footer class="px-3 mt-4 mb-1 text-uppercase position-absolute small text-muted">
+            © 2017-2022 - KeePassXC Team
+          </footer>
         </nav>
 
         <main class="col-md-9 col-lg-10 offset-md-3 offset-lg-2 px-4 mt-5 mt-md-0">


### PR DESCRIPTION
Broken by upgrade to Bootstrap 5, hamburger menu properties are not updated. Also, the footer should be hidden when page width is too small to display it.

Fixes #1734.