### PR TITLE
Remove icon input field from the internal list when removing the icon

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -235,6 +235,8 @@ kpxcObserverHelper.handleObserverAdd = async function(target) {
 
         kpxc.prepareCredentials();
     }
+
+    kpxcIcons.deleteHiddenIcons();
 };
 
 // Removes monitored elements

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -167,6 +167,12 @@ kpxcUI.deleteHiddenIcons = function(iconList, attr) {
             icon.removeIcon(attr);
             iconList.splice(index, 1);
             deletedIcons.push(icon.inputField);
+
+            // Delete the input field from detected fields so the icon can be detected again
+            const inputFieldIndex = kpxc.inputs.indexOf(icon.inputField);
+            if (inputFieldIndex >= 0) {
+                kpxc.inputs.splice(inputFieldIndex, 1);
+            }
         }
     }
 


### PR DESCRIPTION
Ensures that input fields that have gone hidden will have the icons removed. The check is now also made when just adding new elements to the page.

Without the fix using the following site leaves the Username Icon visible on the email field even if Next is pressed:
https://prium.github.io/phoenix/v1.8.0/modules/forms/wizard.html

Fixes #1833.