### PR TITLE
Remove obsolete alt property from div

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -226,10 +226,6 @@
         "message": "KeePassXC is disconnected.",
         "description": "Username field icon hover text when KeePassXC is disconnected."
     },
-    "usernameFieldIcon": {
-        "message": "Username field icon.",
-        "description": "Username field icon text."
-    },
     "totp": {
         "message": "TOTP",
         "description": "TOTP text."

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -83,7 +83,6 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-username-icon ' + className,
         {
             'title': getIconText(this.databaseState),
-            'alt': tr('usernameFieldIcon'),
             'size': size,
             'offset': offset,
             'kpxc-pwgen-field-id': field.getAttribute('data-kpxc-id')


### PR DESCRIPTION
`div` has no `alt`, so this code is some leftovers.

Fixes #2239.