### PR TITLE
Hide Credential Banner on exception

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -13,7 +13,6 @@ kpxcBanner.destroy = async function() {
         return;
     }
 
-    kpxcBanner.created = false;
     kpxcBanner.credentials = {};
 
     const dialog = kpxcBanner.shadowSelector('.kpxc-banner-dialog');
@@ -23,11 +22,17 @@ kpxcBanner.destroy = async function() {
 
     await sendMessage('remove_credentials_from_tab_information');
 
-    if (kpxcBanner.wrapper && window.parent.document.body.contains(kpxcBanner.wrapper)) {
-        window.parent.document.body.removeChild(kpxcBanner.wrapper);
-    } else {
-        window.parent.document.body.removeChild(window.parent.document.body.querySelector('#kpxc-banner'));
+    try {
+        if (kpxcBanner.wrapper && window.parent.document.body.contains(kpxcBanner.wrapper)) {
+            window.parent.document.body.removeChild(kpxcBanner.wrapper);
+        } else {
+            window.parent.document.body.removeChild(window.parent.document.body.querySelector('#kpxc-banner'));
+        }
+    } catch(e) {
+        kpxcBanner.wrapper.style.display = 'hidden';
     }
+
+    kpxcBanner.created = false;
 };
 
 kpxcBanner.create = async function(credentials = {}) {


### PR DESCRIPTION
If `querySelector()` is unabled to find the Credential Banner (Shadow DOM is tricky), lets just hide the element instead. This prevents user for creating duplicate or possibly empty credentials by accident.

Fixes #2312
Fixes #2320