### PR TITLE
Refactor extension messaging

### DIFF
--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -134,7 +134,7 @@ keepassClient.handleNativeMessage = async function(response) {
             }
         }
 
-        logError('Corresponding request not found in the message buffer for response: ', response);
+        debugLogMessage('Corresponding request not found in the message buffer for response: ', response);
     });
 };
 

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -96,6 +96,7 @@ class Message {
 
 keepassClient.sendNativeMessage = async function(request, enableTimeout = false, timeoutValue) {
     if (!keepassClient.nativePort) {
+        logError('No native messaging port defined.');
         return;
     }
 
@@ -132,6 +133,8 @@ keepassClient.handleNativeMessage = async function(response) {
                 return;
             }
         }
+
+        logError('Corresponding request not found in the message buffer for response: ', response);
     });
 };
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -15,7 +15,6 @@ keepass.latestVersionUrl = 'https://api.github.com/repos/keepassxreboot/keepassx
 keepass.cacheTimeout = 30 * 1000; // Milliseconds
 keepass.databaseHash = '';
 keepass.previousDatabaseHash = '';
-keepass.passwordRequestSent = false;
 keepass.reconnectLoop = null;
 
 const kpActions = {
@@ -169,13 +168,7 @@ keepass.retrieveCredentials = async function(tab, args = []) {
 
 keepass.generatePassword = async function(tab) {
     if (!keepass.isConnected) {
-        return '';
-    }
-
-    if (keepass.passwordRequestSent) {
         return undefined;
-    } else {
-        keepass.passwordRequestSent = true;
     }
 
     try {
@@ -208,11 +201,9 @@ keepass.generatePassword = async function(tab) {
             logError('generatePassword rejected');
         }
 
-        keepass.passwordRequestSent = false;
         return password;
     } catch (err) {
         logError(`generatePassword failed: ${err}`);
-        keepass.passwordRequestSent = false;
         return undefined;
     }
 };

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -159,7 +159,7 @@
     "applications": {
         "gecko": {
             "id": "keepassxc-browser@keepassxc.org",
-            "strict_min_version": "93.0"
+            "strict_min_version": "96.0"
         }
     },
     "default_locale": "en"


### PR DESCRIPTION
This change refactors the way messages and stored to the message buffer, and how the response message is being waited and handled.

Previously the extension created a new listener for every command sent via `.addListener()`, and after a proper response `.removeListener()` was used after a response. In some cases the response is not received, or there is only a generic error message available that cannot be identified as a response to any message. When these messages (and listeners) pile up, the extension will be shown `Nonce compare failed` error messages and the connection to KeePassXC might get broken. In thise case KeePassXC' native messaging handler can show multiple messages waiting inside one socket message, and the messages are not handled properly.

This is been fixed by creating a new custom `Message` class that stores the `Promise` needed to be wait for the response, without creating any new listeners to the native messaging port. Instead, when sending a new message, new `Message` class is stored to a buffer, and the native messaging's `onMessage()` handler goes through the buffer and finds the corresponding `Promise` to be resolved. After that the `Message` will be removed from the buffer, and the response is returned to the command function that awaits it.

The change fixes password generator popups and possibly other situations where only locking and unlocking the database (or reconnecting to KeePassXC) has been the only workaround.

Minimum version of Firefox has been increased from 93 to 96 because of [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API).