### PR TITLE
Allow force-fill to String Fields even if readonly

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -288,7 +288,7 @@ kpxcFill.fillInStringFields = function(fields, stringFields) {
             const currentField = fields[i];
 
             if (currentField && stringFieldValue[0]) {
-                kpxc.setValue(currentField, stringFieldValue[0]);
+                kpxc.setValue(currentField, stringFieldValue[0], true);
                 filledInFields.push(currentField);
             }
         }

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -643,7 +643,7 @@ kpxc.setPasswordFilled = async function(state) {
 };
 
 // Special handling for settings value to select element
-kpxc.setValue = function(field, value) {
+kpxc.setValue = function(field, value, forced = false) {
     if (field.matches('select')) {
         value = value.toLowerCase().trim();
         const options = field.querySelectorAll('option');
@@ -658,12 +658,12 @@ kpxc.setValue = function(field, value) {
         return;
     }
 
-    kpxc.setValueWithChange(field, value);
+    kpxc.setValueWithChange(field, value, forced);
 };
 
 // Sets a new value to input field and triggers necessary events
-kpxc.setValueWithChange = function(field, value) {
-    if (field.readOnly) {
+kpxc.setValueWithChange = function(field, value, forced = false) {
+    if (!forced && field.readOnly) {
         return;
     }
 


### PR DESCRIPTION
Fixing a regression for #818 from change #1841. Filling `readonly` fields should be allowed if those are specified as String Fields using Custom Login Fields. That's the only exception. No username/password/totp will be allowed to do that.