### PR TITLE
Fix login popup change with locked database

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -37,17 +37,9 @@ browserAction.showDefault = async function(tab) {
         popupData.iconType = 'locked';
     }
 
-    if (page.tabs[tab.id] && page.tabs[tab.id].loginList.length > 0) {
-        popupData.iconType = 'questionmark';
-        popupData.popup = 'popup_login';
-    }
-
-    browserAction.show(tab, popupData);
-};
-
-browserAction.updateIcon = async function(tab, iconType) {
+    // Get the current tab if no tab given
     if (!tab) {
-        const tabs = await browser.tabs.query({ 'active': true, 'currentWindow': true });
+        const tabs = await browser.tabs.query({ active: true, currentWindow: true });
         if (tabs.length === 0) {
             return;
         }
@@ -55,9 +47,12 @@ browserAction.updateIcon = async function(tab, iconType) {
         tab = tabs[0];
     }
 
-    browser.browserAction.setIcon({
-        path: browserAction.generateIconName(iconType)
-    });
+    if (page.tabs[tab.id] && page.tabs[tab.id].loginList.length > 0) {
+        popupData.iconType = 'questionmark';
+        popupData.popup = 'popup_login';
+    }
+
+    browserAction.show(tab, popupData);
 };
 
 browserAction.generateIconName = function(iconType) {
@@ -72,7 +67,7 @@ browserAction.ignoreSite = async function(url) {
     await browser.windows.getCurrent();
 
     // Get current active window
-    const tabs = await browser.tabs.query({ 'active': true, 'currentWindow': true });
+    const tabs = await browser.tabs.query({ active: true, currentWindow: true });
     const tab = tabs[0];
 
     // Send the message to the current tab's content script

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -855,9 +855,9 @@ keepass.handleError = function(tab, errorCode, errorMessage = '') {
     }
 };
 
-keepass.updatePopup = function(iconType) {
+keepass.updatePopup = function() {
     if (page && page.tabs.length > 0) {
-        browserAction.updateIcon(undefined, iconType);
+        browserAction.showDefault();
     }
 };
 
@@ -868,9 +868,8 @@ keepass.updateDatabase = async function() {
     page.clearAllLogins();
 
     await keepass.testAssociation(null, [ true ]);
-    const configured = await keepass.isConfigured();
 
-    keepass.updatePopup(configured ? 'normal' : 'locked');
+    keepass.updatePopup();
     keepass.updateDatabaseHashToContent();
 };
 

--- a/keepassxc-browser/popups/popup_httpauth.html
+++ b/keepassxc-browser/popups/popup_httpauth.html
@@ -48,7 +48,7 @@
         <p style="margin-left: 1em">
           <code id="database-error-message"></code>
         </p>
-        <div style="text-align: right">
+        <div class="right-align">
           <button id="reopen-database-button" class="btn btn-sm btn-primary"><i class="fa fa-lock" aria-hidden="true"></i> <span data-i18n="popupReopenButton"></span></button>
         </div>
       </div>

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -49,7 +49,7 @@
         <p style="margin-left: 1em">
           <code id="database-error-message"></code>
         </p>
-        <div id="right-align">
+        <div class="right-align">
           <button id="reopen-database-button" class="btn btn-sm btn-primary"><i class="fa fa-lock" aria-hidden="true"></i> <span data-i18n="popupReopenButton"></span></button>
         </div>
       </div>


### PR DESCRIPTION
Fixes the old annoying bug that shows this kind of popup if you switch from open database to a closed one, and the open database had credentials:
<img width="460" alt="Screenshot 2023-01-24 at 18 13 39" src="https://user-images.githubusercontent.com/24570482/214347424-c01fd340-c943-4345-afe0-602f2ee85140.png">

This change also fixes the position of "Reopen database" buttons after database lock has been made from the popup icon.

Steps to reproduce:
1. Have two databases in KeePassXC, open the first one.
2. Go to a page where the open database has credentials.
3. Switch from KeePassXC to the closed database.
4. The extension popup shows no login data, and no error is shown.