### PR TITLE
Refactor how the URL is set when clicking the username-only button in the popup

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -44,10 +44,13 @@ kpxc.addToSitePreferences = async function() {
 
     if (!siteExists) {
         // Add wildcard to the URL
-        site = site.slice(0, site.lastIndexOf('/') + 1) + '*';
+        const url = new URL(window.top.location.href);
+        url.pathname = '/*';
+        url.search = '';
+        url.hash = '';
 
         kpxc.settings['sitePreferences'].push({
-            url: site,
+            url: url.toString(),
             ignore: IGNORE_NOTHING,
             usernameOnly: true
         });


### PR DESCRIPTION
This is a fix for https://odysee.com/. The login page is https://odysee.com/$/signin and the username-only button adds `https://odysee.com/$/*` to the list of URLs. However, since this is interpreted as a regex, `$` is messing with the matching so the new preference doesn't actually take effect.

I'm still not sure if using regex to match the site is a good idea, but that might be a discussion for another time.

It is not clear to me if this code is currently working as intended or not:

https://github.com/keepassxreboot/keepassxc-browser/blob/2ea0fe2b97c9451c94bc517e0b7bd287556ae807/keepassxc-browser/content/keepassxc-browser.js#L46-L47

Is it supposed to convert `https://odysee.com/$/signin` to `https://odysee.com/$/*` or `https://odysee.com/*`?

I'm guessing the latter. I decided to refactor it using [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) but let me know if you prefer string manipulation instead.
