### PR TITLE
Remove browser.runtime.getBackgroundPage()

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -234,6 +234,7 @@ kpxcEvent.messageHandlers = {
     'get_database_hash': keepass.getDatabaseHash,
     'get_database_groups': keepass.getDatabaseGroups,
     'get_keepassxc_versions': kpxcEvent.onGetKeePassXCVersions,
+    'get_login_list': page.getLoginList,
     'get_status': kpxcEvent.onGetStatus,
     'get_tab_information': kpxcEvent.onGetTabInformation,
     'get_totp': keepass.getTotp,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -371,6 +371,14 @@ page.setAutoSubmitPerformed = async function(tab) {
     }
 };
 
+page.getLoginList = async function(tab) {
+    if (page.tabs[tab.id]) {
+        return page.tabs[tab.id].loginList;
+    }
+
+    return [];
+};
+
 // Update context menu for attribute filling
 page.updateContextMenu = async function(tab, credentials) {
     // Remove any old attribute items

--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -48,6 +48,19 @@ async function initColorTheme() {
     }
 }
 
+async function getLoginData() {
+    const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+    if (tabs.length === 0) {
+        return [];
+    }
+
+    const logins = await browser.runtime.sendMessage({
+        action: 'get_login_list'
+    });
+
+    return logins;
+}
+
 // Sets default popup size for Chromium based browsers to prevent flash on popup open
 function setDefaultPopupSize() {
     if (!isFirefox()) {

--- a/keepassxc-browser/popups/popup_httpauth.js
+++ b/keepassxc-browser/popups/popup_httpauth.js
@@ -1,11 +1,5 @@
 'use strict';
 
-const getLoginData = async () => {
-    const global = await browser.runtime.getBackgroundPage();
-    const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-    return global.page.tabs[tabs[0].id].loginList;
-};
-
 (async () => {
     resizePopup();
     await initColorTheme();

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -6,14 +6,12 @@
 
     $('#lock-database-button').show();
 
-    const global = await browser.runtime.getBackgroundPage();
     const tabs = await browser.tabs.query({ active: true, currentWindow: true });
     if (tabs.length === 0) {
-        return; // For example: only the background devtools or a popup are opened
+        return [];
     }
 
-    const tab = tabs[0];
-    const logins = global.page.tabs[tab.id].loginList;
+    const logins = await getLoginData();
     const ll = document.getElementById('login-list');
 
     for (let i = 0; i < logins.length; i++) {
@@ -29,7 +27,7 @@
             }
 
             const id = e.target.id;
-            browser.tabs.sendMessage(tab.id, {
+            browser.tabs.sendMessage(tabs[0].id, {
                 action: 'fill_user_pass_with_specific_login',
                 id: Number(id),
                 uuid: uuid


### PR DESCRIPTION
Removes the `browser.runtime.getBackgroundPage()` request from the popup code. It's slightly cleaner and directly compatible with Manifest V3 where the runtime function is no longer allowed.