### PR TITLE
Fix XML formatting with Firefox

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -806,6 +806,10 @@ kpxc.updateTOTPList = async function() {
 
 // Apply a script to the page for intercepting Passkeys (WebAuthn) requests
 kpxc.enablePasskeys = function() {
+    if (document?.documentElement?.ownerDocument?.contentType === 'text/xml') {
+        return;
+    }
+
     const passkeys = document.createElement('script');
     passkeys.src = browser.runtime.getURL('content/passkeys.js');
     document.documentElement.appendChild(passkeys);


### PR DESCRIPTION
Passkey script injection breaks XML formatting with Firefox. If the page is plain XML document, no script should be injected.

Fixes #2198.