### PR TITLE
Passkeys: Fixes invalid error message related to Resident Keys

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -147,9 +147,9 @@
         "message": "Invalid URL provided.",
         "description": "Invalid URL provided."
     },
-    "errorMessagePasskeysResidentKeyNotSupported": {
-        "message": "Resident Keys are not supported.",
-        "description": "Resident Keys are not supported."
+    "errorMessagePasskeysNonResidentKeysNotSupported": {
+        "message": "Non-Resident Keys are not supported.",
+        "description": "Non-Resident Keys are not supported."
     },
     "errorNotConnected": {
         "message": "Not connected to KeePassXC.",

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -60,7 +60,7 @@ const kpErrors = {
         23: { msg: tr('errorMessagePasskeysInvalidUserVerification') },
         24: { msg: tr('errorMessagePasskeysEmptyPublicKey') },
         25: { msg: tr('errorMessagePasskeysInvalidUrlProvided') },
-        26: { msg: tr('errorMessagePasskeysResidentKeyNotSupported') },
+        26: { msg: tr('errorMessagePasskeysNonResidentKeysNotSupported') },
     },
 
     getError(errorCode) {


### PR DESCRIPTION
Non-Resident Keys are the ones that aren't supported. Related KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/10283