### PR TITLE
Adds a "do not load content scripts" checkbox in the options.

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -706,6 +706,10 @@
         "message": "Automatically retrieve credentials",
         "description": "Automatically retrieve credentials checkbox text."
     },
+    "optionsCheckboxNoContentScripts": {
+        "message": "Do not load content scripts on every page.  Need to manually start via the redetect button.",
+        "description": "No content scripts checkbox text."
+    },
     "optionsCheckboxAutomaticReconnect": {
         "message": "Automatically reconnect to KeePassXC",
         "description": "Auto-reconnect checkbox text."
@@ -853,6 +857,10 @@
     "optionsAutoRetrieveCredentialsHelpText": {
         "message": "KeePassXC-Browser will immediately retrieve credentials when a tab is activated.",
         "description": "Auto-Retrive Credentials option help text."
+    },
+    "optionsNoContentScriptsHelpText": {
+        "message": "Used if this extension is slowing down or freezing the browser.",
+        "description": "No content scripts option help text."
     },
     "optionsAutomaticReconnectHelpText": {
         "message": "Reconnects automatically to KeePassXC when it is detected.",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -292,5 +292,6 @@ kpxcEvent.messageHandlers = {
     'save_settings': kpxcEvent.onSaveSettings,
     'update_available_keepassxc': kpxcEvent.onUpdateAvailableKeePassXC,
     'update_context_menu': page.updateContextMenu,
-    'update_popup': page.updatePopup
+    'update_popup': page.updatePopup,
+    'add_content_scripts': page.addContentScripts
 };

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -84,6 +84,9 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
         if (!page.tabs[tab.id]) {
             page.createTabEntry(tab.id);
         }
+        if(!page.settings.noContentScripts) {
+            page.addContentScripts(tab);
+        }
     }
 });
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -19,6 +19,7 @@ const defaultSettings = {
     defaultGroup: '',
     defaultGroupAlwaysAsk: false,
     downloadFaviconAfterSave: false,
+    noContentScripts: false,
     passkeys: false,
     passkeysFallback: true,
     redirectAllowance: 1,
@@ -334,6 +335,33 @@ page.updateContextMenu = async function(tab, credentials) {
 
 page.updatePopup = function(tab) {
     browserAction.showDefault(tab);
+};
+
+page.addContentScripts = function(tab) {
+    return browser.scripting.executeScript({
+        target : { tabId:tab.id, allFrames: true },
+        files : [
+            '../common/browser-polyfill.min.js',
+            '../common/global.js',
+            '../common/sites.js',
+            '../content/ui.js',
+            '../content/banner.js',
+            '../content/autocomplete.js',
+            '../content/credential-autocomplete.js',
+            '../content/custom-fields-banner.js',
+            '../content/fields.js',
+            '../content/fill.js',
+            '../content/form.js',
+            '../content/icons.js',
+            '../content/keepassxc-browser.js',
+            '../content/observer-helper.js',
+            '../content/pwgen.js',
+            '../content/totp-autocomplete.js',
+            '../content/totp-field.js',
+            '../content/username-field.js',
+            '../content/passkeys-utils.js'
+        ]
+    });
 };
 
 page.setAllowIframes = async function(tab, args = []) {

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -47,36 +47,6 @@
             "background/init.js"
         ]
     },
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "common/browser-polyfill.min.js",
-                "common/global.js",
-                "common/sites.js",
-                "content/ui.js",
-                "content/banner.js",
-                "content/autocomplete.js",
-                "content/credential-autocomplete.js",
-                "content/custom-fields-banner.js",
-                "content/fields.js",
-                "content/fill.js",
-                "content/form.js",
-                "content/icons.js",
-                "content/keepassxc-browser.js",
-                "content/observer-helper.js",
-                "content/pwgen.js",
-                "content/totp-autocomplete.js",
-                "content/totp-field.js",
-                "content/username-field.js",
-                "content/passkeys-utils.js"
-            ],
-            "run_at": "document_idle",
-            "all_frames": true
-        }
-    ],
     "commands": {
         "fill_username_password": {
             "description": "__MSG_contextMenuFillUsernameAndPassword__",
@@ -151,6 +121,7 @@
         "nativeMessaging",
         "notifications",
         "storage",
+        "scripting",
         "tabs",
         "webNavigation",
         "webRequest",

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -178,6 +178,14 @@
                     </div>
                   </div>
 
+                  <div class="form-group">
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" name="noContentScripts" id="noContentScripts" value="true">
+                      <label class="form-check-label" for="noContentScripts" data-i18n="optionsCheckboxNoContentScripts"></label>
+                      <div class="form-text" data-i18n="optionsNoContentScriptsHelpText"></div>
+                    </div>
+                  </div>
+
                   <!-- Use Autocomplete Menu -->
                   <div class="form-group">
                     <div class="form-check">

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -118,7 +118,9 @@ const sendMessageToTab = async function(message) {
         window.close();
     });
 
+
     $('#redetect-fields-button').addEventListener('click', async () => {
+        await browser.runtime.sendMessage({ action: 'add_content_scripts' });
         const res = await sendMessageToTab('redetect_fields');
         if (!res) {
             return;


### PR DESCRIPTION
For people who don't need to use keepassxc on every page.
Normally almost 200kb of content scripts is inserted into every web page you visit.  By ticking this box, this is disabled and you have to click the "redetect" for the keepassxc button to appear.  Easier to use with the extension setup as "pin to toolbar"

Might be a related issue, (I have a random freezing problem too)...
https://github.com/keepassxreboot/keepassxc-browser/issues/1516