### PR TITLE
Update segmented TOTP detection to work with epicgames.com

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -154,7 +154,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements, exceptionFound);
     } else if (inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
-                || (i.type === 'text' && i.maxLength === 1)
+                || ((i.type === 'text' || i.type === 'number') && i.maxLength === 1)
                 || i.type === 'tel')) {
         // No form is found, but input fields are possibly segmented TOTP fields
         addTotpFieldsToCombination(inputs);


### PR DESCRIPTION
This fixes TOTP input detection on epicgames.com's segmented input fields.

![epicgames](https://user-images.githubusercontent.com/1991151/198176013-43e5c458-8ed6-4bd6-8abf-6897ae0c2c4b.png)
