### PR TITLE
Fix selecting first item on Autocomplete Menu open

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -152,6 +152,8 @@ class Autocomplete {
                 this.list.appendChild(item);
             }
         }
+
+        this.selectItem();
     }
 
     selectItem() {


### PR DESCRIPTION
When opening Autocomplete Menu from keyboard while pressing <kbd>Down</kbd>, the Autocomplete Menu opens but the first item is not selected. If user presses <kbd>Down</kbd> again, the second item is selected normally.