### PR TITLE
Fix forwarding to fallback on errors

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -843,7 +843,9 @@ kpxc.enablePasskeys = function() {
                     kpxcUI.createNotification('error', errorMessage);
                 }
 
-                if (letTimerRunOut(ret?.response?.errorCode)) {
+                if (kpxc.settings.passkeysFallback) {
+                    kpxcPasskeysUtils.sendPasskeysResponse(undefined, ret.response?.errorCode, errorMessage);
+                } else if (letTimerRunOut(ret?.response?.errorCode)) {
                     return;
                 }
             }

--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -56,7 +56,7 @@ const kpxcPasskeysUtils = {};
 // Sends response from KeePassXC back to the injected script
 kpxcPasskeysUtils.sendPasskeysResponse = function(publicKey, errorCode, errorMessage) {
     const response = errorCode
-        ? { errorCode: errorCode, errorMessage: errorMessage }
+        ? { errorCode: errorCode, errorMessage: errorMessage, fallback: kpxc.settings.passkeysFallback }
         : { publicKey: publicKey, fallback: kpxc.settings.passkeysFallback };
     const details = isFirefox() ? cloneInto(response, document.defaultView) : response;
     document.dispatchEvent(new CustomEvent('kpxc-passkeys-response', { detail: details }));

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -46,7 +46,7 @@ const isSameOriginWithAncestors = function() {
 };
 
 // Throws errors to a correct exceptions
-const handleError = function(errorCode, errorMessage) {
+const throwError = function(errorCode, errorMessage) {
     if ((!errorCode && !errorMessage) || errorCode === PASSKEYS_REQUEST_CANCELED) {
         // No error or canceled by user. Stop the timer but throw no exception. Fallback with be called instead.
         return;
@@ -103,7 +103,9 @@ const handleError = function(errorCode, errorMessage) {
             });
 
             if (!response.publicKey) {
-                handleError(response?.errorCode, response?.errorMessage);
+                if (!response.fallback) {
+                    throwError(response?.errorCode, response?.errorMessage);
+                }
                 return response.fallback ? originalCredentials.create(options) : null;
             }
 
@@ -129,7 +131,9 @@ const handleError = function(errorCode, errorMessage) {
             });
 
             if (!response.publicKey) {
-                handleError(response?.errorCode, response?.errorMessage);
+                if (!response.fallback) {
+                    throwError(response?.errorCode, response?.errorMessage);
+                }
                 return response.fallback ? originalCredentials.get(options) : null;
             }
 


### PR DESCRIPTION
Errors should be only thrown if the fallback option is not used. Otherwise it prevents to use the browser/OS level dialog when there are no saved Passkeys in KeePassXC, but user has a Yubikey or other device that is being used to login instead.

Fixes #2140.