### PR TITLE
Adjust contributors list and About page

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -686,36 +686,33 @@
                 </div>
                 <div class="card-body">
                   <p>
+                    <span data-i18n="optionsAboutExtensionVersion" data-i18n-placeholder="<em class='versionCIP'></em>"></span>
+                    <br>
+                    <span data-i18n="optionsAboutKeePassXCVersion" data-i18n-placeholder="<em class='versionKPH'></em>"></span>
+                  </p>
+                  <hr class="mt-0">
+                  <p>
                     <a target="_blank" href="https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk" data-i18n="[title]openNewTab" tabindex="6">
                     <span data-i18n="optionsAboutChrome"></span></a>
-                  </p>
-                  <p>
+                    <br>
                     <a target="_blank" href="https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/" data-i18n="[title]openNewTab" tabindex="7">
                     <span data-i18n="optionsAboutMozilla"></span></a>
-                  </p>
-                  <p>
+                    <br>
                     <a target="_blank" href="https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo" data-i18n="[title]openNewTab" tabindex="8">
                     <span data-i18n="optionsAboutEdge"></span></a>
-                  </p>
-                  <p>
+                    <br>
                     <a target="_blank" href="https://github.com/keepassxreboot/keepassxc-browser" data-i18n="[title]openNewTab" tabindex="9">
                     <span data-i18n="optionsAboutGitHub"></span></a>
                   </p>
                   <hr class="mt-0">
                   <p>
-                    <span data-i18n="optionsAboutExtensionVersion" data-i18n-placeholder="<em class='versionCIP'></em>"></span>
-                  </p>
-                  <p>
-                    <span data-i18n="optionsAboutKeePassXCVersion" data-i18n-placeholder="<em class='versionKPH'></em>"></span>
-                  </p>
-                  <hr class="mt-0">
-                  <p>
-                    <span data-i18n="optionsAboutContributors"></span>:<br>
-                    <a target="_blank" href="https://github.com/pfn/" data-i18n="[title]openNewTab" tabindex="10">Perry Nguyen</a>,
-                    <a target="_blank" href="http://lukas-schulze.de" data-i18n="[title]openNewTab" tabindex="11">Lukas Schulze</a>,
-                    <a target="_blank" href="https://github.com/smorks" data-i18n="[title]openNewTab" tabindex="12">Andy Brandt</a>,
-                    <a target="_blank" href="https://github.com/varjolintu/" data-i18n="[title]openNewTab" tabindex="13">Sami Vänttinen</a>,
-                    <a target="_blank" href="https://github.com/keepassxreboot/keepassxc-browser" data-i18n="[title]openNewTab" tabindex="14">KeePassXC Team</a>.
+                    <span data-i18n="optionsAboutContributors"></span>:
+                    <br><a target="_blank" href="https://github.com/varjolintu/" data-i18n="[title]openNewTab" tabindex="13">Sami Vänttinen</a>
+                    <br><a target="_blank" href="https://github.com/smorks" data-i18n="[title]openNewTab" tabindex="12">Andy Brandt</a>
+                    <br><a target="_blank" href="https://github.com/pfn/" data-i18n="[title]openNewTab" tabindex="10">Perry Nguyen</a>
+                    <br><a target="_blank" href="http://lukas-schulze.de" data-i18n="[title]openNewTab" tabindex="11">Lukas Schulze</a>
+                    <br><a target="_blank" href="https://github.com/stefansundin" data-i18n="[title]openNewTab" tabindex="12">Stefan Sundin</a>
+                    <br><a target="_blank" href="https://github.com/dynobo" data-i18n="[title]openNewTab" tabindex="12">dynobo</a>
                   </p>
 
                   <details>


### PR DESCRIPTION
Adjusts the About page in the options:
- Change contributors to a list
- Add new contributors to the list
- Move extension version information to the top
- Remove some extra line changes to make the page more compact
- Checked the Patreon supportes list (no new additions)