### PR TITLE
Try harder to prevent false-positive password change banners

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -158,6 +158,15 @@ kpxcForm.onSubmit = async function(e) {
     } else if (kpxc.credentials.length === 1) {
         // Single entry found for the page, use the username of it instead of an empty one
         usernameValue = kpxc.credentials[0].login;
+    } else {
+        // Multiple entries found for the page, try to find out which one might have been used
+        const pageUuid = await sendMessage('page_get_login_id');
+        if (pageUuid) {
+            const credential = kpxc.credentials.find(c => c.uuid === pageUuid);
+            if (credential) {
+                usernameValue = credential.login;
+            }
+        }
     }
 
     // Check if the form has three password fields -> a possible password change form


### PR DESCRIPTION
Try harder to identify the username used if the user have multiple entries for a website. This should help prevent false-positive banners when the user did *not* change their password, especially on multi-step login forms.

This has been a long-standing annoyance for me but I haven't really understood why it happens. Happens every time if you have multiple entries for a page _and_ the website is using a multi-page login form.

I tested this on https://odysee.com/ and I confirmed that the banner still showed up when I actually changed my password.

I was also considering changing
```javascript
if (kpxc.credentials.some(c => c.login === usernameValue && c.password === passwordValue)) {
```

to
```javascript
if (kpxc.credentials.some(c => (!usernameValue || c.login === usernameValue) && c.password === passwordValue)) {
```

But not sure if that's overkill or not.
