### PR TITLE
Fix line height with the new Autocomplete Menu

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -30,6 +30,7 @@
     color: var(--kpxc-text-color);
     cursor: pointer;
     letter-spacing: normal !important;
+    line-height: 1.25em;
     padding: 12px;
     text-align: start !important;
     text-rendering: auto !important;


### PR DESCRIPTION
On Windows some letters might get cut off with the new Autocomplete Menu style. Couldn't reproduce this with macOS, but the error can be seen in Windows.

Fixes #2268.