### PR TITLE
Improve filling from Username Icon

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -32,14 +32,10 @@ kpxcBanner.destroy = async function() {
 
 kpxcBanner.create = async function(credentials = {}) {
     const connectedDatabase = await sendMessage('get_connected_database');
-    if (!kpxc.settings.showLoginNotifications || kpxcBanner.created || connectedDatabase.identifier === null) {
-        return;
-    }
-
-    // Check if database is closed
-    const state = await sendMessage('check_database_hash');
-    if (state === '') {
-        //kpxcUI.createNotification('error', tr('rememberErrorDatabaseClosed'));
+    if (!kpxc.settings.showLoginNotifications
+        || kpxcBanner.created
+        || connectedDatabase.identifier === null
+        || kpxc.databaseState !== DatabaseState.UNLOCKED) {
         return;
     }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -115,7 +115,7 @@ kpxc.detectDatabaseChange = async function(response) {
             // If user has requested a manual fill through context menu the actual credential filling
             // is handled here when the opened database has been regognized. It's not a pretty hack.
             const manualFill = await sendMessage('page_get_manual_fill');
-            if (manualFill !== ManualFill.NONE) {
+            if (manualFill !== ManualFill.NONE && kpxc.combinations.length > 0) {
                 await kpxcFill.fillInFromActiveElement(manualFill === ManualFill.PASSWORD);
                 await sendMessage('page_set_manual_fill', ManualFill.NONE);
             }

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -131,8 +131,7 @@ const iconClicked = async function(field, icon) {
         return;
     }
 
-    const databaseHash = await sendMessage('check_database_hash');
-    if (databaseHash === '') {
+    if (kpxc.databaseState !== DatabaseState.UNLOCKED) {
         // Triggers database unlock
         await sendMessage('page_set_manual_fill', ManualFill.BOTH);
         await sendMessage('get_database_hash', [ false, true ]); // Set triggerUnlock to true
@@ -148,7 +147,7 @@ const getIconClassName = function(state = DatabaseState.UNLOCKED) {
     if (state === DatabaseState.LOCKED) {
         return (isFirefox() ? 'lock-moz' : 'lock');
     } else if (state === DatabaseState.DISCONNECTED) {
-        return (isFirefox() ? 'lock-disconnected' : 'disconnected');
+        return (isFirefox() ? 'disconnected-moz' : 'disconnected');
     }
 
     return (isFirefox() ? 'unlock-moz' : 'unlock');


### PR DESCRIPTION
Improves the filling from Username Icon on multiple situations:
- Fill when KeePassXC is connected but database is unlocked.
- Fill when KeePassXC is not connected and database is unlocked.
- Fill when KeePassXC is not connected and database is locked.

Previously the code relied on `check_database_status` for checking if the database is open, but that should not be used. Especially when the new implementation for database handling is implemented in the future, KeePassXC can return database hash also from locked databases. Instead we should check the `kpxc.databaseStatus` which already has the up-to-date information.

When database is locked when using the Username Icon, a Manual Fill is requested. It's performed after the database is unlocked. In some situations the first page triggering the fill can be an iframe without any input fields or combinations. This is why the extra check is added before doing the Manual Fill.

Also found out a wrong CSS value with Firefox when disconnected icon is displayed. That caused the icon to go invisible.

Fixes #1855.
Fixes #1817.
Fixes #1766.
Fixes #1382.
