### PR TITLE
Do not allow filling password (only) to plain text fields

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -347,6 +347,10 @@
         "message": "Error: Unable to find a password field.",
         "description": "Message shown when no password fields are found."
     },
+    "fieldsPasswordFillNotAccepted": {
+        "message": "Filling password to a plain text field is prevented.",
+        "description": "Message shown when password fill to a plain text field is prevented."
+    },
     "rememberNothingChanged": {
         "message": "Error: Could not detect changed credentials.",
         "description": "Message shown when trying to save credentials that haven't changed."

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -23,6 +23,12 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 
 // Fill requested from the context menu. Active element is used for combination detection
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
+    const elem = document.activeElement;
+    if (passOnly && !passwordFillIsAllowed(elem)) {
+        kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
+        return;
+    }
+
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
         logDebug(`Error: Credential list is empty for: ${document.location.origin}`);
@@ -30,7 +36,6 @@ kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
         return;
     }
 
-    const elem = document.activeElement;
     if (kpxc.combinations.length > 0) {
         if (await kpxcFill.fillFromCombination(elem, passOnly)) {
             // Combination found and filled
@@ -88,7 +93,9 @@ kpxcFill.fillFromAutofill = async function() {
     kpxcFill.fillInCredentials(kpxc.combinations[index], kpxc.credentials[0].login, kpxc.credentials[0].uuid);
 
     // Generate popup-list of usernames + descriptions
-    sendMessage('popup_login', [ { text: `${kpxc.credentials[0].login} (${kpxc.credentials[0].name})`, uuid: kpxc.credentials[0].uuid } ]);
+    sendMessage('popup_login', [
+        { text: `${kpxc.credentials[0].login} (${kpxc.credentials[0].name})`, uuid: kpxc.credentials[0].uuid },
+    ]);
 };
 
 // Fill requested by selecting credentials from the popup
@@ -328,4 +335,22 @@ kpxcFill.performAutoSubmit = async function(combination, skipAutoSubmit) {
     } else {
         (combination.username || combination.password).focus();
     }
+};
+
+// Check if password fill is done to a plain text field
+const passwordFillIsAllowed = function(elem) {
+    const elementIsPasswordField =
+        kpxc.combinations?.some(c => c.password === elem || c?.passwordInputs.some(p => p === elem));
+
+    // Allow if Custom Login fields are used
+    if (kpxcFields.isCustomLoginFieldsUsed() && elementIsPasswordField) {
+        return true;
+    }
+
+    if (elem?.getLowerCaseAttribute('type') !== 'password') {
+        kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
+        return false;
+    }
+
+    return true;
 };


### PR DESCRIPTION
When filling password from a keyboard shortcut or from a context menu, plain text fields should not be filled. When Custom Login Fields are used and the input element is specified as a password field, then the fill is allowed.

Fixes #2102.