### PR TITLE
Passkeys: Set userVerification to default value if not found

### DIFF
--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -66,6 +66,10 @@ kpxcPasskeysUtils.buildCredentialCreationOptions = function(pkOptions) {
         const publicKey = {};
         publicKey.attestation = pkOptions.attestation || 'none';
         publicKey.authenticatorSelection = pkOptions.authenticatorSelection || { userVerification: 'preferred' };
+        if (!publicKey.authenticatorSelection.userVerification) {
+            publicKey.authenticatorSelection.userVerification = 'preferred';
+        }
+
         publicKey.challenge = arrayBufferToBase64(pkOptions.challenge);
         publicKey.extensions = pkOptions.extensions;
         publicKey.pubKeyCredParams = pkOptions.pubKeyCredParams;


### PR DESCRIPTION
If `authenticatorSelection` is found from the public key, but `userVerification` is missing, set it to the default value `preferred`.

Fixes #2033.