### PR TITLE
Change password fill shortcut with Chrome

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -75,8 +75,8 @@
         "fill_password": {
             "description": "__MSG_contextMenuFillPassword__",
             "suggested_key": {
-                "default": "Alt+Shift+I",
-                "mac": "MacCtrl+Shift+I"
+                "default": "Alt+Shift+P",
+                "mac": "MacCtrl+Shift+P"
             }
         },
         "fill_totp": {


### PR DESCRIPTION
Chrome has reserved the current shortcut for "Send Feedback" functionality. It is now changed to <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> for Windows/Linux and <kbd>MacCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> for macOS.

Fixes #2115.