### PR TITLE
Add even more PayPal URLs to predefined sites

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -2,6 +2,8 @@
 
 const PREDEFINED_SITELIST = [
     'https://accounts.google.com/*',
+    'https://www.paypal.com/*/cgi-bin/webscr*',
+    'https://www.paypal.com/*/checkoutnow*',
     'https://www.paypal.com/*/signin*',
     'https://www.paypal.com/cgi-bin/webscr*',
     'https://www.paypal.com/checkoutnow*',


### PR DESCRIPTION
I have missed a few URLs in #1673.

Example URL from ebay checkout
```
https://www.paypal.com/DE/cgi-bin/webscr?cmd=_express-checkout&token=XYZ&useraction=commit
```
