### PR TITLE
Fix segmented TOTP field identification

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -95,9 +95,10 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
 
     let exceptionFound = false;
 
-    // Returns true if all 6 inputs are numeric, tel or text/number with maxLength of 1
-    const allAreSegmentedFields = inputs =>
-        inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS &&
+    // Returns true if all 6 inputs are numeric, tel or text/number with maxLength of 1.
+    // If ignoreLength is true, number of TOTP fields are allowed to differ from the default (6).
+    const allAreSegmentedFields = (inputs, ignoreLength = false) =>
+        (inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS || ignoreLength) &&
         inputs.every(
             i =>
                 (i.inputMode === 'numeric' && i.pattern.includes('0-9')) ||
@@ -109,7 +110,8 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         const totpInputs = Array.from(inputFields).filter(
             e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden' && e.type !== 'submit',
         );
-        if (allAreSegmentedFields(totpInputs) || ignoreLength) {
+
+        if (allAreSegmentedFields(totpInputs, ignoreLength)) {
             const combination = {
                 form: form,
                 totpInputs: totpInputs,

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -104,10 +104,10 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
             ((ignoreFieldCount && totpInputs.length >= MIN_SEGMENTED_TOTP_FIELDS) ||
                 totpInputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS) &&
             totpInputs.every(
-                i =>
-                    (i.inputMode === 'numeric' && i.pattern.includes('0-9')) ||
-                    ((i.type === 'text' || i.type === 'number') && i.maxLength === 1) ||
-                    i.type === 'tel',
+                input =>
+                    (input.inputMode === 'numeric' && input.pattern.includes('0-9')) ||
+                    ((input.type === 'text' || input.type === 'number') && input.maxLength === 1) ||
+                    input.type === 'tel'
             )
         );
     };
@@ -164,11 +164,18 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         return false;
     };
 
+    // Returns true of form's className, id or name points to a possible TOTP form
+    const isSegmentedTotpForm = (form) =>
+        acceptedOTPFields.some(
+            field =>
+                (form.className && form.className.includes(field)) ||
+                (form.id && typeof form.id === 'string' && form.id.includes(field)) ||
+                (form.name && typeof form.name === 'string' && form.name.includes(field))
+        );
+
+    // Use the form if it has segmented TOTP fields, otherwise try checking the input fields directly
     const form = inputs.length > 0 ? inputs[0].form : undefined;
-    if (form && (acceptedOTPFields.some(f => (form.className && form.className.includes(f))
-        || (form.id && typeof(form.id) === 'string' && form.id.includes(f))
-        || (form.name && typeof(form.name) === 'string' && form.name.includes(f))
-        || formLengthMatches(form)))) {
+    if (form && (formLengthMatches(form) || isSegmentedTotpForm(form))) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements, exceptionFound);
     } else if (areFieldsSegmentedTotp(inputs)) {

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -95,9 +95,21 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
 
     let exceptionFound = false;
 
+    // Returns true if all 6 inputs are numeric, tel or text/number with maxLength of 1
+    const allAreSegmentedFields = inputs =>
+        inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS &&
+        inputs.every(
+            i =>
+                (i.inputMode === 'numeric' && i.pattern.includes('0-9')) ||
+                ((i.type === 'text' || i.type === 'number') && i.maxLength === 1) ||
+                i.type === 'tel',
+        );
+
     const addTotpFieldsToCombination = function(inputFields, ignoreLength = false) {
-        const totpInputs = Array.from(inputFields).filter(e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden' && e.type !== 'submit');
-        if (totpInputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS || ignoreLength) {
+        const totpInputs = Array.from(inputFields).filter(
+            e => e.nodeName === 'INPUT' && e.type !== 'password' && e.type !== 'hidden' && e.type !== 'submit',
+        );
+        if (allAreSegmentedFields(totpInputs) || ignoreLength) {
             const combination = {
                 form: form,
                 totpInputs: totpInputs,
@@ -151,9 +163,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
         || formLengthMatches(form)))) {
         // Use the form's elements
         addTotpFieldsToCombination(form.elements, exceptionFound);
-    } else if (inputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS && inputs.every(i => (i.inputMode === 'numeric' && i.pattern.includes('0-9'))
-                || ((i.type === 'text' || i.type === 'number') && i.maxLength === 1)
-                || i.type === 'tel')) {
+    } else if (allAreSegmentedFields(inputs)) {
         // No form is found, but input fields are possibly segmented TOTP fields
         addTotpFieldsToCombination(inputs);
     }


### PR DESCRIPTION
When segmented TOTP fields are identified inside a form, the types are not checked properly. Added the same check that is used in a different situation to this also. This way it's ensured that the input field types are identical.

Fixes #2303.