### PR TITLE
Remove obsolete hashed scripts from manifest

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.9.0.5 (2024-05-12)
+=========================
+-  Remove obsolete hashed scripts from manifest [#2195]
+
 1.9.0.4 (2024-05-03)
 =========================
 - Passkeys: Wrap response to PublicKeyCredential [#2178]

--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 3,
     "name": "KeePassXC-Browser",
-    "version": "1.9.0.4",
-    "version_name": "1.9.0.4",
+    "version": "1.9.0.5",
+    "version_name": "1.9.0.5",
     "minimum_chrome_version": "93",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.9.0.4",
+    "version": "1.9.0.5",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
     "icons": {
@@ -156,7 +156,6 @@
         "http://*/*",
         "https://api.github.com/"
     ],
-    "content_security_policy": "script-src 'self' 'sha256-4nJ8uLezzRE3SiBFdkVN/uNwV9YTOGCqRXg6AvB5rCY='; object-src 'none'",
     "applications": {
         "gecko": {
             "id": "keepassxc-browser@keepassxc.org",

--- a/keepassxc-browser/_locales/ja/messages.json
+++ b/keepassxc-browser/_locales/ja/messages.json
@@ -1263,15 +1263,15 @@
         "description": "Extension title in settings page"
     },
     "optionsPasskeysTitle": {
-        "message": "Passkeys",
+        "message": "パスキー",
         "description": "Passkeys settings title in settings page."
     },
     "optionsPasskeysEnable": {
-        "message": "Enable passkeys",
+        "message": "パスキーを有効にする",
         "description": "Enabled passkeys option text."
     },
     "optionsPasskeysEnableHelpText": {
-        "message": "Enable support for Web Authentication.",
+        "message": "ウェブ認証への対応を有効にします。",
         "description": "Passkeys option help text."
     },
     "optionsPasskeysEnableFallback": {
@@ -1279,7 +1279,7 @@
         "description": "Enabled passkeys fallback option text."
     },
     "optionsPasskeysEnableFallbackHelpText": {
-        "message": "When enabled, a failed or canceled request to KeePassXC will trigger the browser's own internal passkeys request. If disabled, connection to KeePassXC is required and canceled request will fail. Default: enabled.",
+        "message": "有効にすると、KeePassXC へのリクエストに失敗したりキャンセルされた場合に、ブラウザー内部のパスキーリクエストを開始します。無効にすると KeePassXC への接続が必須になり、リクエストをキャンセルすると登録失敗になります。デフォルト: 有効。",
         "description": "Passkeys fallback option help text."
     },
     "openNewTab": {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "KeePassXC-Browser",
-    "version": "1.9.0.4",
-    "version_name": "1.9.0.4",
+    "version": "1.9.0.5",
+    "version_name": "1.9.0.5",
     "minimum_chrome_version": "93",
     "description": "__MSG_extensionDescription__",
     "author": "KeePassXC Team",
@@ -158,7 +158,6 @@
         "http://*/*",
         "https://api.github.com/"
     ],
-    "content_security_policy": "script-src 'self' 'sha256-o4BRBtP28Aof7Hm1dUp+wlMic7aYLfwjS3E5vTxthQU=' 'sha256-4nJ8uLezzRE3SiBFdkVN/uNwV9YTOGCqRXg6AvB5rCY='; object-src 'none'",
     "applications": {
         "gecko": {
             "id": "keepassxc-browser@keepassxc.org",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keepassxc-browser",
-  "version": "1.9.0.4",
+  "version": "1.9.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "keepassxc-browser",
-      "version": "1.9.0.4",
+      "version": "1.9.0.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keepassxc-browser",
-  "version": "1.9.0.4",
+  "version": "1.9.0.5",
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {


### PR DESCRIPTION
The SHA256 hashes in `content_security_policy` are no longer needed, and our 1.9.0.4 release for Firefox has blocked from review because of these. A new release must be made ASAP.

`sha256-o4BRBtP28Aof7Hm1dUp+wlMic7aYLfwjS3E5vTxthQU=` was added [here](https://github.com/keepassxreboot/keepassxc-browser/pull/1987), and no longer needed after [this](https://github.com/keepassxreboot/keepassxc-browser/pull/1723).

`sha256-4nJ8uLezzRE3SiBFdkVN/uNwV9YTOGCqRXg6AvB5rCY=` was added [here](https://github.com/keepassxreboot/keepassxc-browser/pull/1571), and no longer needed after [this](https://github.com/keepassxreboot/keepassxc-browser/pull/1771).

I'll update the CHANGELOG and translations to this same PR before merge.