### PR TITLE
Fix scrollbar colors with Autocomplete Menu

### DIFF
--- a/keepassxc-browser/css/autocomplete.css
+++ b/keepassxc-browser/css/autocomplete.css
@@ -12,6 +12,7 @@
     overflow: hidden; /* Prevent the content from bleeding over the border radius. */
     padding: 6px;
     position: absolute !important;
+    scrollbar-color: --var(--kpxc-scrollbar-thumb) --var(--kpxc-scrollbar-background);
     z-index: 2147483646;
 }
 

--- a/keepassxc-browser/css/colors.css
+++ b/keepassxc-browser/css/colors.css
@@ -17,6 +17,8 @@
     --kpxc-input-main-border-color: rgba(0, 0, 0, .125);
     --kpxc-link-color: #3a8233;
     --kpxc-link-hover-color: #429f14;
+    --kpxc-scrollbar-background: #fcfcfc;
+    --kpxc-scrollbar-thumb: #8b8b8b;
     --kpxc-sidebar-background-color: #27272a;
     --kpxc-table-border-color: rgb(222, 226, 230);
     --kpxc-table-hover-color: #f2f2f2;
@@ -46,6 +48,8 @@
         --kpxc-input-main-border-color: #3b3d3c;
         --kpxc-link-color: #6cac4d;
         --kpxc-link-hover-color: #429f14;
+        --kpxc-scrollbar-background: #2c2c2c;
+        --kpxc-scrollbar-thumb: #9f9f9f;
         --kpxc-table-border-color: #a0a0a0;
         --kpxc-table-hover-color: #474948;
         --kpxc-table-odd-color: #383a39;
@@ -73,6 +77,8 @@
     --kpxc-input-main-border-color: #3b3d3c;
     --kpxc-link-color: #6cac4d;
     --kpxc-link-hover-color: #429f14;
+    --kpxc-scrollbar-background: #2c2c2c;
+    --kpxc-scrollbar-thumb: #9f9f9f;
     --kpxc-table-border-color: #a0a0a0;
     --kpxc-table-hover-color: #474948;
     --kpxc-table-odd-color: #383a39;
@@ -99,6 +105,8 @@
     --kpxc-input-main-border-color: rgba(0, 0, 0, .125);
     --kpxc-link-color: #3a8233;
     --kpxc-link-hover-color: #429f14;
+    --kpxc-scrollbar-background: #fcfcfc;
+    --kpxc-scrollbar-thumb: #8b8b8b;
     --kpxc-table-border-color: rgb(222, 226, 230);
     --kpxc-table-hover-color: #f2f2f2;
     --kpxc-table-odd-color: #f2f2f2;


### PR DESCRIPTION
At some pages scrollbar colors on Autocomplete Menu do not respect the current theme setting. These needs to be set explicitly.

Fixes #2290.