### PR TITLE
Fix adding Username Icon to non-identified forms

### DIFF
--- a/keepassxc-browser/content/icons.js
+++ b/keepassxc-browser/content/icons.js
@@ -34,7 +34,7 @@ kpxcIcons.addIcon = async function(field, iconType) {
     }
 };
 
-// Adds all necessary icons to a saved form
+// Adds all icons from a form struct
 kpxcIcons.addIconsFromForm = async function(form) {
     const addUsernameIcons = async function(c) {
         if (kpxc.settings.showLoginFormIcon && await kpxc.passwordFilledWithExceptions(c) === false) {
@@ -93,13 +93,12 @@ kpxcIcons.initIcons = async function(combinations = []) {
         await kpxcIcons.addIconsFromForm(form);
     }
 
-    // Check for other combinations that are not in any form
+    // Check for other combinations that are not in any form,
+    // or there's a form that wasn't present in savedForms (and it's not null)
     for (const c of combinations) {
-        if (c.form) {
-            continue;
+        if (!c.form || (c.form && !kpxcForm.savedForms.some(sf => sf.form === c.form))) {
+            await kpxcIcons.addIconsFromForm(c);
         }
-
-        await kpxcIcons.addIconsFromForm(c);
     }
 };
 


### PR DESCRIPTION
In some rare cases form can contain non-standard properties (for example a HTML element in `form.action`) which causes the extension to ignore the form and it will be not added to `kpxcForms.savedForms` and submits are not listened. Combinations from these forms are ignored later when trying to create Username Icons.

The fix ensures that if an internal form struct has a `form` defined but it's not in `savedForms`, the Username Icons are still added to DOM normally.

Fixes #1900.