### PR TITLE
Fix `keyId` not showing in popup

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -16,7 +16,7 @@ kpxcEvent.onMessage = async function(request, sender) {
 kpxcEvent.showStatus = async function(tab, configured, internalPoll) {
     let keyId = null;
     if (configured && keepass.databaseHash !== ''
-        && Object.hasOwn(keepass.databaseHash, keepass.databaseHash)) {
+        && Object.hasOwn(keepass.keyRing, keepass.databaseHash)) {
         keyId = keepass.keyRing[keepass.databaseHash].id;
     }
 


### PR DESCRIPTION
Broken since 1a218573e7d26b5c7f95d4902f657c081c5418d4.