### PR TITLE
Improve message origin check for banner selector

### DIFF
--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -678,24 +678,11 @@ const topLevelDomainMatches = function(host) {
     }
 
     const originUrl = new URL(host);
-    const frameUrl = new URL(window.self.document.location.origin);
-    const urlParts = originUrl.host.split('.');
-    const dotCount = urlParts.length - 1;
+    const frameUrl = new URL(window.location.origin);
 
-    // Simple host like google.com, check directly
-    if (dotCount < 1) {
-        return false;
-    } else if (dotCount === 1) {
-        return frameUrl.host.includes(originUrl.host);
-    }
-
-    // Get the top-level-domain using counts of '.' but backwards, max 3.
-    // A basic host is like idmsa.apple.com, a more complex one like www.bbva.com.ar.
-    const index = Math.min(dotCount, 3);
-    const subDomain = `${urlParts[dotCount - index]}.`;
-    const topLevelDomain = originUrl.host.substring(originUrl.host.indexOf(subDomain) + subDomain.length);
-
-    return frameUrl.host.includes(topLevelDomain);
+    // Use the last two parts of the host name as "domain"
+    const domain = frameUrl.host.split('.').slice(-2).join('.');
+    return originUrl.host == domain || originUrl.host.endsWith('.' + domain);
 };
 
 // Handles messages sent from iframes to the top window


### PR DESCRIPTION
The `topLevelDomainMatches()` function logic in `custom-fields-banner.js` is currently rather flawed. On `github.com` it will accept `https://github.co` as a valid message origin but not `https://abc.abc.github.com`.

While this allows malicious websites to send messages that circumvent the origin check, I think that the security impact here is low given the functionality triggered by these messages. Still, this needs fixing.

Note that my change does not address the concern that this code will consider `co.uk` to be a domain name. Fixing this requires using https://publicsuffix.org/.