### PR TITLE
Extract object from proxy before posting message to extension

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -69,6 +69,22 @@ const createPublicKeyCredential = function(publicKey) {
 
 // Posts a message to extension's content script and waits for response
 const postMessageToExtension = function(request) {
+    // Extract object from proxy
+    const extractFromProxy = obj => {
+        let newObj = obj;
+        if (typeof obj === "object") {
+            if (obj instanceof Array) {
+                newObj = new Array(...obj);
+            }
+            else if (!(obj instanceof ArrayBuffer)) {
+                newObj = {...obj};
+            }
+            Object.keys(newObj)
+            .forEach(k => newObj[k] = extractFromProxy(newObj[k]));
+        }
+        return newObj;
+    }
+
     return new Promise((resolve, reject) => {
         const ev = document;
 
@@ -85,7 +101,7 @@ const postMessageToExtension = function(request) {
         ev.addEventListener('kpxc-passkeys-response', listener);
 
         // Send the request
-        document.dispatchEvent(new CustomEvent('kpxc-passkeys-request', { detail: request }));
+        document.dispatchEvent(new CustomEvent('kpxc-passkeys-request', { detail: extractFromProxy(request) }));
     });
 };
 


### PR DESCRIPTION
In some web page that supports passkey (ex. https://misskey.io/), public key object is passed as [proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), not plain object. Ploxy cannot be passed from the page script to the extension script with `dispatchEvent` method in `postMessageToExtension` function in `passkeys.js`, thus authentication with passkey fails.

In this PR, extraction from proxy to plain object before passing with `dispatchEvent` method is added.