### PR TITLE
Fix calculation of icon offset

### DIFF
--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -126,7 +126,8 @@ kpxcUI.updateIconPosition = function(iconClass) {
 };
 
 kpxcUI.calculateIconOffset = function(field, size) {
-    const offset = Math.floor((field.offsetHeight - size) / 3);
+    const offset = Math.floor((field.offsetHeight / 2) - (size / 2) - 1);
+    console.log(field.offsetHeight, size, offset);
     return (offset < 0) ? 0 : offset;
 };
 

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -127,7 +127,6 @@ kpxcUI.updateIconPosition = function(iconClass) {
 
 kpxcUI.calculateIconOffset = function(field, size) {
     const offset = Math.floor((field.offsetHeight / 2) - (size / 2) - 1);
-    console.log(field.offsetHeight, size, offset);
     return (offset < 0) ? 0 : offset;
 };
 


### PR DESCRIPTION
Hello,

this PR fixes the current calculation of the icon offset relative to input fields.
Especially with large input fields it can happen, that the icon is not placed appropiately. Please refer to my before/after screenshots for a comparison.

**Before:**
![1_before](https://github.com/keepassxreboot/keepassxc-browser/assets/6287093/e1744bc6-c077-4f0a-b7d3-be99a1dae6c3)

**After:**
![1_after](https://github.com/keepassxreboot/keepassxc-browser/assets/6287093/2323be89-aefe-4022-bed5-4808be3e5ae6)


**Before:**
![2_before](https://github.com/keepassxreboot/keepassxc-browser/assets/6287093/ae277880-ee3b-4f57-bc23-422c51b19be5)

**After:**
![2_after](https://github.com/keepassxreboot/keepassxc-browser/assets/6287093/94b296eb-685e-42f9-8160-46282be0c037)
