### PR TITLE
Fix Check for updates button response

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -135,7 +135,7 @@ kpxcEvent.onGetKeePassXCVersions = async function(tab) {
 
 kpxcEvent.onCheckUpdateKeePassXC = async function() {
     keepass.checkForNewKeePassXCVersion();
-    return { current: keepass.currentKeePassXC.version, latest: keepass.latestKeePassXC.version };
+    return { current: keepass.currentKeePassXC, latest: keepass.latestKeePassXC.version };
 };
 
 kpxcEvent.onUpdateAvailableKeePassXC = async function() {


### PR DESCRIPTION
When clicking "Check for updates" button from the settings page, the current KeePassXC version object is not parsed correctly, showing the version as empty string.