### PR TITLE
Do not clear the username field if the entry has no username set

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -256,7 +256,8 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     }
 
     // Fill username
-    if (combination.username && (!combination.username.value || combination.username.value !== usernameValue)) {
+    if (combination.username && usernameValue &&
+        (!combination.username.value || combination.username.value !== usernameValue)) {
         if (!passOnly) {
             kpxc.setValueWithChange(combination.username, usernameValue);
         }


### PR DESCRIPTION
Username field should not be cleared if the entry has no username set.

Fixes #2105.