### PR TITLE
Ignore all ports by default in Site Preferences

### DIFF
--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -87,8 +87,8 @@ const siteMatch = function(site, url) {
         const siteUrl = new URL(site);
         const currentUrl = new URL(url);
 
-        // Match scheme and port
-        if (siteUrl.protocol !== currentUrl.protocol || siteUrl.port !== currentUrl.port) {
+        // Match scheme and port. If Site Preferences does not use a port, all ports are ignored.
+        if (siteUrl.protocol !== currentUrl.protocol || (siteUrl.port && siteUrl.port !== currentUrl.port)) {
             return false;
         }
 


### PR DESCRIPTION
If e.g. `http://localhost` is set to Site Preferences and all features are disabled, URL's with ports (for example `http://localhost:8000`) are still accepted.

Changed the behavior so that with `http://localhost` all ports are also disabled by default. Single ports can be still ignored if explicitly set with `http://localhost:8000`, but both rules cannot exist simultaneously. Sadly, this removes the possibility to have a global ignore rule but some single ports allowed at the same time.

Fixes #2201.