### PR TITLE
Prevent build script for creating a parent folder

### DIFF
--- a/build.js
+++ b/build.js
@@ -41,7 +41,7 @@ const updateTranslations = async () => {
 };
 
 const createZipFile = async (fileName, path) => {
-    await exec(`tar -a -cf ${fileName} ${path}/*`);
+    await exec(`cd ${path} && tar -a -cf ../${fileName} * && cd ..`);
 };
 
 (async() => {


### PR DESCRIPTION
Noticed this when releasing the new build. The `tar` will create a parent folder `keepassxc-browser` inside the zip file. There shouldn't be any parent folder. If `tar -C` is used, parent folder is set to `./`, and the file is still not accepted by Google. Using `cd` is an easy way to make this work properly.