### PR TITLE
Remove duplicate notification

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -348,10 +348,5 @@ const passwordFillIsAllowed = function(elem) {
         return true;
     }
 
-    if (elem?.getLowerCaseAttribute('type') !== 'password') {
-        kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
-        return false;
-    }
-
-    return true;
+    return elem?.getLowerCaseAttribute('type') === 'password';
 };


### PR DESCRIPTION
The `passwordFillIsAllowed` function should only do a check. The logging is done in the caller