### PR TITLE
Handle iframe URLs correctly

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -340,7 +340,7 @@ page.setAllowIframes = async function(tab, args = []) {
     const [ allowIframes, site ] = args;
 
     // Only set when main windows' URL is used
-    if (tab?.url === site) {
+    if (trimURL(tab?.url) === trimURL(site)) {
         page.tabs[tab.id].allowIframes = allowIframes;
     }
 };

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -33,7 +33,13 @@ kpxc.url = null;
 // Add page to Site Preferences with a selected option enabled. Set from the popup.
 kpxc.addToSitePreferences = async function(optionName, addWildcard = false) {
     // Returns a predefined URL for certain sites
-    let site = trimURL(window.top.location.href);
+    let site;
+    try {
+        site = trimURL(window.top.location.href);
+    } catch (err) {
+        logDebug('Adding to Site Preferences denied from iframe.');
+        return;
+    }
 
     // Check if the site already exists -> update the current settings
     let siteExists = false;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -33,7 +33,7 @@ kpxc.url = null;
 // Add page to Site Preferences with a selected option enabled. Set from the popup.
 kpxc.addToSitePreferences = async function(optionName, addWildcard = false) {
     // Returns a predefined URL for certain sites
-    let site = trimURL(window.top.location.href).toLowerCase();
+    let site = trimURL(window.top.location.href);
 
     // Check if the site already exists -> update the current settings
     let siteExists = false;
@@ -718,11 +718,12 @@ kpxc.siteIgnored = async function(condition) {
     if (kpxc.settings.sitePreferences) {
         let currentLocation;
         try {
-            currentLocation = window.top.location.href.toLowerCase();
+            currentLocation = window.top.location.href;
         } catch (err) {
             // Cross-domain security error inspecting window.top.location.href.
-            // This catches an error when an iframe is being accessed from another (sub)domain -> use the iframe URL instead.
-            currentLocation = window.self.location.href.toLowerCase();
+            // This catches an error when an iframe is being accessed from another (sub)domain
+            // -> use the iframe URL instead.
+            currentLocation = window.self.location.href;
         }
 
         // Refresh current settings for the site


### PR DESCRIPTION
When comparing URL's with the new iframe support, things are not working as planned.
Fixes:
- Do not use `toLowerCase()`. The paths can contain uppercase letters, and we no longer rely just on domains.
- Use `trimURL()` to remove search part of the URL so a proper comparisons can be made.

Fixes the issue mentioned in https://github.com/keepassxreboot/keepassxc-browser/issues/1358#issuecomment-2031388026.