### PR TITLE
Add steamcommunity.com to 2FA exception list

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -150,7 +150,8 @@ kpxcSites.segmentedTotpExceptionFound = function(form) {
         return false;
     }
 
-    if (document.location.href.startsWith('https://store.steampowered.com') && form.length === 5) {
+    if ((document.location.href.startsWith('https://store.steampowered.com')
+        || document.location.href.startsWith('https://steamcommunity.com/login')) && form.length === 5) {
         return true;
     }
 


### PR DESCRIPTION
Adds a new exception for `steamcommunity.com`'s 2FA page.

Fixes #1762.