### PR TITLE
Fix getting combination from Custom Login Fields during credential save

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -195,10 +195,9 @@ kpxcFields.getAllPageInputs = async function(previousInputs = []) {
 /**
  * Returns the combination where input field is used
  * @param {HTMLElement} field Input field
- * @param {String} givenType 'username' or 'password'
+ * @param {String} givenType For example: 'username', 'password', 'totp', 'totpInputs'
  */
 kpxcFields.getCombination = async function(field, givenType) {
-    // If givenType is not set, return the combination that uses the selected field
     for (const combination of kpxc.combinations) {
         if (givenType) {
             // Strictly search a given type

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -546,22 +546,27 @@ kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue
 
 // Save credentials triggered fron the context menu
 kpxc.rememberCredentialsFromContextMenu = async function() {
+    if (kpxc.databaseState === DatabaseState.LOCKED) {
+        kpxcUI.createNotification('error', tr('rememberErrorDatabaseClosed'));
+        return;
+    }
+
     const el = document.activeElement;
     if (el.nodeName !== 'INPUT') {
         return;
     }
 
-    const type = el.getAttribute('type');
-    const combination = await kpxcFields.getCombination(el, (type === 'password' ? type : 'username'));
+    const combination = await kpxcFields.getCombination(el);
     if (!combination) {
         logDebug('Error: No combination found.');
         return;
     }
 
-    const usernameValue = combination.username ? combination.username.value : '';
-    const passwordValue = combination.password ? combination.password.value : '';
+    const usernameValue = combination.username?.value ?? '';
+    const passwordValue = combination.password?.value ?? '';
 
-    const result = await kpxc.rememberCredentials(usernameValue, passwordValue, undefined, undefined, kpxc.settings.showLoginNotifications);
+    const result = await kpxc.rememberCredentials(usernameValue, passwordValue, undefined, undefined,
+        kpxc.settings.showLoginNotifications);
     if (result === undefined) {
         kpxcUI.createNotification('error', tr('rememberNoPassword'));
         return;


### PR DESCRIPTION
Fixes a few bugs related to credential saving from context menu:
- No notification is shown if database is closed.
- If Custom Login Fields have set to the page, combination is not found because it is bound to the active element `type`. This is not needed because the combination array already includes the input elements correctly.