### PR TITLE
Fix Autocomplete Menu fill on Enter when list is sorted

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -33,7 +33,7 @@ class Autocomplete {
 
     }
 
-    async itemEnter(index, elements) {
+    async itemEnter(index, item) {
 
     }
 
@@ -132,6 +132,7 @@ class Autocomplete {
         for (const c of this.elements) {
             const item = document.createElement('div');
             item.textContent = c.label;
+            item.setAttribute('uuid', c.uuid);
 
             const itemInput = kpxcUI.createElement('input', '', { 'type': 'hidden', 'value': c.value });
             item.append(itemInput);
@@ -220,7 +221,7 @@ class Autocomplete {
             if (this.index >= 0 && items[this.index] !== undefined) {
                 cancelEvent(e);
 
-                await this.itemEnter(this.index, this.elements);
+                await this.itemEnter(this.index, items[this.index]);
                 this.closeList();
             }
         } else if (e.key === 'Tab' && this.input) {

--- a/keepassxc-browser/content/credential-autocomplete.js
+++ b/keepassxc-browser/content/credential-autocomplete.js
@@ -30,9 +30,10 @@ CredentialAutocomplete.prototype.itemClick = async function(e, input, uuid) {
     input.focus();
 };
 
-CredentialAutocomplete.prototype.itemEnter = async function(index, elements) {
-    const usernameValue = elements[index].value;
-    this.fillPassword(usernameValue, index, elements[index].uuid);
+CredentialAutocomplete.prototype.itemEnter = async function(index, item) {
+    const usernameValue = item?.getElementsByTagName('input')[0].value;
+    const uuid = item?.getAttribute('uuid');
+    this.fillPassword(usernameValue, index, uuid);
 };
 
 CredentialAutocomplete.prototype.fillPassword = async function(value, index, uuid) {

--- a/keepassxc-browser/content/totp-autocomplete.js
+++ b/keepassxc-browser/content/totp-autocomplete.js
@@ -22,8 +22,9 @@ TOTPAutocomplete.prototype.itemClick = async function(e, input, uuid) {
     input.focus();
 };
 
-TOTPAutocomplete.prototype.itemEnter = async function(index, elements) {
-    this.fillTotp(index, elements[index].uuid);
+TOTPAutocomplete.prototype.itemEnter = async function(index, item) {
+    const uuid = item?.getAttribute('uuid');
+    this.fillTotp(index, uuid);
 };
 
 TOTPAutocomplete.prototype.fillTotp = async function(index, uuid, currentInput) {


### PR DESCRIPTION
When the visible Autocomplete Menu list is sorted, the internal non-sorted list is still used for credential filling with an index when pressing Enter. Instead, the selected item and it's UUID must be used.

Fixes #1917.