### PR TITLE
Fix showing number of credentials with HTTP Basic Auth

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -17,7 +17,13 @@ browserAction.show = async function(tab, popupData) {
             popup: `popups/${popupData.popup}.html`
         });
 
-        const badgeText = popupData.popup === 'popup_login' ? String(page.tabs[tab.id]?.loginList?.length) : '';
+        let badgeText = '';
+        if (popupData.popup === 'popup_login') {
+            badgeText = String(page.tabs[tab.id]?.loginList?.length);
+        } else if (popupData.popup === 'popup_httpauth') {
+            badgeText = String(page.tabs[tab.id]?.loginList?.logins?.length);
+        }
+
         browserAction.setBadgeText(tab?.id, badgeText);
     }
 };


### PR DESCRIPTION
https://github.com/keepassxreboot/keepassxc-browser/pull/2125 changed the toolbar icon behavior to show number of credentials instead of a small question mark in the bottom right corner. If HTTP Basic Auth has more than one credentials available, the icon is not changed properly.