### PR TITLE
Update Playwright and improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .bz2
 .xz
 node_modules
+test-results

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -145,3 +145,12 @@ const getCurrentTab = async function() {
     const tabs = await browser.tabs.query({ active: true, currentWindow: true });
     return tabs.length > 0 ? tabs[0] : undefined;
 };
+
+// Exports for tests
+if (typeof module === 'object') {
+    module.exports = {
+        siteMatch,
+        slashNeededForUrl,
+        trimURL,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.9.1.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "file-url": "^4.0.0"
+        "@npmcli/fs": "^2.1.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.22.0",
+        "@playwright/test": "^1.45.1",
+        "@types/node": "^20.14.10",
         "eslint": "^8.49.0"
       }
     },
@@ -168,26 +168,30 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright": "1.45.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -632,17 +636,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
-      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -667,6 +660,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -950,16 +958,36 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+    "node_modules/playwright": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.45.1"
+      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prelude-ls": {
@@ -1158,6 +1186,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1315,20 +1350,22 @@
       }
     },
     "@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright": "1.45.1"
       }
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "acorn": {
       "version": "8.10.0",
@@ -1653,11 +1690,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "file-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
-      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw=="
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -1679,6 +1711,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.2.3",
@@ -1899,10 +1938,20 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "playwright": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.45.1"
+      }
+    },
     "playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+      "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
       "dev": true
     },
     "prelude-ls": {
@@ -2019,6 +2068,12 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "KeePassXC-Browser",
   "main": "build.js",
   "devDependencies": {
-    "@playwright/test": "^1.22.0",
+    "@playwright/test": "^1.45.1",
+    "@types/node": "^20.14.10",
     "eslint": "^8.49.0"
   },
   "dependencies": {
-    "@npmcli/fs": "^2.1.0",
-    "file-url": "^4.0.0"
+    "@npmcli/fs": "^2.1.0"
   },
   "scripts": {
     "build": "node build.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
-const { devices } = require('@playwright/test');
+import { defineConfig, devices } from '@playwright/test';
 
-const config = {
+export default defineConfig({
     testDir: './tests',
+    fullyParallel: true,
     timeout: 30 * 1000,
     expect: {
         timeout: 5000
@@ -19,18 +20,12 @@ const config = {
     projects: [
         {
             name: 'chromium',
-            use: {
-                ...devices['Desktop Chrome'],
-            },
+            use: { ...devices['Desktop Chrome'] },
         },
         {
             name: 'firefox',
-            use: {
-                ...devices['Desktop Firefox'],
-            },
+            use: { ...devices['Desktop Firefox'] },
         },
     ],
-    testMatch: 'content-script-tests.mjs',
-};
-
-module.exports = config;
+    testMatch: '*.spec.ts',
+});

--- a/tests/content-scripts.spec.ts
+++ b/tests/content-scripts.spec.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { test, expect } from '@playwright/test';
-import fileUrl from 'file-url';
+import { pathToFileURL } from 'node:url';
 
 const DEST = 'keepassxc-browser/tests';
 
@@ -10,11 +10,7 @@ let page;
 test.describe('Content script tests', () => {
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
-        await page.goto(fileUrl(`${DEST}/tests.html`));
-    });
-
-    test('General tests', async () => {
-        await verifyResults('general-results');
+        await page.goto(pathToFileURL(`${DEST}/tests.html`).toString());
     });
 
     test('Input field matching tests', async() => {

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -1,9 +1,0 @@
-const fs = require('@npmcli/fs');
-
-const DEST = 'keepassxc-browser/tests';
-
-module.exports = async config => {
-    // Create a temporary directory and copy tests/* to keepassxc-browser/tests
-    await fs.exists(DEST);
-    await fs.cp('./tests', DEST, { recursive: true });
-};

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,10 @@
+import type { FullConfig } from '@playwright/test';
+import fs from 'fs';
+
+const DEST = 'keepassxc-browser/tests';
+
+export default async function globalSetup(config: FullConfig) {
+  // Create a temporary directory and copy tests/* to keepassxc-browser/tests
+  fs.existsSync(DEST);
+  fs.cpSync('./tests', DEST, { recursive: true });
+}

--- a/tests/global-teardown.js
+++ b/tests/global-teardown.js
@@ -1,8 +1,0 @@
-const fs = require('@npmcli/fs');
-
-const DEST = 'keepassxc-browser/tests';
-
-module.exports = async config => {
-    // Delete previously created temporary directory. Comment for re-running tests manually inside the extension.
-    await fs.rm(DEST, { recursive: true });
-};

--- a/tests/global-teardown.ts
+++ b/tests/global-teardown.ts
@@ -1,0 +1,9 @@
+import type { FullConfig } from '@playwright/test';
+import fs from 'fs';
+
+const DEST = 'keepassxc-browser/tests';
+
+export default async function globalTeardown(config: FullConfig) {
+  // Delete previously created temporary directory. Comment for re-running tests manually inside the extension.
+  fs.rmSync(DEST, { recursive: true });
+}

--- a/tests/global.spec.ts
+++ b/tests/global.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import {
+    siteMatch,
+    slashNeededForUrl,
+    trimURL
+} from '../keepassxc-browser/common/global.js';
+
+test('Test siteMatch()', async ({ page }) => {
+    expect(siteMatch('https://example.com/*', 'https://example.com/login_page')).toBe(true);
+    expect(siteMatch('https://*.lexample.com/*', 'https://example.com/login_page')).toBe(false);
+    expect(siteMatch('https://example.com/*', 'https://example2.com/login_page')).toBe(false);
+    expect(siteMatch('https://example.com/*', 'https://subdomain.example.com/login_page')).toBe(false);
+    expect(siteMatch('https://example.com', 'https://subdomain.example.com/login_page')).toBe(false);
+    expect(siteMatch('https://*.example.com/*', 'https://example.com/login_page')).toBe(true);
+    expect(siteMatch('https://*.example.com/*', 'https://test.example.com/login_page')).toBe(true);
+    expect(siteMatch('https://test.example.com/*', 'https://subdomain.example.com/login_page')).toBe(false);
+    expect(siteMatch('https://test.example.com/page/*', 'https://test.example.com/page/login_page')).toBe(true);
+    expect(siteMatch('https://test.example.com/page/*', 'https://test.example.com/page/login_page?dontcare=aboutme')).toBe(true);
+    expect(siteMatch('https://test.example.com/page/another_page/*', 'https://test.example.com/page/login')).toBe(false);
+    expect(siteMatch('https://test.example.com/path/another/a/', 'https://test.example.com/path/another/a/')).toBe(true);
+    expect(siteMatch('https://test.example.com/path/another/a/', 'https://test.example.com/path/another/b/')).toBe(false);
+    expect(siteMatch('https://test.example.com/*/another/a/', 'https://test.example.com/path/another/a/')).toBe(true);
+    expect(siteMatch('https://test.example.com/path/*/a/', 'https://test.example.com/path/another/a/')).toBe(true);
+    expect(siteMatch('https://test.example.com/path2/*/a/', 'https://test.example.com/path/another/a/')).toBe(false);
+    expect(siteMatch('https://example.com:8448/', 'https://example.com/')).toBe(false);
+    expect(siteMatch('https://example.com:8448/', 'https://example.com:8448/')).toBe(true);
+    expect(siteMatch('https://example.com:8448/login/page', 'https://example.com/login/page')).toBe(false);
+    expect(siteMatch('https://example.com:8448/*', 'https://example.com:8448/login/page')).toBe(true);
+    expect(siteMatch('https://example.com/$/*', 'https://example.com/$/login_page')).toBe(true); // Special character in URL
+    expect(siteMatch('https://example.com/*/*', 'https://example.com/$/login_page')).toBe(true);
+    expect(siteMatch('https://example.com/*/*', 'https://example.com/login_page')).toBe(false);
+    expect(siteMatch('https://*.com/*', 'https://example.com/$/login_page')).toBe(true);
+    expect(siteMatch('https://*.com/*', 'https://example.org/$/login_page')).toBe(false);
+    expect(siteMatch('https://*.*/*', 'https://example.org/$/login_page')).toBe(true);
+
+    // IP based URL's
+    expect(siteMatch('https://127.128.129.130:8448/', 'https://127.128.129.130:8448/')).toBe(true);
+    expect(siteMatch('https://127.128.129.*:8448/', 'https://127.128.129.130:8448/')).toBe(true);
+    expect(siteMatch('https://127.128.*/', 'https://127.128.129.130/')).toBe(true);
+    expect(siteMatch('https://127.128.*/', 'https://127.1.129.130/')).toBe(false);
+    expect(siteMatch('https://127.128.129.130/', 'https://127.128.129.130:8448/')).toBe(true);
+    expect(siteMatch('https://127.128.129.*/', 'https://127.128.129.130:8448/')).toBe(true);
+
+    // Invalid URL's
+    expect(siteMatch('', 'https://example.com')).toBe(false);
+    expect(siteMatch('abcdefgetc', 'https://example.com')).toBe(false);
+    expect(siteMatch('{TOTP}\\no', 'https://example.com')).toBe(false);
+    expect(siteMatch('https://320.320.320.320', 'https://example.com')).toBe(false);
+});
+
+test('Test slashNeededForUrl()', async ({ page }) => {
+    expect(slashNeededForUrl('https://test.com')).not.toBe(null);
+    expect(slashNeededForUrl('https://test.com/')).toBe(null);
+});
+
+test('Test trimURL()', async ({ page }) => {
+    expect(trimURL('https://example.com/path/?login=yes&fallback=no')).toBe('https://example.com/path/');
+    expect(trimURL('https://example.com/path/?login=yes')).toBe('https://example.com/path/');
+    expect(trimURL('https://example.com/path/')).toBe('https://example.com/path/');
+    expect(trimURL('https://example.com/path/#extra')).toBe('https://example.com/path/#extra');
+});

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+//import { getBaseDomainFromUrl, getTopLevelDomainFromUrl } from '../keepassxc-browser/background/page.js';
+
+test.skip('Test getTopLevelDomainFromUrl()', async ({ page }) => {
+    // TODO: Enable these tests later. Not sure how to tests cookies API which requires to be running in the
+    //       background script.
+    // Top-Level-Domain tests
+    /*const tldUrls = [
+        [ 'another.example.co.uk', 'co.uk' ],
+        [ 'www.example.com', 'com' ],
+        [ 'github.com', 'com' ],
+        [ 'test.net', 'net' ],
+        [ 'so.many.subdomains.co.jp', 'co.jp' ],
+        [ '192.168.0.1', '192.168.0.1' ],
+        [ 'www.nic.ar','ar' ],
+        [ 'no.no.no', 'no' ],
+        [ 'www.blogspot.com.ar', 'blogspot.com.ar' ], // blogspot.com.ar is a TLD
+        [ 'jap.an.ide.kyoto.jp', 'ide.kyoto.jp' ], // ide.kyoto.jp is a TLD
+    ];
+
+    for (const d of tldUrls) {
+        //kpxcAssert(page.getTopLevelDomainFromUrl(d[0]), d[1], testCard, 'getTopLevelDomainFromUrl() for ' + d[0]);
+        expect(getTopLevelDomainFromUrl(d[0], 'https://' + d[0])).toBe(d[2]);
+    }
+
+    // Base domain tests
+    const domains = [
+        [ 'another.example.co.uk', 'example.co.uk' ],
+        [ 'www.example.com', 'example.com' ],
+        [ 'test.net', 'test.net' ],
+        [ 'so.many.subdomains.co.jp', 'subdomains.co.jp' ],
+        [ '192.168.0.1', '192.168.0.1' ],
+        [ 'www.nic.ar', 'nic.ar' ],
+        [ 'www.blogspot.com.ar', 'www.blogspot.com.ar' ], // blogspot.com.ar is a TLD
+        [ 'www.arpa', 'www.arpa' ],
+        [ 'jap.an.ide.kyoto.jp', 'an.ide.kyoto.jp' ], // ide.kyoto.jp is a TLD
+        [ 'kobe.jp', 'kobe.jp' ],
+    ];
+
+    for (const d of domains) {
+        //kpxcAssert(page.getBaseDomainFromUrl(d[0]), d[1], testCard, 'getBaseDomainFromUrl() for ' + d[0]);
+        expect(getBaseDomainFromUrl(d[0], 'https://' + d[0])).toBe(d[1]);
+    }*/
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -16,101 +16,6 @@ function createResult(card, res, text) {
     document.querySelector(card).appendMultiple(icon, span, br);
 }
 
-// General (global.js)
-async function testGeneral() {
-    const testCard = Tests.GENERAL;
-
-    // General
-    kpxcAssert(trimURL('https://test.com/path_to_somwhere?login=username'), 'https://test.com/path_to_somwhere', testCard, 'trimURL()');
-    assertRegex(slashNeededForUrl('https://test.com'), true, testCard, 'slashNeededForUrl()');
-    assertRegex(slashNeededForUrl('https://test.com/'), false, testCard, 'slashNeededForUrl()');
-
-    // URL matching (URL in Site Preferences, page URL, expected result).
-    // Consider using slighly different URL's for the tests cases.
-    const matches = [
-        [ 'https://example.com/*', 'https://example.com/login_page', true ],
-        [ 'https://*.lexample.com/*', 'https://example.com/login_page', false ],
-        [ 'https://example.com/*', 'https://example2.com/login_page', false ],
-        [ 'https://example.com/*', 'https://subdomain.example.com/login_page', false ],
-        [ 'https://example.com', 'https://subdomain.example.com/login_page', false ],
-        [ 'https://*.example.com/*', 'https://example.com/login_page', true ],
-        [ 'https://*.example.com/*', 'https://test.example.com/login_page', true ],
-        [ 'https://test.example.com/*', 'https://subdomain.example.com/login_page', false ],
-        [ 'https://test.example.com/page/*', 'https://test.example.com/page/login_page', true ],
-        [ 'https://test.example.com/page/*', 'https://test.example.com/page/login_page?dontcare=aboutme', true ],
-        [ 'https://test.example.com/page/another_page/*', 'https://test.example.com/page/login', false ],
-        [ 'https://test.example.com/path/another/a/', 'https://test.example.com/path/another/a/', true ],
-        [ 'https://test.example.com/path/another/a/', 'https://test.example.com/path/another/b/', false ],
-        [ 'https://test.example.com/*/another/a/', 'https://test.example.com/path/another/a/', true ],
-        [ 'https://test.example.com/path/*/a/', 'https://test.example.com/path/another/a/', true ],
-        [ 'https://test.example.com/path2/*/a/', 'https://test.example.com/path/another/a/', false ],
-        [ 'https://example.com:8448/', 'https://example.com/', false ],
-        [ 'https://example.com:8448/', 'https://example.com:8448/', true ],
-        [ 'https://example.com:8448/login/page', 'https://example.com/login/page', false ],
-        [ 'https://example.com:8448/*', 'https://example.com:8448/login/page', true ],
-        [ 'https://example.com/$/*', 'https://example.com/$/login_page', true ], // Special character in URL
-        [ 'https://example.com/*/*', 'https://example.com/$/login_page', true ],
-        [ 'https://example.com/*/*', 'https://example.com/login_page', false ],
-        [ 'https://*.com/*', 'https://example.com/$/login_page', true ],
-        [ 'https://*.com/*', 'https://example.org/$/login_page', false ],
-        [ 'https://*.*/*', 'https://example.org/$/login_page', false ],
-        // IP based URL's
-        [ 'https://127.128.129.130:8448/', 'https://127.128.129.130:8448/', true ],
-        [ 'https://127.128.129.*:8448/', 'https://127.128.129.130:8448/', true ],
-        [ 'https://127.128.*/', 'https://127.128.129.130/', true ],
-        [ 'https://127.128.*/', 'https://127.1.129.130/', false ],
-        [ 'https://127.128.129.130/', 'https://127.128.129.130:8448/', false ],
-        [ 'https://127.128.129.*/', 'https://127.128.129.130:8448/', false ],
-        // Invalid URL's
-        [ '', 'https://example.com', false ],
-        [ 'abcdefgetc', 'https://example.com', false ],
-        [ '{TOTP}\\no', 'https://example.com', false ],
-        [ 'https://320.320.320.320', 'https://example.com', false ]
-    ];
-
-    for (const m of matches) {
-        assertRegex(siteMatch(m[0], m[1]), m[2], testCard, `siteMatch() for ${m[1]}`);
-    }
-
-    // TODO: Enable these tests later. Not sure how to tests cookies API which requires to be running in the
-    //       background script.
-    // Top-Level-Domain tests
-    /*const tldUrls = [
-        [ 'another.example.co.uk', 'co.uk' ],
-        [ 'www.example.com', 'com' ],
-        [ 'github.com', 'com' ],
-        [ 'test.net', 'net' ],
-        [ 'so.many.subdomains.co.jp', 'co.jp' ],
-        [ '192.168.0.1', '192.168.0.1' ],
-        [ 'www.nic.ar','ar' ],
-        [ 'no.no.no', 'no' ],
-        [ 'www.blogspot.com.ar', 'blogspot.com.ar' ], // blogspot.com.ar is a TLD
-        [ 'jap.an.ide.kyoto.jp', 'ide.kyoto.jp' ], // ide.kyoto.jp is a TLD
-    ];
-
-    for (const d of tldUrls) {
-        kpxcAssert(page.getTopLevelDomainFromUrl(d[0]), d[1], testCard, 'getTopLevelDomainFromUrl() for ' + d[0]);
-    }
-
-    // Base domain tests
-    const domains = [
-        [ 'another.example.co.uk', 'example.co.uk' ],
-        [ 'www.example.com', 'example.com' ],
-        [ 'test.net', 'test.net' ],
-        [ 'so.many.subdomains.co.jp', 'subdomains.co.jp' ],
-        [ '192.168.0.1', '192.168.0.1' ],
-        [ 'www.nic.ar', 'nic.ar' ],
-        [ 'www.blogspot.com.ar', 'www.blogspot.com.ar' ], // blogspot.com.ar is a TLD
-        [ 'www.arpa', 'www.arpa' ],
-        [ 'jap.an.ide.kyoto.jp', 'an.ide.kyoto.jp' ], // ide.kyoto.jp is a TLD
-        [ 'kobe.jp', 'kobe.jp' ],
-    ];
-
-    for (const d of domains) {
-        kpxcAssert(page.getBaseDomainFromUrl(d[0]), d[1], testCard, 'getBaseDomainFromUrl() for ' + d[0]);
-    }*/
-}
-
 // Input field matching (keepassxc-browser.js)
 async function testInputFields() {
     // Div ID, expected fields, action element ID (a button to be clicked)
@@ -208,7 +113,6 @@ async function testPasswordChange() {
 // Run tests
 (async () => {
     await Promise.all([
-        await testGeneral(),
         await testInputFields(),
         await testSearchFields(),
         await testTotpFields(),


### PR DESCRIPTION
Makes some updates to tests:
- Update Playwright to the latest version
- Remove dependency to `file-url`. A native method already exists.
- Change all Playwright files to TypeScript. Content script files are still JavaScript files because those are used directly in the `tests.html`
- Move `global.js` tests to a separate file. There's no need to test those with the content scripts.

In the future I'll investigate the possibility to get rid of the content script tests and remake those in a more practical way, where the extension itself is loaded to the test instead as a headless browser. Mocking `kpxc.credentials` etc. could improve the test coverage quite a bit. But here's just the first step.