### PR TITLE
Remove requestId from retrieve credentials request

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -140,10 +140,6 @@ keepass.retrieveCredentials = async function(tab, args = []) {
             keys: keys
         };
 
-        if (keepass.compareVersion('2.7.2', keepass.currentKeePassXC)) {
-            messageData.requestID = keepassClient.getRequestId();
-        }
-
         if (submiturl) {
             messageData.submitUrl = submiturl;
         }

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.8.3",
-    "version_name": "1.8.3",
+    "version": "1.8.3.1",
+    "version_name": "1.8.3.1",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.3",
+  "version": "1.8.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.3",
+  "version": "1.8.3.1",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
If this parameter is added to the request, the extension requires it for reply, which is no longer used.

Fixes #1760.