### PR TITLE
Handle errors properly when waiting for response

### DIFF
--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -83,7 +83,7 @@ keepassClient.sendNativeMessage = function(request, enableTimeout = false, timeo
             const handler = (msg) => {
                 if (msg && msg?.action === action) {
                     // If the request has a separate requestID, check if it matches when there's no nonce (an error message)
-                    const isNotificationOrError = !msg.nonce && request.requestID === msg.requestID;
+                    const isNotificationOrError = !msg.nonce && (request.requestID === msg.requestID || (msg.error && msg.errorCode));
 
                     // Only resolve a matching response or a notification (without nonce)
                     if (isNotificationOrError || messageBuffer.matchAndRemove(msg)) {


### PR DESCRIPTION
If there's an error message returned when waiting for response, the listener should be destroyed. Applies at least to Password Generator widget when it is closed and an error message is received.

Some more testing needed to ensure this doesn't break anything.