### PR TITLE
Fix Autocomplete Menu border color on dark theme

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -93,7 +93,7 @@ class Autocomplete {
             this.shadowRoot.append(styleSheet);
 
             this.list = kpxcUI.createElement('div', 'kpxcAutocomplete-items', { 'id': 'kpxcAutocomplete-list' });
-            initColorTheme(this.list);
+            initColorTheme(this.container);
 
             this.container.append(this.list);
             this.shadowRoot.append(this.container);

--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -3,7 +3,6 @@
     z-index: 2147483646;
     position: absolute !important;
     background-color: #ddd;
-    border: 1px solid rgba(0,0,0,.125);
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
     overflow: hidden; /* this fixes an issue with the border radius not showing up clearly */
@@ -18,7 +17,7 @@
     padding: 5px;
     cursor: pointer;
     background-color: var(--kpxc-background-color);
-    border-bottom: 1px solid rgba(0,0,0,.125);
+    border: 1px solid rgba(0,0,0,.125);
     width: auto;
     color: var(--kpxc-text-color);
     font-size: max(10px, .9em) !important;

--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -1,8 +1,8 @@
-#kpxcAutocomplete-container {
+.kpxcAutocomplete-container {
     display: none;
     z-index: 2147483646;
     position: absolute !important;
-    background-color: #ddd;
+    border: var(--kpxc-autocomplete-menu-border);
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
     overflow: hidden; /* this fixes an issue with the border radius not showing up clearly */
@@ -17,7 +17,7 @@
     padding: 5px;
     cursor: pointer;
     background-color: var(--kpxc-background-color);
-    border: 1px solid rgba(0,0,0,.125);
+    border-bottom: 1px solid rgba(0,0,0,.125);
     width: auto;
     color: var(--kpxc-text-color);
     font-size: max(10px, .9em) !important;
@@ -36,8 +36,9 @@
     color: #ffffff !important;
 }
 
-#kpxcAutocomplete-container footer {
+.kpxcAutocomplete-container footer {
     padding: 5px;
+    background-color: #ddd;
     border-top: 1px solid rgba(0,0,0,.125) !important;
     width: auto;
     color: #000;
@@ -46,6 +47,10 @@
 }
 
 @media (prefers-color-scheme: dark) {
+    .kpxcAutocomplete-container {
+        border: var(--kpxc-autocomplete-menu-border);
+    }
+
     .kpxcAutocomplete-items {
         background: var(--kpxc-background-color);
         color: var(--kpxc-text-color);

--- a/keepassxc-browser/css/colors.css
+++ b/keepassxc-browser/css/colors.css
@@ -1,4 +1,5 @@
 :root, :host {
+    --kpxc-autocomplete-menu-border: 1px solid #ddd;
     --kpxc-background-color: #fff;
     --kpxc-card-background-color: #fff;
     --kpxc-card-border-color: rgba(0,0,0,.125);
@@ -22,6 +23,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root, :host {
+        --kpxc-autocomplete-menu-border: 1px solid #3b3b3d;
         --kpxc-background-color: #3b3b3d;
         --kpxc-card-background-color: #2b2a2a;
         --kpxc-card-border-color: #292a2a;
@@ -45,6 +47,7 @@
 
 /* Same colors for manual switching */
 [data-color-theme='dark'] {
+    --kpxc-autocomplete-menu-border: 1px solid #3b3b3d;
     --kpxc-background-color: #3b3b3d;
     --kpxc-card-background-color: #2b2a2a;
     --kpxc-card-border-color: #292a2a;
@@ -66,6 +69,7 @@
 }
 
 [data-color-theme='light'] {
+    --kpxc-autocomplete-menu-border: 1px solid #ddd;
     --kpxc-background-color: #fff;
     --kpxc-card-background-color: #fff;
     --kpxc-card-border-color: rgba(0,0,0,.125);


### PR DESCRIPTION
Introduced in https://github.com/keepassxreboot/keepassxc-browser/pull/1758 the Autocomplete Menu now has an extra border on dark theme. This removes it.
