### PR TITLE
Use bang icon when connection is needed

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -30,6 +30,8 @@ browserAction.showDefault = async function(tab) {
 
     if (!response && !keepass.isKeePassXCAvailable) {
         popupData.iconType = 'cross';
+    } else if (!keepass.isAssociated() && !keepass.isDatabaseClosed) {
+        popupData.iconType = 'bang';
     } else if (keepass.isKeePassXCAvailable && keepass.isDatabaseClosed) {
         popupData.iconType = 'locked';
     }

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -241,7 +241,7 @@ keepass.associate = async function(tab) {
             keepass.associated.value = true;
             keepass.associated.hash = response.hash || 0;
 
-            browserAction.show(tab);
+            browserAction.showDefault(tab);
             return AssociatedAction.NEW_ASSOCIATION;
         }
 

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -380,6 +380,7 @@ options.initConnectedDatabases = function() {
         });
 
         hideEmptyMessageRow();
+        browser.runtime.sendMessage({ action: 'update_popup' });
     });
 
     const removeButtonClicked = function(e) {


### PR DESCRIPTION
Use the icon with `!` when a connection to KeePass database is needed. Previously just the default icon was used, that does not show the status correctly. There should be some kind of indication for the non-connected state.