### PR TITLE
Extended message timeout and modified the `reconnect` function.

### DIFF
--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -2,7 +2,7 @@
 
 const keepassClient = {};
 keepassClient.keySize = 24;
-keepassClient.messageTimeout = 5000; // Milliseconds
+keepassClient.messageTimeout = 1500; // Milliseconds
 keepassClient.nativeHostName = 'org.keepassxc.keepassxc_browser';
 keepassClient.nativePort = null;
 

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -2,7 +2,7 @@
 
 const keepassClient = {};
 keepassClient.keySize = 24;
-keepassClient.messageTimeout = 1500; // Milliseconds
+keepassClient.messageTimeout = 500; // Milliseconds
 keepassClient.nativeHostName = 'org.keepassxc.keepassxc_browser';
 keepassClient.nativePort = null;
 

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -2,7 +2,7 @@
 
 const keepassClient = {};
 keepassClient.keySize = 24;
-keepassClient.messageTimeout = 500; // Milliseconds
+keepassClient.messageTimeout = 5000; // Milliseconds
 keepassClient.nativeHostName = 'org.keepassxc.keepassxc_browser';
 keepassClient.nativePort = null;
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -806,7 +806,7 @@ keepass.disableAutomaticReconnect = function() {
     keepass.reconnectLoop = null;
 };
 
-keepass.reconnect = async function(tab = null, connectionTimeout = null) {
+keepass.reconnect = async function(tab = null, connectionTimeout = 1500) {
     keepassClient.connectToNative();
     keepass.generateNewKeyPair();
     const keyChangeResult = await keepass.changePublicKeys(tab, !!connectionTimeout, connectionTimeout).catch(() => false);

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -795,7 +795,7 @@ keepass.enableAutomaticReconnect = async function() {
     if (keepass.reconnectLoop === null) {
         keepass.reconnectLoop = setInterval(async () => {
             if (!keepass.isKeePassXCAvailable) {
-                keepass.reconnect();
+                keepass.reconnect(null, 1500); // 1.5 seconds timeout for reconnect
             }
         }, 1000);
     }
@@ -806,7 +806,7 @@ keepass.disableAutomaticReconnect = function() {
     keepass.reconnectLoop = null;
 };
 
-keepass.reconnect = async function(tab, connectionTimeout) {
+keepass.reconnect = async function(tab = null, connectionTimeout = null) {
     keepassClient.connectToNative();
     keepass.generateNewKeyPair();
     const keyChangeResult = await keepass.changePublicKeys(tab, !!connectionTimeout, connectionTimeout).catch(() => false);

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -795,7 +795,7 @@ keepass.enableAutomaticReconnect = async function() {
     if (keepass.reconnectLoop === null) {
         keepass.reconnectLoop = setInterval(async () => {
             if (!keepass.isKeePassXCAvailable) {
-                keepass.reconnect(null, 1500); // 1.5 seconds timeout for reconnect
+                keepass.reconnect();
             }
         }, 1000);
     }

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -809,7 +809,7 @@ keepass.disableAutomaticReconnect = function() {
 keepass.reconnect = async function(tab, connectionTimeout) {
     keepassClient.connectToNative();
     keepass.generateNewKeyPair();
-    const keyChangeResult = await keepass.changePublicKeys(tab, true, connectionTimeout).catch(() => false);
+    const keyChangeResult = await keepass.changePublicKeys(tab, !!connectionTimeout, connectionTimeout).catch(() => false);
 
     // Change public keys timeout
     if (!keyChangeResult) {


### PR DESCRIPTION
I found that sometimes when calling the reconnect function, it may be called without any parameters, causing both `tab` and `connectionTimeout` to be `undefined`.

https://github.com/keepassxreboot/keepassxc-browser/blob/b0fd415e425d9e37c7826e4c2904e6eaeae6fb4e/keepassxc-browser/background/keepass.js#L798

In this case, message timeout should not be enabled. 

https://github.com/keepassxreboot/keepassxc-browser/blob/b0fd415e425d9e37c7826e4c2904e6eaeae6fb4e/keepassxc-browser/background/keepass.js#L812

Additionally, the default timeout is too short, so it has been extended, which might explain the console output in https://github.com/keepassxreboot/keepassxc-browser/pull/2233#issuecomment-2158049881

Fixes the issue mentioned in #2232.

