### PR TITLE
Fix showing TOTP error message

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -115,7 +115,7 @@ kpxcFill.fillFromTOTP = async function(target) {
     const el = target || document.activeElement;
     const credentialList = await kpxc.updateTOTPList();
 
-    if (credentialList?.length === 0) {
+    if (!credentialList || credentialList?.length === 0) {
         kpxcUI.createNotification('warning', tr('credentialsNoTOTPFound'));
         return;
     }


### PR DESCRIPTION
The `credentialList` can be `undefined`. In that case the error notification is now shown at all.