### PR TITLE
Lower the required KeePassXC version for Passkeys

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -331,13 +331,13 @@ options.showKeePassXCVersions = async function(response) {
         $('#tab-general-settings #downloadFaviconAfterSaveFormGroup').hide();
     }
 
-    // Hide certain options with older KeePassXC versions than 2.8.0
-    const version280Result = await browser.runtime.sendMessage({
+    // Hide certain options with older KeePassXC versions than 2.7.7
+    const version277Result = await browser.runtime.sendMessage({
         action: 'compare_version',
-        args: [ '2.8.0', response.current ]
+        args: [ '2.7.7', response.current ]
     });
 
-    if (!version280Result) {
+    if (!version277Result) {
         $('#tab-general-settings #passkeysOptionsCard').hide();
     }
 };

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -437,7 +437,7 @@ Response message data (success, decrypted):
 }
 ```
 
-### passkeys-get (decrypted, KeePassXC 2.8.0 and newer)
+### passkeys-get (decrypted, KeePassXC 2.7.7 and newer)
 Unencrypted message:
 ```json
 {
@@ -457,7 +457,7 @@ Unencrypted message:
 Response (success, decrypted):
 ```json
 {
-    "version": "2.8.0",
+    "version": "2.7.7",
     "success": "true",
     "nonce": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q",
     "response": PublicKeyCredential
@@ -467,7 +467,7 @@ Response (success, decrypted):
 Response (error, decrypted):
 ```json
 {
-    "version": "2.8.0",
+    "version": "2.7.7",
     "success": "true",
     "nonce": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q",
     "response": {
@@ -476,7 +476,7 @@ Response (error, decrypted):
 }
 ```
 
-### passkeys-register (decrypted, KeePassXC 2.8.0 and newer)
+### passkeys-register (decrypted, KeePassXC 2.7.7 and newer)
 Unencrypted message:
 ```json
 {
@@ -496,7 +496,7 @@ Unencrypted message:
 Response (success, decrypted):
 ```json
 {
-    "version": "2.8.0",
+    "version": "2.7.7",
     "success": "true",
     "nonce": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q"
     "response": PublicKeyCredential
@@ -506,7 +506,7 @@ Response (success, decrypted):
 Response (error, decrypted):
 ```json
 {
-    "version": "2.8.0",
+    "version": "2.7.7",
     "success": "true",
     "nonce": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q",
     "response": {


### PR DESCRIPTION
Changes the required minimum version of Passkey support from KeePassXC 2.8.0 to 2.7.7.