### PR TITLE
Passkeys: Use hostname instead of host

### DIFF
--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -46,9 +46,9 @@ kpxcPasskeysUtils.buildCredentialCreationOptions = function(pkOptions) {
         }
 
         if (!pkOptions.rp.id) {
-            pkOptions.rp.id = window.location.host;
-            pkOptions.rp.name = window.location.host;
-        } else if (!window.location.host.endsWith(pkOptions.rp.id)) {
+            pkOptions.rp.id = window.location.hostname;
+            pkOptions.rp.name = window.location.hostname;
+        } else if (!window.location.hostname.endsWith(pkOptions.rp.id)) {
             throw new DOMException('Site domain differs from RP ID', DOMException.SecurityError);
         }
 
@@ -102,8 +102,8 @@ kpxcPasskeysUtils.buildCredentialRequestOptions = function(pkOptions) {
         checkErrors(pkOptions);
 
         if (!pkOptions.rpId) {
-            pkOptions.rpId = window.location.host;
-        } else if (!window.location.host.endsWith(pkOptions.rpId)) {
+            pkOptions.rpId = window.location.hostname;
+        } else if (!window.location.hostname.endsWith(pkOptions.rpId)) {
             throw new DOMException('Site domain differs from RP ID', DOMException.SecurityError);
         }
 


### PR DESCRIPTION
`hostname` should be used instead of `host`. The latter can contain port information that causes Relying Party to be ignored.