### PR TITLE
Fix handling message timeouts

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -387,8 +387,9 @@ keepass.getDatabaseHash = async function(tab, args = []) {
 
         keepass.databaseHash = '';
         keepass.isDatabaseClosed = true;
-        if (response.message && response.message === '') {
+        if ((response.message && response.message === '') || response.errorCode === kpErrors.TIMEOUT_OR_NOT_CONNECTED) {
             keepass.isKeePassXCAvailable = false;
+            keepass.isConnected = false;
             keepass.handleError(tab, kpErrors.TIMEOUT_OR_NOT_CONNECTED);
         } else {
             keepass.handleError(tab, response.errorCode, response.error);


### PR DESCRIPTION
In this change:
- SImplify the `messageBuffer` with `getMessage()` and `removeMessage()`.
- Remove timeouted messages from the buffer immediately.
- Ensure `keepass.isConnected` is set to false when `get-databasehash` fails. This affects reconnecting to KeePassXC and can cause request not to return during HTTP Basic Auth.

1.8.8.1 must be released after this.

Fixes #1996.
Fixes #1997.