### PR TITLE
Fix monochrome icon in Chrome when `colorTheme == 'system'` (MV3 fix)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -159,6 +159,7 @@
         "Pixels": true,
         "PREDEFINED_SITELIST": true,
         "RED_BUTTON": true,
+        "retrieveColorScheme": true,
         "sendMessage": true,
         "showNotification": true,
         "siteMatch": true,

--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -143,6 +143,7 @@
         "cookies",
         "nativeMessaging",
         "notifications",
+        "offscreen",
         "storage",
         "tabs",
         "webNavigation",

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -38,6 +38,7 @@
             "background/client.js",
             "background/keepass.js",
             "background/httpauth.js",
+            "background/offscreen.js",
             "background/browserAction.js",
             "background/page.js",
             "background/event.js",

--- a/keepassxc-browser/background/background_service.js
+++ b/keepassxc-browser/background/background_service.js
@@ -10,6 +10,7 @@ try {
         'client.js',
         'keepass.js',
         'httpauth.js',
+        'offscreen.js',
         'browserAction.js',
         'page.js',
         'event.js',

--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -83,7 +83,7 @@ browserAction.generateIconName = async function(iconType) {
     let style = 'colored';
     if (page.settings.useMonochromeToolbarIcon) {
         if (page.settings.colorTheme === 'system') {
-            style = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            style = await retrieveColorScheme();
         } else {
             style = page.settings.colorTheme;
         }

--- a/keepassxc-browser/background/offscreen.js
+++ b/keepassxc-browser/background/offscreen.js
@@ -1,0 +1,31 @@
+'use strict';
+
+async function retrieveColorScheme() {
+    if (typeof window !== 'undefined') {
+        // Firefox does not support the offscreen API but its background script still has a window (so far)
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    const offscreenUrl = browser.runtime.getURL('offscreen/offscreen.html');
+    const existingContexts = await browser.runtime.getContexts({
+        contextTypes: [ 'OFFSCREEN_DOCUMENT' ],
+        documentUrls: [ offscreenUrl ],
+    });
+    if (existingContexts.length === 0) {
+        await browser.offscreen.createDocument({
+            url: offscreenUrl,
+            reasons: [ 'MATCH_MEDIA' ],
+            justification: 'Retrieve color scheme',
+        });
+    }
+
+    const style = await browser.runtime.sendMessage({
+        target: 'offscreen',
+        action: 'retrieve_color_scheme',
+    });
+    if (!style) {
+        // if messaging fails then use "light" icon
+        return 'light';
+    }
+    return style;
+}

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -40,6 +40,7 @@
             "background/client.js",
             "background/keepass.js",
             "background/httpauth.js",
+            "background/offscreen.js",
             "background/browserAction.js",
             "background/page.js",
             "background/event.js",

--- a/keepassxc-browser/offscreen/offscreen.html
+++ b/keepassxc-browser/offscreen/offscreen.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="offscreen.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/keepassxc-browser/offscreen/offscreen.js
+++ b/keepassxc-browser/offscreen/offscreen.js
@@ -1,0 +1,9 @@
+chrome.runtime.onMessage.addListener(({ target, action }, sender, sendResponse) => {
+    if (target !== 'offscreen') {
+        return;
+    }
+    if (action === 'retrieve_color_scheme') {
+        const style = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        sendResponse(style);
+    }
+});


### PR DESCRIPTION
Since the MV3 upgrade, the background script in Chrome does not have a `window`. Attempting to use the monochrome icon when the theme is `system` results in an error.

![Screenshot 2024-03-18 at 20 04 00](https://github.com/keepassxreboot/keepassxc-browser/assets/1991151/55f7417e-a430-4b84-b475-011fea765827)

This uses the offscreen API to work around the issue. Another option is to set the "effective" theme when the options are saved. This would be a poor experience if the user changes the theme (or if their computer is set to automatically change it based on the time of day).

This doesn't close the offscreen document, which I _think_ is ok. I think it will automatically close on its own. I think this is called a lot so it is probably good to keep it around. 🤷 
