### PR TITLE
Use defaultView instead of scrollingElement when positioning icons and menus

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -283,8 +283,8 @@ class Autocomplete {
             this.container.classList.remove('kpxcAutocomplete-container-on-top');
         }
 
-        const scrollTop = document.defaultView ? document.defaultView.scrollY : document.scrollingElement.scrollTop;
-        const scrollLeft = document.defaultView ? document.defaultView.scrollX : document.scrollingElement.scrollLeft;
+        const scrollTop = document.defaultView?.scrollY ?? document.scrollingElement?.scrollTop ?? 0;
+        const scrollLeft = document.defaultView?.scrollX ?? document.scrollingElement?.scrollLeft ?? 0;
         if (kpxcUI.bodyStyle.position.toLowerCase() === 'relative') {
             this.container.style.top = Pixels(rect.top - kpxcUI.bodyRect.top + scrollTop + this.input.offsetHeight - menuOffset);
             this.container.style.left = Pixels(rect.left - kpxcUI.bodyRect.left + scrollLeft);

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -283,12 +283,14 @@ class Autocomplete {
             this.container.classList.remove('kpxcAutocomplete-container-on-top');
         }
 
+        const scrollTop = document.defaultView ? document.defaultView.scrollY : document.scrollingElement.scrollTop;
+        const scrollLeft = document.defaultView ? document.defaultView.scrollX : document.scrollingElement.scrollLeft;
         if (kpxcUI.bodyStyle.position.toLowerCase() === 'relative') {
-            this.container.style.top = Pixels(rect.top - kpxcUI.bodyRect.top + document.scrollingElement.scrollTop + this.input.offsetHeight - menuOffset);
-            this.container.style.left = Pixels(rect.left - kpxcUI.bodyRect.left + document.scrollingElement.scrollLeft);
+            this.container.style.top = Pixels(rect.top - kpxcUI.bodyRect.top + scrollTop + this.input.offsetHeight - menuOffset);
+            this.container.style.left = Pixels(rect.left - kpxcUI.bodyRect.left + scrollLeft);
         } else {
-            this.container.style.top = Pixels(rect.top + document.scrollingElement.scrollTop + this.input.offsetHeight - menuOffset);
-            this.container.style.left = Pixels(rect.left + document.scrollingElement.scrollLeft);
+            this.container.style.top = Pixels(rect.top + scrollTop + this.input.offsetHeight - menuOffset);
+            this.container.style.left = Pixels(rect.left + scrollLeft);
         }
     }
 }

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -283,8 +283,8 @@ class Autocomplete {
             this.container.classList.remove('kpxcAutocomplete-container-on-top');
         }
 
-        const scrollTop = document.defaultView?.scrollY ?? document.scrollingElement?.scrollTop ?? 0;
-        const scrollLeft = document.defaultView?.scrollX ?? document.scrollingElement?.scrollLeft ?? 0;
+        const scrollTop = kpxcUI.getScrollTop();
+        const scrollLeft = kpxcUI.getScrollLeft();
         if (kpxcUI.bodyStyle.position.toLowerCase() === 'relative') {
             this.container.style.top = Pixels(rect.top - kpxcUI.bodyRect.top + scrollTop + this.input.offsetHeight - menuOffset);
             this.container.style.left = Pixels(rect.left - kpxcUI.bodyRect.left + scrollLeft);

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -621,8 +621,8 @@ kpxcCustomLoginFieldsBanner.setSelectionPosition = function(field) {
     const rect = field.originalElement.getBoundingClientRect();
     const left = kpxcUI.getRelativeLeftPosition(rect);
     const top = kpxcUI.getRelativeTopPosition(rect);
-    const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;
-    const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : 0;
+    const scrollTop = kpxcUI.getScrollTop();
+    const scrollLeft = kpxcUI.getScrollLeft();
 
     field.style.top = Pixels(top + scrollTop);
     field.style.left = Pixels(left + scrollLeft);

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -143,12 +143,20 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         top = iconOffset[1];
     }
 
-    const scrollTop = document.defaultView?.scrollY ?? document.scrollingElement?.scrollTop ?? 0;
-    const scrollLeft = document.defaultView?.scrollX ?? document.scrollingElement?.scrollLeft ?? 0;
+    const scrollTop = kpxcUI.getScrollTop();
+    const scrollLeft = kpxcUI.getScrollLeft();
     icon.style.top = Pixels(top + scrollTop + offset + 1);
     icon.style.left = rtl
                     ? Pixels((left + scrollLeft) + offset)
                     : Pixels(left + scrollLeft + field.offsetWidth - size - offset);
+};
+
+kpxcUI.getScrollTop = function() {
+    return document.defaultView?.scrollY ?? document.scrollingElement?.scrollTop ?? 0;
+};
+
+kpxcUI.getScrollLeft = function() {
+    return document.defaultView?.scrollX ?? document.scrollingElement?.scrollLeft ?? 0;
 };
 
 kpxcUI.getRelativeLeftPosition = function(rect) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -143,8 +143,8 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         top = iconOffset[1];
     }
 
-    const scrollTop = document.defaultView ? document.defaultView.scrollY : document.scrollingElement.scrollTop;
-    const scrollLeft = document.defaultView ? document.defaultView.scrollX : document.scrollingElement.scrollLeft;
+    const scrollTop = document.defaultView?.scrollY ?? document.scrollingElement?.scrollTop ?? 0;
+    const scrollLeft = document.defaultView?.scrollX ?? document.scrollingElement?.scrollLeft ?? 0;
     icon.style.top = Pixels(top + scrollTop + offset + 1);
     icon.style.left = rtl
                     ? Pixels((left + scrollLeft) + offset)

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -143,8 +143,8 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         top = iconOffset[1];
     }
 
-    const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : 0;
-    const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : 0;
+    const scrollTop = document.defaultView ? document.defaultView.scrollY : document.scrollingElement.scrollTop;
+    const scrollLeft = document.defaultView ? document.defaultView.scrollX : document.scrollingElement.scrollLeft;
     icon.style.top = Pixels(top + scrollTop + offset + 1);
     icon.style.left = rtl
                     ? Pixels((left + scrollLeft) + offset)

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -158,7 +158,7 @@
     "applications": {
         "gecko": {
             "id": "keepassxc-browser@keepassxc.org",
-            "strict_min_version": "67.0"
+            "strict_min_version": "74.0"
         }
     },
     "default_locale": "en"


### PR DESCRIPTION
With some webpages `document.scrollingElement` or `document.documentElement` are not providing correct `scrollTop` and `scrollLeft` values. Instead `document.defaultView` is used with `scrollX` and `scrollY` values.

Needs a little more testing to ensure this doesn't break any sites with scrolling.

Fixes #1872.