### PR TITLE
Make sure checkUpdateKeePassXC is an integer

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -137,7 +137,7 @@ kpxcEvent.onCheckUpdateKeePassXC = async function() {
 };
 
 kpxcEvent.onUpdateAvailableKeePassXC = async function() {
-    return (page.settings.checkUpdateKeePassXC !== CHECK_UPDATE_NEVER) ? keepass.keePassXCUpdateAvailable() : false;
+    return (Number(page.settings.checkUpdateKeePassXC) !== CHECK_UPDATE_NEVER) ? keepass.keePassXCUpdateAvailable() : false;
 };
 
 kpxcEvent.onRemoveCredentialsFromTabInformation = async function(tab) {

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -800,10 +800,11 @@ keepass.setcurrentKeePassXCVersion = function(version) {
 };
 
 keepass.keePassXCUpdateAvailable = function() {
-    if (page.settings.checkUpdateKeePassXC && page.settings.checkUpdateKeePassXC !== CHECK_UPDATE_NEVER) {
+    const checkUpdate = Number(page.settings.checkUpdateKeePassXC);
+    if (checkUpdate !== CHECK_UPDATE_NEVER) {
         const lastChecked = (keepass.latestKeePassXC.lastChecked) ? new Date(keepass.latestKeePassXC.lastChecked) : new Date(1986, 11, 21);
         const daysSinceLastCheck = Math.floor(((new Date()).getTime() - lastChecked.getTime()) / 86400000);
-        if (daysSinceLastCheck >= page.settings.checkUpdateKeePassXC) {
+        if (daysSinceLastCheck >= checkUpdate) {
             keepass.checkForNewKeePassXCVersion();
         }
 


### PR DESCRIPTION
Sometimes a strange bug can occur where `checkUpdateKeePassXC` setting is saved as a string. It should be made sure that only integers are used when making comparisons.
The actual bug where saving the setting as string has not been caught.

Fixes #1832.