### PR TITLE
Fix attribute filling with identical usernames

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -321,7 +321,7 @@ page.updateContextMenu = async function(tab, credentials) {
                 : attributeName;
 
             const menuItem = {
-                action: `fill_attribute_${cred?.uuid}`,
+                action: `fill_attribute_${cred?.uuid}_${attributeName}`,
                 args: attribute,
                 parentId: 'fill_attribute',
                 title: finalName

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -317,7 +317,7 @@ page.updateContextMenu = async function(tab, credentials) {
             // Show username inside [] if there are KPH attributes inside multiple credentials
             const attributeName = Object.keys(attribute)[0].slice(5);
             const finalName = credentials.length > 1
-                ? `[${cred.login}] ${attributeName}`
+                ? `[${cred?.login}] ${attributeName} (${cred?.name})`
                 : attributeName;
 
             const menuItem = {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -317,11 +317,11 @@ page.updateContextMenu = async function(tab, credentials) {
             // Show username inside [] if there are KPH attributes inside multiple credentials
             const attributeName = Object.keys(attribute)[0].slice(5);
             const finalName = credentials.length > 1
-                ? `[${cred?.login}] ${attributeName} (${cred?.name})`
+                ? `[${cred?.login}] ${attributeName} (${cred.name || credentials.indexOf(cred)})`
                 : attributeName;
 
             const menuItem = {
-                action: `fill_attribute_${finalName}`,
+                action: `fill_attribute_${cred?.uuid}`,
                 args: attribute,
                 parentId: 'fill_attribute',
                 title: finalName


### PR DESCRIPTION
If there are multiple entries with identical usernames, the context menu item's ID is also identical, and the duplicate item is not shown. Entry name is appended to the item's ID/name.

Fixes #2299.