### PR TITLE
Fill whole combination when Autocomplete Menu is disabled

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -30,7 +30,7 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
         return;
     }
 
-    if (kpxc.combinations.length > 0 && kpxc.settings.autoCompleteUsernames) {
+    if (kpxc.combinations.length > 0) {
         if (await kpxcFill.fillFromCombination(passOnly)) {
             // Combination found and filled
             return;
@@ -64,7 +64,7 @@ kpxcFill.fillFromCombination = async function(passOnly) {
     // Set focus to the input field
     field.focus();
 
-    if (kpxc.credentials.length > 1) {
+    if (kpxc.credentials.length > 1 && kpxc.settings.autoCompleteUsernames) {
         // More than one credential -> show autocomplete list
         kpxcUserAutocomplete.showList(field);
     } else {


### PR DESCRIPTION
If Autocomplete Menu is disabled from the extension settings, only active element is filled with username or password, not the whole combination.

Note: Filling only the active element should be done only if a combination is not detected at all (for example single username field that is not automatically detected).

Fixes #1973.