### PR TITLE
Show group name in Credential Banner's menu when updating a credential

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -146,6 +146,12 @@ kpxc.getDocumentLocation = function() {
     return kpxc.settings.saveDomainOnly ? document.location.origin : document.location.href;
 };
 
+kpxc.getUniqueGroupCount = function(creds) {
+    const groups = creds.map(c => c.group || '');
+    const uniqueGroups = new Set(groups);
+    return uniqueGroups.size;
+};
+
 // Returns the form that includes the inputField
 kpxc.getForm = function(inputField) {
     if (inputField.form) {
@@ -391,13 +397,8 @@ kpxc.initLoginPopup = function() {
             : first.localeCompare(second);
     };
 
-    const getUniqueGroupCount = function(creds) {
-        const groups = creds.map(c => c.group || '');
-        const uniqueGroups = new Set(groups);
-        return uniqueGroups.size;
-    };
-
-    const showGroupNameInAutocomplete = kpxc.settings.showGroupNameInAutocomplete && (getUniqueGroupCount(kpxc.credentials) > 1);
+    const showGroupNameInAutocomplete =
+        kpxc.settings.showGroupNameInAutocomplete && kpxc.getUniqueGroupCount(kpxc.credentials) > 1;
 
     // Initialize login items
     const loginItems = [];
@@ -506,10 +507,13 @@ kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue
         }
     }
 
+    const showGroupNameInAutocomplete =
+        kpxc.settings.showGroupNameInAutocomplete && kpxc.getUniqueGroupCount(credentials) > 1;
+
     const credentialsList = [];
     for (const c of credentials) {
         credentialsList.push({
-            login: c.login,
+            login: showGroupNameInAutocomplete ? `[${c.group}] ${c.login}` : c.login,
             name: c.name,
             uuid: c.uuid
         });


### PR DESCRIPTION
Showing a group in the front of credential is not working with the Credential Banner's update menu.

To reproduce:
1) Have _Display the group name in autocomplete list when credentials are from different groups._ enabled in the extension settings.
2) Create credential for the same site in two different groups.
3) Save new credentials manually for the site using e.g. context menu's Save Credentials.
4) Click _Update_.
5) Group name is not shown in the list.

Fixes #2225.
