### PR TITLE
Stop pages from being able to style the shadow DOM wrapper div element

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -88,6 +88,7 @@ class Autocomplete {
             const colorStyleSheet = createStylesheet('css/colors.css');
             this.wrapper = kpxcUI.createElement('div');
             this.wrapper.style.display = 'none';
+            this.wrapper.style.all = 'unset';
             styleSheet.addEventListener('load', () => this.wrapper.style.display = 'block');
             this.container = kpxcUI.createElement('div', 'kpxcAutocomplete-container', { 'id': 'kpxcAutocomplete-container' });
 

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -87,8 +87,8 @@ class Autocomplete {
             const styleSheet = createStylesheet('css/autocomplete.css');
             const colorStyleSheet = createStylesheet('css/colors.css');
             this.wrapper = kpxcUI.createElement('div');
-            this.wrapper.style.display = 'none';
             this.wrapper.style.all = 'unset';
+            this.wrapper.style.display = 'none';
             styleSheet.addEventListener('load', () => this.wrapper.style.display = 'block');
             this.container = kpxcUI.createElement('div', 'kpxcAutocomplete-container', { 'id': 'kpxcAutocomplete-container' });
 

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -123,6 +123,7 @@ kpxcBanner.create = async function(credentials = {}) {
 
     const wrapper = document.createElement('div');
     wrapper.style.display = 'none';
+    wrapper.style.all = 'unset';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(colorStyleSheet);

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -122,8 +122,8 @@ kpxcBanner.create = async function(credentials = {}) {
     const colorStyleSheet = createStylesheet('css/colors.css');
 
     const wrapper = document.createElement('div');
-    wrapper.style.display = 'none';
     wrapper.style.all = 'unset';
+    wrapper.style.display = 'none';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(colorStyleSheet);

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -128,14 +128,14 @@ kpxcCustomLoginFieldsBanner.create = async function() {
     const colorStyleSheet = createStylesheet('css/colors.css');
 
     const wrapper = document.createElement('div');
-    wrapper.style.display = 'none';
     wrapper.style.all = 'unset';
+    wrapper.style.display = 'none';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(colorStyleSheet);
-    this.shadowRoot.append(styleSheet);
     this.shadowRoot.append(defineStyleSheet);
     this.shadowRoot.append(buttonStyleSheet);
+    this.shadowRoot.append(styleSheet);
 
     // Only create the banner to top window
     if (window.self === window.top) {

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -129,6 +129,7 @@ kpxcCustomLoginFieldsBanner.create = async function() {
 
     const wrapper = document.createElement('div');
     wrapper.style.display = 'none';
+    wrapper.style.all = 'unset';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });
     this.shadowRoot.append(colorStyleSheet);

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -160,8 +160,8 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
 
     const styleSheet = createStylesheet('css/totp.css');
     const wrapper = document.createElement('div');
-    wrapper.style.display = 'none';
     wrapper.style.all = 'unset';
+    wrapper.style.display = 'none';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
 
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -161,6 +161,7 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
     const styleSheet = createStylesheet('css/totp.css');
     const wrapper = document.createElement('div');
     wrapper.style.display = 'none';
+    wrapper.style.all = 'unset';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
 
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -292,8 +292,8 @@ kpxcUI.createNotification = function(type, message) {
 
     const styleSheet = createStylesheet('css/notification.css');
     notificationWrapper = notificationWrapper || document.createElement('div');
-    notificationWrapper.style.display = 'none';
     notificationWrapper.style.all = 'unset';
+    notificationWrapper.style.display = 'none';
     styleSheet.addEventListener('load', () => notificationWrapper.style.display = 'block');
     this.shadowRoot = notificationWrapper.attachShadow({ mode: 'closed' });
     if (!this.shadowRoot) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -293,6 +293,7 @@ kpxcUI.createNotification = function(type, message) {
     const styleSheet = createStylesheet('css/notification.css');
     notificationWrapper = notificationWrapper || document.createElement('div');
     notificationWrapper.style.display = 'none';
+    notificationWrapper.style.all = 'unset';
     styleSheet.addEventListener('load', () => notificationWrapper.style.display = 'block');
     this.shadowRoot = notificationWrapper.attachShadow({ mode: 'closed' });
     if (!this.shadowRoot) {

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -110,6 +110,7 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
     const styleSheet = createStylesheet('css/username.css');
     const wrapper = document.createElement('div');
     wrapper.style.display = 'none';
+    wrapper.style.all = 'unset';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
 
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -109,8 +109,8 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
 
     const styleSheet = createStylesheet('css/username.css');
     const wrapper = document.createElement('div');
-    wrapper.style.display = 'none';
     wrapper.style.all = 'unset';
+    wrapper.style.display = 'none';
     styleSheet.addEventListener('load', () => wrapper.style.display = 'block');
 
     this.shadowRoot = wrapper.attachShadow({ mode: 'closed' });


### PR DESCRIPTION
This UI issue is easy to reproduce on https://example.com/. That website applies styles to all `div` elements, which includes our wrapper div elements.

If you open the custom fields toolbar on that page then you will see a second white bubble appear at the bottom. This is our wrapper div. By setting <code>[all](https://developer.mozilla.org/en-US/docs/Web/CSS/all): [unset](https://developer.mozilla.org/en-US/docs/Web/CSS/unset);</code> we stop the page's styles from applying to this element.

![Screenshot 2023-12-22 at 14 18 19](https://github.com/keepassxreboot/keepassxc-browser/assets/1991151/981f530c-de7b-4e5b-8359-da83d67abe54)

