### PR TITLE
Fix extension behavior for Auto-Open

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -103,7 +103,7 @@ kpxc.detectDatabaseChange = async function(response) {
     kpxcIcons.switchIcons();
 
     if (document.visibilityState !== 'hidden') {
-        if (response.hash.new !== '' && response.hash.new !== response.hash.old) {
+        if (response.hash.new !== '') {
             _called.retrieveCredentials = false;
             const settings = await sendMessage('load_settings');
             kpxc.settings = settings;


### PR DESCRIPTION
This makes the extension behave as expected in my set up, where unlocking the primary DB (which unlocks the child DBs automatically) keep the extension in an "unlocked" state.