### PR TITLE
Add "missing" icon size for Firefox

### DIFF
--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -6,6 +6,7 @@
     "author": "KeePassXC Team",
     "icons": {
         "16": "icons/keepassxc.svg",
+        "32": "icons/keepassxc.svg",
         "48": "icons/keepassxc.svg",
         "64": "icons/keepassxc.svg",
         "96": "icons/keepassxc.svg",


### PR DESCRIPTION
Hey :)

Tiny, silly, tid bit..

At about:addons at zoom levels 50% and lower (on my 2022 MacBook Air), Firefox looks for a 32px icon, though doesn't find it, as it's not defined.

So it fetches https://addons.mozilla.org/user-media/addon_icons/917/917354-32.png?modified=1648138451

I'd prefer if the same SVG were displayed at all sizes.