### PR TITLE
Fix plain text password fill prevention

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -24,10 +24,6 @@ kpxcFill.fillAttributeToActiveElementWith = async function(attr) {
 // Fill requested from the context menu. Active element is used for combination detection
 kpxcFill.fillInFromActiveElement = async function(passOnly = false) {
     const elem = document.activeElement;
-    if (passOnly && !passwordFillIsAllowed(elem)) {
-        kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
-        return;
-    }
 
     await kpxc.receiveCredentialsIfNecessary();
     if (kpxc.credentials.length === 0) {
@@ -250,12 +246,18 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
     }
 
     // Fill password
-    if (combination.password) {
+    if (combination.password && combination.password.nodeName === 'INPUT') {
         // Show a notification if password length exceeds the length defined in input
         if (combination.password.maxLength
             && combination.password.maxLength > 0
             && selectedCredentials.password.length > combination.password.maxLength) {
             kpxcUI.createNotification('error', tr('errorMessagePaswordLengthExceeded'));
+        }
+
+        // Prevent filling password to plain text input field
+        if (passOnly && !passwordFillIsAllowed(combination.password)) {
+            kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
+            return;
         }
 
         kpxc.setValueWithChange(combination.password, selectedCredentials.password);

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -146,7 +146,7 @@ kpxcFill.fillTOTPFromUuid = async function(el, uuid) {
 
     if (user.totp?.length > 0) {
         // Retrieve a new TOTP value
-        const totp = await sendMessage('get_totp', [ user.uuid, user.totp ]);
+        const totp = await sendMessage('get_totp', [user.uuid, user.totp]);
         if (!totp) {
             kpxcUI.createNotification('warning', tr('credentialsNoTOTPFound'));
             return;
@@ -251,12 +251,12 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
         if (combination.password.maxLength
             && combination.password.maxLength > 0
             && selectedCredentials.password.length > combination.password.maxLength) {
-            kpxcUI.createNotification('error', tr('errorMessagePaswordLengthExceeded'));
+            kpxcUI.createNotification('warning', tr('errorMessagePaswordLengthExceeded'));
         }
 
         // Prevent filling password to plain text input field
         if (passOnly && !passwordFillIsAllowed(combination.password)) {
-            kpxcUI.createNotification('warning', tr('fieldsPasswordFillNotAccepted'));
+            kpxcUI.createNotification('error', tr('fieldsPasswordFillNotAccepted'));
             return;
         }
 


### PR DESCRIPTION
Regression from https://github.com/keepassxreboot/keepassxc-browser/pull/2107.

The password fill should be prevented at the last part of the fill, inside `kpxcFill.fillInCredentials()`. It should be also checked if the element is actually an input field. If not, we just don't even try to fill the password.

Fixes #2135.