### PR TITLE
Fix setting Autocomplete Menu min-width

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -8,7 +8,7 @@
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     font-size: 14px;
     line-height: 1em;
-    min-width: 16rem;
+    min-width: 16em;
     overflow: hidden; /* Prevent the content from bleeding over the border radius. */
     padding: 6px;
     position: absolute !important;


### PR DESCRIPTION
The Autocomplete Menu's `min-width` should be using `em` instead of `rem`.

Fixes #2273.