### PR TITLE
Use active element on fillFromCombination()

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -30,26 +30,26 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
         return;
     }
 
+    const elem = document.activeElement;
     if (kpxc.combinations.length > 0) {
-        if (await kpxcFill.fillFromCombination(passOnly)) {
+        if (await kpxcFill.fillFromCombination(elem, passOnly)) {
             // Combination found and filled
             return;
         }
     }
 
     // No previous combinations detected. Create a new one from active element
-    const el = document.activeElement;
-    const combination = await kpxc.createCombination(el, passOnly);
+    const combination = await kpxc.createCombination(elem, passOnly);
 
     await sendMessage('page_set_login_id', kpxc.credentials[0].uuid);
     kpxcFill.fillInCredentials(combination, kpxc.credentials[0].login, kpxc.credentials[0].uuid, passOnly);
 };
 
 // Fill from combination, if found
-kpxcFill.fillFromCombination = async function(passOnly) {
+kpxcFill.fillFromCombination = async function(elem, passOnly) {
     const combination = passOnly
-        ? kpxc.combinations.find(c => c.password)
-        : kpxc.combinations.find(c => c.username);
+        ? kpxc.combinations.find(c => c.password === elem)
+        : kpxc.combinations.find(c => c.username === elem);
     if (!combination) {
         logDebug('Error: No combination found.');
         return false;

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -51,7 +51,7 @@ kpxcFill.fillFromCombination = async function(elem, passOnly) {
         ? kpxc.combinations.find(c => c.password === elem)
         : kpxc.combinations.find(c => c.username === elem);
     if (!combination) {
-        logDebug('Error: No combination found.');
+        logDebug('Error: No username/password field combination found.');
         return false;
     }
 


### PR DESCRIPTION
Find the active element from the combinations list instead of just returning the first value that has username or password fields. There can be multiple combinations detected from a page.

Can be tested using https://banking.postbank.de/#/login