### PR TITLE
Add Wordpress to Site Preferences

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -30,7 +30,8 @@ const PREDEFINED_SITELIST = [
     'https://login3.id.hp.com/*',
     'https://secure.fnac.com/identity/server/gateway/*',
     'https://*.openai.com/u/login/*',
-    'https://www.patreon.com/login'
+    'https://www.patreon.com/login',
+    'https://*.wordpress.com/log-in/'
 ];
 
 const awsUrl = 'signin.aws.amazon.com';
@@ -85,6 +86,8 @@ kpxcSites.exceptionFound = function(identifier, field) {
               && identifier === 'mailboxPassword') {
         return true;
     } else if (document.location.origin === 'https://www.patreon.com' && field?.name === 'current-password') {
+        return true;
+    } else if (document.location.origin === 'https://wordpress.com' && identifier?.value === 'login__form-password') {
         return true;
     }
 


### PR DESCRIPTION
Wordpress' login page has a dynamic password field, plus a single username field. Those are not detected at all by default.