### PR TITLE
Transfer iframe messages without postMessage()

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -220,6 +220,11 @@ kpxcEvent.hideTroubleshootingGuideAlert = async function(tab) {
     await kpxcEvent.onSaveSettings(tab, settings);
 };
 
+// Bounce message back to all frames
+kpxcEvent.sendBackToTabs = async function(tab, args = []) {
+    await browser.tabs.sendMessage(tab.id, { action: 'frame_message', args: args });
+};
+
 // All methods named in this object have to be declared BEFORE this!
 kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
@@ -231,6 +236,7 @@ kpxcEvent.messageHandlers = {
     'enable_automatic_reconnect': keepass.enableAutomaticReconnect,
     'disable_automatic_reconnect': keepass.disableAutomaticReconnect,
     'fill_http_auth': page.fillHttpAuth,
+    'frame_message': kpxcEvent.sendBackToTabs,
     'generate_password': keepass.generatePassword,
     'get_color_theme': kpxcEvent.getColorTheme,
     'get_connected_database': kpxcEvent.onGetConnectedDatabase,

--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -66,7 +66,7 @@ kpxcSites.exceptionFound = function(identifier) {
 
     if (document.location.origin === 'https://idmsa.apple.com'
         && ((typeof identifier === 'string' && identifier === 'password_text_field')
-        || [ 'password', 'form-row', 'show-password' ].every(c => identifier.contains(c)))) {
+        || (typeof identifier === 'object' && [ 'password', 'form-row', 'show-password' ].every(c => identifier.contains(c))))) {
         return true;
     } else if (document.location.origin.startsWith('https://signin.ebay.')
                && (identifier === 'null' || identifier.value === 'null' || identifier === 'pass')) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -864,6 +864,12 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
         } else if (req.action === 'fill_attribute' && req.args) {
             await kpxc.receiveCredentialsIfNecessary();
             kpxcFill.fillAttributeToActiveElementWith(req.args);
+        } else if (req.action === 'frame_message') {
+            if (req.args?.[0] === 'frame_request_to_frames' && window.self !== window.top) {
+                kpxcCustomLoginFieldsBanner.handleParentWindowMessage(req.args);
+            } else if (req.args?.[0] === 'frame_request_to_parent' && window.self === window.top) {
+                kpxcCustomLoginFieldsBanner.handleTopWindowMessage(req.args);
+            }
         } else if (req.action === 'ignore_site') {
             kpxc.ignoreSite(req.args);
         } else if (req.action === 'redetect_fields') {


### PR DESCRIPTION
Instead of unsafe `postMessage()` all messages between iframes should be transferred using `sendMessage()`.

For this a new event `frame_message` is added to `event.js` which only bounces the message back to the current tab's frames. After that `keepassxc-browser.js` handles the internal message (`frame_request_to_frames` or `frame_request_to_parent`) and calls the correct functions based on top window or iframe status. It's possible to use the same `frame_message` for other similar situations in the future.