### PR TITLE
Fix HTTP Auth fill

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -228,6 +228,7 @@ kpxcEvent.messageHandlers = {
     'create_new_group': keepass.createNewGroup,
     'enable_automatic_reconnect': keepass.enableAutomaticReconnect,
     'disable_automatic_reconnect': keepass.disableAutomaticReconnect,
+    'fill_http_auth': page.fillHttpAuth,
     'generate_password': keepass.generatePassword,
     'get_color_theme': kpxcEvent.getColorTheme,
     'get_connected_database': kpxcEvent.onGetConnectedDatabase,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -379,6 +379,17 @@ page.getLoginList = async function(tab) {
     return [];
 };
 
+page.fillHttpAuth = async function(tab, credentials) {
+    if (page.tabs[tab.id] && page.tabs[tab.id].loginList.resolve) {
+        page.tabs[tab.id].loginList.resolve({
+            authCredentials: {
+                username: credentials.login,
+                password: credentials.password
+            }
+        });
+    }
+};
+
 // Update context menu for attribute filling
 page.updateContextMenu = async function(tab, credentials) {
     // Remove any old attribute items

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.8.5",
-    "version_name": "1.8.5",
+    "version": "1.8.5.1",
+    "version_name": "1.8.5.1",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {

--- a/keepassxc-browser/popups/popup_httpauth.js
+++ b/keepassxc-browser/popups/popup_httpauth.js
@@ -19,16 +19,12 @@
                 return;
             }
 
-            if (data.resolve) {
-                const id = e.target.id;
-                const creds = data.logins[Number(id)];
-                data.resolve({
-                    authCredentials: {
-                        username: creds.login,
-                        password: creds.password
-                    }
-                });
-            }
+            const credentials = data.logins[Number(e.target.id)];
+            browser.runtime.sendMessage({
+                action: 'fill_http_auth',
+                args: credentials
+            });
+
             close();
         });
         ll.appendChild(a);
@@ -47,16 +43,12 @@
     });
 
     $('#btn-dismiss').addEventListener('click', async () => {
-        const loginData = await getLoginData();
-        // Using reject won't work with every browser. So return empty credentials instead.
-        if (loginData.resolve) {
-            loginData.resolve({
-                authCredentials: {
-                    username: '',
-                    password: ''
-                }
-            });
-        }
+        // Return empty credentials
+        browser.runtime.sendMessage({
+            action: 'fill_http_auth',
+            args: { login: '', password: '' }
+        });
+
         close();
     });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.5",
+  "version": "1.8.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "KeePassXC-Browser",
-      "version": "1.8.5",
+      "version": "1.8.5.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KeePassXC-Browser",
-  "version": "1.8.5",
+  "version": "1.8.5.1",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
https://github.com/keepassxreboot/keepassxc-browser/pull/1822 broke Basic HTTP Auth. Old `browser.runtime.getBackgroundPage()` allows Promises to be inside objects, but `sendMessage()` does not. The credentials selected for HTTP Auth must be passed to the background script for resolving the Promise correctly.

Fixes #1868.