### PR TITLE
Passkeys: Wrap response to PublicKeyCredential

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -838,10 +838,7 @@ kpxc.enablePasskeys = function() {
             let errorMessage;
             if (ret.response && ret.response.errorCode) {
                 errorMessage = await sendMessage('get_error_message', ret.response.errorCode);
-                // Do not create a notification for this error
-                if (ret?.response?.errorCode !== PASSKEYS_WAIT_FOR_LIFETIMER) {
-                    kpxcUI.createNotification('error', errorMessage);
-                }
+                kpxcUI.createNotification('error', errorMessage);
 
                 if (kpxc.settings.passkeysFallback) {
                     kpxcPasskeysUtils.sendPasskeysResponse(undefined, ret.response?.errorCode, errorMessage);
@@ -850,8 +847,8 @@ kpxc.enablePasskeys = function() {
                 }
             }
 
-            const responsePublicKey = callback(ret.response);
-            kpxcPasskeysUtils.sendPasskeysResponse(responsePublicKey, ret.response?.errorCode, errorMessage);
+            logDebug('Passkey response', ret.response);
+            kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
             stopTimer(lifetimeTimer);
         }
     };
@@ -867,15 +864,15 @@ kpxc.enablePasskeys = function() {
                 ev.detail.publicKey,
                 ev.detail.sameOriginWithAncestors,
             );
-            logDebug('publicKey', publicKey);
-            await sendResponse('passkeys_register', publicKey, kpxcPasskeysUtils.parsePublicKeyCredential);
+            logDebug('Passkey request', publicKey);
+            await sendResponse('passkeys_register', publicKey);
         } else if (ev.detail.action === 'passkeys_get') {
             const publicKey = kpxcPasskeysUtils.buildCredentialRequestOptions(
                 ev.detail.publicKey,
                 ev.detail.sameOriginWithAncestors,
             );
-            logDebug('publicKey', publicKey);
-            await sendResponse('passkeys_get', publicKey, kpxcPasskeysUtils.parseGetPublicKeyCredential);
+            logDebug('Passkey request', publicKey);
+            await sendResponse('passkeys_get', publicKey);
         }
     });
 };

--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -4,16 +4,6 @@ const MINIMUM_TIMEOUT = 15000;
 const DEFAULT_TIMEOUT = 30000;
 const DISCOURAGED_TIMEOUT = 120000;
 
-const stringToArrayBuffer = function(str) {
-    const arr = Uint8Array.from(str, c => c.charCodeAt(0));
-    return arr.buffer;
-};
-
-// From URL encoded base64 string to ArrayBuffer
-const base64ToArrayBuffer = function(str) {
-    return stringToArrayBuffer(window.atob(str.replaceAll('-', '+').replaceAll('_', '/')));
-};
-
 // From ArrayBuffer to URL encoded base64 string
 const arrayBufferToBase64 = function(buf) {
     const str = [ ...new Uint8Array(buf) ].map(c => String.fromCharCode(c)).join('');
@@ -157,37 +147,4 @@ kpxcPasskeysUtils.buildCredentialRequestOptions = function(pkOptions, sameOrigin
     } catch (e) {
         console.log(e);
     }
-};
-
-// Parse register response back from base64 strings to ByteArrays
-kpxcPasskeysUtils.parsePublicKeyCredential = function(publicKeyCredential) {
-    if (!publicKeyCredential || !publicKeyCredential.type) {
-        return undefined;
-    }
-
-    publicKeyCredential.rawId = base64ToArrayBuffer(publicKeyCredential.id);
-    publicKeyCredential.response.attestationObject =
-        base64ToArrayBuffer(publicKeyCredential.response.attestationObject);
-    publicKeyCredential.response.clientDataJSON = base64ToArrayBuffer(publicKeyCredential.response.clientDataJSON);
-
-    return publicKeyCredential;
-};
-
-// Parse authentication response back from base64 strings to ByteArrays
-kpxcPasskeysUtils.parseGetPublicKeyCredential = function(publicKeyCredential) {
-    if (!publicKeyCredential || !publicKeyCredential.type) {
-        return undefined;
-    }
-
-    publicKeyCredential.rawId = base64ToArrayBuffer(publicKeyCredential.id);
-    publicKeyCredential.response.authenticatorData =
-        base64ToArrayBuffer(publicKeyCredential.response.authenticatorData);
-    publicKeyCredential.response.clientDataJSON = base64ToArrayBuffer(publicKeyCredential.response.clientDataJSON);
-    publicKeyCredential.response.signature = base64ToArrayBuffer(publicKeyCredential.response.signature);
-
-    if (publicKeyCredential.response.userHandle) {
-        publicKeyCredential.response.userHandle = base64ToArrayBuffer(publicKeyCredential.response.userHandle);
-    }
-
-    return publicKeyCredential;
 };


### PR DESCRIPTION
Wraps the response to a proper `PublicKeyCredential` object. The object is passed as a normal object from the content script, and constructed at the injected script side. I had some strange problems when passing `PublicKeyCredential` object directly to the injected script, so this is the safest way to ensure compatibility.

Also fixes showing an error when credential is excluded, which is quite a common case. Even if we just let the lifetime timer run out, user should have some indication why the passkey creation fails.

I tested this with almost every site I have working passkeys. These changes didn't improve the situation with some problematic sites, e.g. Microsoft.

Supports extension JSON changes with https://github.com/keepassxreboot/keepassxc/pull/10615.

Fixes #2173.