### PR TITLE
Rename functions to prevent override

### DIFF
--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -5,7 +5,7 @@ const DEFAULT_TIMEOUT = 30000;
 const DISCOURAGED_TIMEOUT = 120000;
 
 // From ArrayBuffer to URL encoded base64 string
-const arrayBufferToBase64 = function(buf) {
+const kpxcArrayBufferToBase64 = function(buf) {
     const str = [ ...new Uint8Array(buf) ].map(c => String.fromCharCode(c)).join('');
     return window.btoa(str).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
 };
@@ -60,7 +60,7 @@ kpxcPasskeysUtils.buildCredentialCreationOptions = function(pkOptions, sameOrigi
         const publicKey = {};
         publicKey.attestation = pkOptions?.attestation;
         publicKey.authenticatorSelection = pkOptions?.authenticatorSelection;
-        publicKey.challenge = arrayBufferToBase64(pkOptions.challenge);
+        publicKey.challenge = kpxcArrayBufferToBase64(pkOptions.challenge);
         publicKey.extensions = pkOptions?.extensions;
 
         // Make sure integers are used for "alg". Set to reserved if not found.
@@ -82,7 +82,7 @@ kpxcPasskeysUtils.buildCredentialCreationOptions = function(pkOptions, sameOrigi
         if (pkOptions.excludeCredentials && pkOptions.excludeCredentials.length > 0) {
             for (const cred of pkOptions.excludeCredentials) {
                 publicKey.excludeCredentials.push({
-                    id: arrayBufferToBase64(cred.id),
+                    id: kpxcArrayBufferToBase64(cred.id),
                     transports: cred.transports,
                     type: cred.type
                 });
@@ -91,7 +91,7 @@ kpxcPasskeysUtils.buildCredentialCreationOptions = function(pkOptions, sameOrigi
 
         publicKey.user = {};
         publicKey.user.displayName = pkOptions.user.displayName;
-        publicKey.user.id = arrayBufferToBase64(pkOptions.user.id);
+        publicKey.user.id = kpxcArrayBufferToBase64(pkOptions.user.id);
         publicKey.user.name = pkOptions.user.name;
 
         return publicKey;
@@ -106,7 +106,7 @@ kpxcPasskeysUtils.buildCredentialRequestOptions = function(pkOptions, sameOrigin
         checkErrors(pkOptions, sameOriginWithAncestors);
 
         const publicKey = {};
-        publicKey.challenge = arrayBufferToBase64(pkOptions.challenge);
+        publicKey.challenge = kpxcArrayBufferToBase64(pkOptions.challenge);
         publicKey.enterpriseAttestationPossible = false;
         publicKey.extensions = pkOptions?.extensions;
         publicKey.rpId = pkOptions?.rpId;
@@ -124,7 +124,7 @@ kpxcPasskeysUtils.buildCredentialRequestOptions = function(pkOptions, sameOrigin
                 }
 
                 const arr = {
-                    id: arrayBufferToBase64(cred.id),
+                    id: kpxcArrayBufferToBase64(cred.id),
                     transports: [ ...transports, 'internal' ],
                     type: cred.type
                 };

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -15,22 +15,22 @@ const PASSKEYS_UNKNOWN_ERROR = 31;
 const PASSKEYS_INVALID_CHALLENGE = 32;
 const PASSKEYS_INVALID_USER_ID = 33;
 
-const stringToArrayBuffer = function(str) {
+const kpxcStringToArrayBuffer = function(str) {
     const arr = Uint8Array.from(str, c => c.charCodeAt(0));
     return arr.buffer;
 };
 
 // From URL encoded base64 string to ArrayBuffer
-const base64ToArrayBuffer = function(str) {
-    return stringToArrayBuffer(window.atob(str?.replaceAll('-', '+').replaceAll('_', '/')));
+const kpxcBase64ToArrayBuffer = function(str) {
+    return kpxcStringToArrayBuffer(window.atob(str?.replaceAll('-', '+').replaceAll('_', '/')));
 };
 
 // Wraps response to AuthenticatorAttestationResponse object
 const createAttestationResponse = function(publicKey) {
     const response = {
-        attestationObject: base64ToArrayBuffer(publicKey.response.attestationObject),
-        clientDataJSON: base64ToArrayBuffer(publicKey.response.clientDataJSON),
-        getAuthenticatorData: () => base64ToArrayBuffer(publicKey.response?.authenticatorData),
+        attestationObject: kpxcBase64ToArrayBuffer(publicKey.response.attestationObject),
+        clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response.clientDataJSON),
+        getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
         getTransports: () => [ 'internal' ]
     };
 
@@ -40,10 +40,10 @@ const createAttestationResponse = function(publicKey) {
 // Wraps response to AuthenticatorAssertionResponse object
 const createAssertionResponse = function(publicKey) {
     const response = {
-        authenticatorData: base64ToArrayBuffer(publicKey.response?.authenticatorData),
-        clientDataJSON: base64ToArrayBuffer(publicKey.response?.clientDataJSON),
-        signature: base64ToArrayBuffer(publicKey.response?.signature),
-        userHandle: publicKey.response?.userHandle ? base64ToArrayBuffer(publicKey.response?.userHandle) : null
+        authenticatorData: kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
+        clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response?.clientDataJSON),
+        signature: kpxcBase64ToArrayBuffer(publicKey.response?.signature),
+        userHandle: publicKey.response?.userHandle ? kpxcBase64ToArrayBuffer(publicKey.response?.userHandle) : null
     };
 
     return Object.setPrototypeOf(response, AuthenticatorAssertionResponse.prototype);
@@ -57,7 +57,7 @@ const createPublicKeyCredential = function(publicKey) {
     const publicKeyCredential = {
         authenticatorAttachment: publicKey.authenticatorAttachment,
         id: publicKey.id,
-        rawId: base64ToArrayBuffer(publicKey.id),
+        rawId: kpxcBase64ToArrayBuffer(publicKey.id),
         response: authenticatorResponse,
         type: publicKey.type,
         clientExtensionResults: () => publicKey?.response?.clientExtensionResults || {},


### PR DESCRIPTION
Rename all conversion functions to include `kpxc` at the beginning to prevent overriding page's own scripts.

Fixes #2210.