### PR TITLE
Add a notification with domain URL when logins are not found for a site

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -25,7 +25,8 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
-        logDebug('Error: Credential list is empty.');
+        logDebug(`Error: Credential list is empty for: ${document.location.origin}`);
+        kpxcUI.createNotification('error', `${tr('credentialsNoLoginsFound')} ${document.location.origin}`);
         return;
     }
 

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -192,7 +192,8 @@ kpxcFill.fillSegmentedTotp = function(elem, val, totpInputs) {
 kpxcFill.fillFromUsernameIcon = async function(combination) {
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
-        logDebug('Error: Credential list is empty.');
+        logDebug(`Error: Credential list is empty for: ${document.location.origin}`);
+        kpxcUI.createNotification('error', `${tr('credentialsNoLoginsFound')} ${document.location.origin}`);
         return;
     } else if (kpxc.credentials.length > 1 && kpxc.settings.autoCompleteUsernames) {
         kpxcUserAutocomplete.showList(combination.username || combination.password);


### PR DESCRIPTION
Adds a new notification when logins are not found a site and fill is done using the Username Icon or context menu. The domain URL is added to the message, clarifying a situation where the login URL can differ from the one user has set. For example `https://www.gog.com` instead of `https://login.gog.com`.

Fixes #1927.