### PR TITLE
Fix C&P issue in test

### DIFF
--- a/tests/global.spec.ts
+++ b/tests/global.spec.ts
@@ -10,9 +10,11 @@ test('Test matchesWithNodeName()', async ({ page }) => {
     const elem1 = { nodeName: 'INPUT' };
     const elem2 = { nodeName: 'input' };
     expect(matchesWithNodeName(elem1, 'INPUT')).toBe(true);
-    expect(matchesWithNodeName(elem1, 'INPUT')).toBe(true);
+    expect(matchesWithNodeName(elem1, 'input')).toBe(true);
     expect(matchesWithNodeName(elem2, 'INPUT')).toBe(true);
+    expect(matchesWithNodeName(elem2, 'input')).toBe(true);
     expect(matchesWithNodeName(elem1, 'TEXT')).toBe(false);
+    expect(matchesWithNodeName(elem1, 'text')).toBe(false);
     expect(matchesWithNodeName(undefined, 'INPUT')).toBe(false);
     expect(matchesWithNodeName(undefined, undefined)).toBe(false);
 });


### PR DESCRIPTION
One test was duplicated. The intention of the function is to match identical strings and any case mismatch, hence that's 4 cases.