### PR TITLE
Prevent retrieving credentials from background tabs

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -196,17 +196,25 @@ page.createTabEntry = function(tabId) {
 // Page reload or tab switch clears the cache.
 // If the retrieval is forced (from Credential Banner), get new credentials normally.
 page.retrieveCredentials = async function(tab, args = []) {
+    if (!tab?.active) {
+        return [];
+    }
+
     const [ url, submitUrl, force ] = args;
     if (page.tabs[tab.id]?.credentials.length > 0 && !force) {
         return page.tabs[tab.id].credentials;
     }
 
-    // Ignore duplicate requests
-    if (page.currentRequest.url === url && page.currentRequest.submitUrl === submitUrl && !force) {
+    // Ignore duplicate requests from the same tab
+    if (page.currentRequest.url === url
+        && page.currentRequest.submitUrl === submitUrl
+        && page.currentRequest.tabId === tab.id
+        && !force) {
         return [];
     } else {
         page.currentRequest.url = url;
         page.currentRequest.submitUrl = submitUrl;
+        page.currentRequest.tabId = tab.id;
     }
 
     const credentials = await keepass.retrieveCredentials(tab, args);


### PR DESCRIPTION
When using a Tab Restore feature or loading a page from a bookmark folder to the background, credential requests are still sent to KeePassXC. The fix makes sure a tab needs to be active before any requests are made.

Storing the `tab.id` allows retrieving credentials from the same URL even if a tab was closed and reopened right after.