### PR TITLE
Fix the handling logic for server-sent public key requests

### DIFF
--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -2,7 +2,7 @@
 
 const keepassClient = {};
 keepassClient.keySize = 24;
-keepassClient.messageTimeout = 500; // Milliseconds
+keepassClient.messageTimeout = 5000; // Milliseconds
 keepassClient.nativeHostName = 'org.keepassxc.keepassxc_browser';
 keepassClient.nativePort = null;
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -809,7 +809,7 @@ keepass.disableAutomaticReconnect = function() {
 keepass.reconnect = async function(tab, connectionTimeout) {
     keepassClient.connectToNative();
     keepass.generateNewKeyPair();
-    const keyChangeResult = await keepass.changePublicKeys(tab, true, connectionTimeout).catch(() => false);
+    const keyChangeResult = await keepass.changePublicKeys(tab, !!connectionTimeout, connectionTimeout).catch(() => false);
 
     // Change public keys timeout
     if (!keyChangeResult) {


### PR DESCRIPTION
In some cases, such as restarting the KeepassXC main program, it may send a `change-public-keys` event. However, improper handling of this event leads to persistent `Key exchange was not successful` popups.

Fixes the issue mentioned in #2232.