### PR TITLE
Adjust segmented TOTP fields check

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -301,7 +301,9 @@ kpxcFields.getElementFromXPathId = function(xpath) {
 kpxcFields.handleSegmentedTOTPFields = function(inputs, combinations) {
     // Check for multiple segmented TOTP fields when there are no inputs, or combination contains the segemented fields
     const segmentedFields = combinations.filter(c => c.totp);
-    if (combinations.length === 0 || segmentedFields.length === DEFAULT_SEGMENTED_TOTP_FIELDS) {
+    if (combinations.length === 0
+        || segmentedFields.length === DEFAULT_SEGMENTED_TOTP_FIELDS
+        || inputs?.length === DEFAULT_SEGMENTED_TOTP_FIELDS) {
         kpxcFields.getSegmentedTOTPFields(inputs, combinations);
     }
 


### PR DESCRIPTION
There can be a situation where a combination is found, but there's not segmented fields inside it. The `inputs` still have the correct amount directly. In that case the segmented fields should be also detected.
Fixes segmented TOTP field detection for example with Epic Games.