### PR TITLE
Remove special handling for Firefox overflow/hamburger menu

### DIFF
--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -4,10 +4,9 @@ body {
     display: flex;
     font-family: sans-serif;
     font-size: 14px !important;
-    overflow: hidden;
     padding-top: 8px;
     padding-bottom: 8px;
-    width: fit-content;
+    width: 460px;
 }
 
 code {

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -15,9 +15,6 @@
     <script defer src="../common/translate.js"></script>
   </head>
   <body>
-    <script>
-      setDefaultPopupSize();
-    </script>
     <div class="container">
       <div id="settings" class="settings">
         <div class="action-buttons-area">

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -75,7 +75,6 @@ const sendMessageToTab = async function(message) {
 };
 
 (async () => {
-    resizePopup();
     await initColorTheme();
 
     $('#connect-button').addEventListener('click', async () => {

--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -4,9 +4,6 @@ const $ = function(elem) {
     return document.querySelector(elem);
 };
 
-const DEFAULT_POPUP_SIZE = '460px';
-const PINNED_POPUP_SIZE = '380px';
-
 function updateAvailableResponse(available) {
     if (available) {
         $('#update-available').show();
@@ -56,22 +53,6 @@ async function getLoginData() {
     });
 
     return logins;
-}
-
-// Sets default popup size for Chromium based browsers to prevent flash on popup open
-function setDefaultPopupSize() {
-    if (!isFirefox()) {
-        document.body.style.width = DEFAULT_POPUP_SIZE;
-    }
-}
-
-// Resizes the popup to the default size if the width is too small
-function resizePopup() {
-    if (document.body.offsetWidth > 0 && document.body.offsetWidth < 100) {
-        document.body.style.width = isFirefox() ? PINNED_POPUP_SIZE : DEFAULT_POPUP_SIZE;
-    } else {
-        document.body.style.width = DEFAULT_POPUP_SIZE;
-    }
 }
 
 (async () => {

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -15,9 +15,6 @@
     <script defer src="../common/translate.js"></script>
   </head>
   <body>
-    <script>
-      setDefaultPopupSize();
-    </script>
     <div class="container">
       <div id="settings" class="settings">
         <div class="function-buttons-area">

--- a/keepassxc-browser/popups/popup_httpauth.js
+++ b/keepassxc-browser/popups/popup_httpauth.js
@@ -1,7 +1,6 @@
 'use strict';
 
 (async () => {
-    resizePopup();
     await initColorTheme();
 
     $('#lock-database-button').show();

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -15,9 +15,6 @@
     <script defer src="../common/translate.js"></script>
   </head>
   <body>
-    <script>
-      setDefaultPopupSize();
-    </script>
     <div class="container">
       <div id="settings" class="settings">
         <div class="function-buttons-area">

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -1,7 +1,6 @@
 'use strict';
 
 (async () => {
-    resizePopup();
     await initColorTheme();
 
     $('#lock-database-button').show();


### PR DESCRIPTION
Firefox 106 has fixed the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1786587) where the popup was smaller size than the normal one, when it was moved to overflow menu in Firefox's toolbar. The special handling for popup size is now removed.

Previously fixed in: https://github.com/keepassxreboot/keepassxc-browser/pull/1571.
Related issue: #721.

This should be merged only after Firefox ESR has the fix. Keeping the WIP state for now.