### PR TITLE
Rename Credential Banner buttons

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -558,9 +558,13 @@
         "message": "Update",
         "description": "Update button text in popup when updating credentials."
     },
-    "popupButtonDismiss": {
-        "message": "Dismiss",
-        "description": "Dismiss button text in popup when updating credentials."
+    "popupButtonCancel": {
+        "message": "Cancel",
+        "description": "Cancel button text in popup when updating credentials."
+    },
+    "popupButtonBack": {
+        "message": "Back",
+        "description": "Back button text in popup when updating credentials."
     },
     "popupButtonIgnore": {
         "message": "Don't ask again for this site",

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -72,7 +72,7 @@ kpxcBanner.create = async function(credentials = {}) {
         'button',
         RED_BUTTON,
         { id: 'kpxc-banner-btn-dismiss' },
-        tr('popupButtonDismiss'),
+        tr('popupButtonCancel'),
     );
 
     const separator = kpxcUI.createElement('div', 'kpxc-separator');
@@ -106,6 +106,7 @@ kpxcBanner.create = async function(credentials = {}) {
             return;
         }
         kpxcBanner.updateCredentials(credentials);
+        dismissButton.textContent = tr('popupButtonBack');
     });
 
     dismissButton.addEventListener('click', function(e) {
@@ -120,6 +121,7 @@ kpxcBanner.create = async function(credentials = {}) {
             kpxcBanner.shadowSelector('#kpxc-banner-btn-update').hidden = false;
             kpxcBanner.shadowSelector('.kpxc-checkbox').disabled = false;
             kpxcBanner.banner.removeChild(dialog);
+            dismissButton.textContent = tr('popupButtonCancel');
         } else {
             if (ignoreCheckbox.checked) {
                 const ignoreUrl = window.location.href.slice(0, window.location.href.lastIndexOf('/') + 1) + '*';


### PR DESCRIPTION
Renames Credential Banner buttons:
- Dismiss -> Cancel
- Dismiss -> Back (when Update is clicked and credential selection dialog is shown)

Related issue: #2216.