### PR TITLE
Use the first combination if active element is not found

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -48,8 +48,8 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
 // Fill from combination, if found
 kpxcFill.fillFromCombination = async function(elem, passOnly) {
     const combination = passOnly
-        ? kpxc.combinations.find(c => c.password === elem)
-        : kpxc.combinations.find(c => c.username === elem);
+        ? kpxc.combinations.find(c => c.password === elem) ?? kpxc.combinations.find(c => c.password)
+        : kpxc.combinations.find(c => c.username === elem) ?? kpxc.combinations.find(c => c.username);
     if (!combination) {
         logDebug('Error: No username/password field combination found.');
         return false;


### PR DESCRIPTION
Addition to #1985. Previously we only selected the first combination, and the fix changed the method to select the one with the active element. Both scenarios should be supported: if the active element is not found in the combination (something else than the input field is selected when trying to fill using keyboard shortcut), select the first combination instead.