### PR TITLE
Fix the coordinate shift caused by CSS zoom

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -341,7 +341,7 @@ class Autocomplete {
         // Calculate Y offset if menu does not fit to the bottom of the screen -> show it at the top of the input field
         const menuRect = this.container.getBoundingClientRect();
         const totalHeight = menuRect.height + rect.height;
-        const menuOffset = (totalHeight + rect.y) / zoom > window.self.visualViewport.height ? totalHeight/ zoom : 0;
+        const menuOffset = (totalHeight + rect.y) / zoom > window.self.visualViewport.height ? totalHeight / zoom : 0;
 
         const scrollTop = kpxcUI.getScrollTop() / zoom;
         const scrollLeft = kpxcUI.getScrollLeft() / zoom;

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -337,24 +337,23 @@ class Autocomplete {
 
         // Get body zoom radio
 	    const zoom = kpxcUI.bodyStyle.zoom || 1;
-	    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
        
         // Calculate Y offset if menu does not fit to the bottom of the screen -> show it at the top of the input field
         const menuRect = this.container.getBoundingClientRect();
         const totalHeight = menuRect.height + rect.height;
-        const menuOffset = (totalHeight + rect.y) / uZoom > window.self.visualViewport.height ? totalHeight/ uZoom : 0;
+        const menuOffset = (totalHeight + rect.y) / zoom > window.self.visualViewport.height ? totalHeight/ zoom : 0;
 
         const scrollTop = kpxcUI.getScrollTop() / zoom;
         const scrollLeft = kpxcUI.getScrollLeft() / zoom;
 
         if (kpxcUI.bodyStyle.position.toLowerCase() === 'relative') {
             this.container.style.top = Pixels(
-                ((rect.top - kpxcUI.bodyRect.top) / uZoom + scrollTop + this.input.offsetHeight - menuOffset)
+                ((rect.top - kpxcUI.bodyRect.top) / zoom + scrollTop + this.input.offsetHeight - menuOffset)
             );
-            this.container.style.left = Pixels((rect.left - kpxcUI.bodyRect.left) / uZoom + scrollLeft);
+            this.container.style.left = Pixels((rect.left - kpxcUI.bodyRect.left) / zoom + scrollLeft);
         } else {
-            this.container.style.top = Pixels(rect.top / uZoom + scrollTop + this.input.offsetHeight - menuOffset)
-            this.container.style.left = Pixels(rect.left / uZoom + scrollLeft);
+            this.container.style.top = Pixels(rect.top / zoom + scrollTop + this.input.offsetHeight - menuOffset)
+            this.container.style.left = Pixels(rect.left / zoom + scrollLeft);
         }
     }
 }

--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -324,7 +324,7 @@ class Autocomplete {
         }
     }
 
-    updatePosition() {
+   updatePosition() {
         if (!this.container || !this.input) {
             return;
         }
@@ -335,21 +335,26 @@ class Autocomplete {
         // Extend the list's max width to input field's width or at least to the maxWidth defined in the CSS file
         this.list.style.maxWidth = `max(${Pixels(this.input.offsetWidth)}, 600px)`;
 
+        // Get body zoom radio
+	    const zoom = kpxcUI.bodyStyle.zoom || 1;
+	    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
+       
         // Calculate Y offset if menu does not fit to the bottom of the screen -> show it at the top of the input field
         const menuRect = this.container.getBoundingClientRect();
         const totalHeight = menuRect.height + rect.height;
-        const menuOffset = totalHeight + rect.y > window.self.visualViewport.height ? totalHeight : 0;
+        const menuOffset = (totalHeight + rect.y) / uZoom > window.self.visualViewport.height ? totalHeight/ uZoom : 0;
 
-        const scrollTop = kpxcUI.getScrollTop();
-        const scrollLeft = kpxcUI.getScrollLeft();
+        const scrollTop = kpxcUI.getScrollTop() / zoom;
+        const scrollLeft = kpxcUI.getScrollLeft() / zoom;
+
         if (kpxcUI.bodyStyle.position.toLowerCase() === 'relative') {
             this.container.style.top = Pixels(
-                rect.top - kpxcUI.bodyRect.top + scrollTop + this.input.offsetHeight - menuOffset,
+                ((rect.top - kpxcUI.bodyRect.top) / uZoom + scrollTop + this.input.offsetHeight - menuOffset)
             );
-            this.container.style.left = Pixels(rect.left - kpxcUI.bodyRect.left + scrollLeft);
+            this.container.style.left = Pixels((rect.left - kpxcUI.bodyRect.left) / uZoom + scrollLeft);
         } else {
-            this.container.style.top = Pixels(rect.top + scrollTop + this.input.offsetHeight - menuOffset);
-            this.container.style.left = Pixels(rect.left + scrollLeft);
+            this.container.style.top = Pixels(rect.top / uZoom + scrollTop + this.input.offsetHeight - menuOffset)
+            this.container.style.left = Pixels(rect.left / uZoom + scrollLeft);
         }
     }
 }

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -505,7 +505,6 @@ kpxcCustomLoginFieldsBanner.markFields = function() {
     let firstInput;
     const inputs = document.querySelectorAll(kpxcCustomLoginFieldsBanner.inputQueryPattern);
     const zoom = kpxcUI.bodyStyle.zoom || 1;
-    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
 
     for (const i of inputs) {
         if (kpxcCustomLoginFieldsBanner.isFieldSelected(i) || inputFieldIsSelected(i)) {
@@ -521,10 +520,10 @@ kpxcCustomLoginFieldsBanner.markFields = function() {
         field.originalElement = i;
 
         const rect = i.getBoundingClientRect();
-        field.style.top = Pixels(rect.top / uZoom);
-        field.style.left = Pixels(rect.left / uZoom);
-        field.style.width = Pixels(rect.width / uZoom);
-        field.style.height = Pixels(rect.height / uZoom);
+        field.style.top = Pixels(rect.top / zoom);
+        field.style.left = Pixels(rect.left / zoom);
+        field.style.width = Pixels(rect.width / zoom);
+        field.style.height = Pixels(rect.height / zoom);
         field.textContent = dataStepToString();
 
         // Change selection theme if needed
@@ -608,10 +607,9 @@ kpxcCustomLoginFieldsBanner.monitorSelectionPosition = function(selection) {
 // Set selection input field position dynamically including the scroll position
 kpxcCustomLoginFieldsBanner.setSelectionPosition = function(field) {
     const zoom = kpxcUI.bodyStyle.zoom || 1;
-    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
     const rect = field.originalElement.getBoundingClientRect();
-    const left = kpxcUI.getRelativeLeftPosition(rect) / uZoom;
-    const top = kpxcUI.getRelativeTopPosition(rect) / uZoom;
+    const left = kpxcUI.getRelativeLeftPosition(rect) / zoom;
+    const top = kpxcUI.getRelativeTopPosition(rect) / zoom;
     const scrollTop = kpxcUI.getScrollTop() / zoom;
     const scrollLeft = kpxcUI.getScrollLeft() / zoom;
 

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -504,6 +504,8 @@ kpxcCustomLoginFieldsBanner.selectStringFields = function() {
 kpxcCustomLoginFieldsBanner.markFields = function() {
     let firstInput;
     const inputs = document.querySelectorAll(kpxcCustomLoginFieldsBanner.inputQueryPattern);
+    const zoom = kpxcUI.bodyStyle.zoom || 1;
+    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
 
     for (const i of inputs) {
         if (kpxcCustomLoginFieldsBanner.isFieldSelected(i) || inputFieldIsSelected(i)) {
@@ -519,10 +521,10 @@ kpxcCustomLoginFieldsBanner.markFields = function() {
         field.originalElement = i;
 
         const rect = i.getBoundingClientRect();
-        field.style.top = Pixels(rect.top);
-        field.style.left = Pixels(rect.left);
-        field.style.width = Pixels(rect.width);
-        field.style.height = Pixels(rect.height);
+        field.style.top = Pixels(rect.top / uZoom);
+        field.style.left = Pixels(rect.left / uZoom);
+        field.style.width = Pixels(rect.width / uZoom);
+        field.style.height = Pixels(rect.height / uZoom);
         field.textContent = dataStepToString();
 
         // Change selection theme if needed
@@ -605,11 +607,13 @@ kpxcCustomLoginFieldsBanner.monitorSelectionPosition = function(selection) {
 
 // Set selection input field position dynamically including the scroll position
 kpxcCustomLoginFieldsBanner.setSelectionPosition = function(field) {
+    const zoom = kpxcUI.bodyStyle.zoom || 1;
+    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
     const rect = field.originalElement.getBoundingClientRect();
-    const left = kpxcUI.getRelativeLeftPosition(rect);
-    const top = kpxcUI.getRelativeTopPosition(rect);
-    const scrollTop = kpxcUI.getScrollTop();
-    const scrollLeft = kpxcUI.getScrollLeft();
+    const left = kpxcUI.getRelativeLeftPosition(rect) / uZoom;
+    const top = kpxcUI.getRelativeTopPosition(rect) / uZoom;
+    const scrollTop = kpxcUI.getScrollTop() / zoom;
+    const scrollLeft = kpxcUI.getScrollLeft() / zoom;
 
     field.style.top = Pixels(top + scrollTop);
     field.style.left = Pixels(left + scrollLeft);

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -97,12 +97,6 @@ if (document.body) {
     kpxcUI.bodyStyle = getComputedStyle(document.body);
 }
 
-// Whether Chrome engine version is greater than 128
-kpxcUI.browserVerUpon128 = (function () {
-    const version = navigator.userAgent.match(/\s(?:Chrom(?:e|ium)|Firefox)\/(\d+[.0-9]*)|$/i)[1]
-    return parseFloat(version) >= 128;
-})();
-
 // Wrapper for creating elements
 kpxcUI.createElement = function(type, classes, attributes, textContent) {
     const element = document.createElement(type);
@@ -161,9 +155,8 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
     const size = Number(icon.getAttribute('size'));
     const offset = kpxcUI.calculateIconOffset(field, size);
     const zoom = kpxcUI.bodyStyle.zoom || 1;
-    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
-    let left = kpxcUI.getRelativeLeftPosition(rect) / uZoom;
-    let top = kpxcUI.getRelativeTopPosition(rect) / uZoom;
+    let left = kpxcUI.getRelativeLeftPosition(rect) / zoom;
+    let top = kpxcUI.getRelativeTopPosition(rect) / zoom;
 
     // Add more space for the icon to show it at the right side of the field if TOTP fields are segmented
     if (segmented) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -97,6 +97,12 @@ if (document.body) {
     kpxcUI.bodyStyle = getComputedStyle(document.body);
 }
 
+// Whether Chrome engine version is greater than 128
+kpxcUI.browserVerUpon128 = (function () {
+    const version = navigator.userAgent.match(/\s(?:Chrom(?:e|ium)|Firefox)\/(\d+[.0-9]*)|$/i)[1]
+    return parseFloat(version) >= 128;
+})();
+
 // Wrapper for creating elements
 kpxcUI.createElement = function(type, classes, attributes, textContent) {
     const element = document.createElement(type);
@@ -154,8 +160,10 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
     const rect = field.getBoundingClientRect();
     const size = Number(icon.getAttribute('size'));
     const offset = kpxcUI.calculateIconOffset(field, size);
-    let left = kpxcUI.getRelativeLeftPosition(rect);
-    let top = kpxcUI.getRelativeTopPosition(rect);
+    const zoom = kpxcUI.bodyStyle.zoom || 1;
+    const uZoom = kpxcUI.browserVerUpon128 ? zoom: 1;
+    let left = kpxcUI.getRelativeLeftPosition(rect) / uZoom;
+    let top = kpxcUI.getRelativeTopPosition(rect) / uZoom;
 
     // Add more space for the icon to show it at the right side of the field if TOTP fields are segmented
     if (segmented) {
@@ -169,11 +177,11 @@ kpxcUI.setIconPosition = function(icon, field, rtl = false, segmented = false) {
         top = iconOffset[1];
     }
 
-    const scrollTop = kpxcUI.getScrollTop();
-    const scrollLeft = kpxcUI.getScrollLeft();
+    const scrollTop = kpxcUI.getScrollTop() / zoom;
+    const scrollLeft = kpxcUI.getScrollLeft() / zoom;
     icon.style.top = Pixels(top + scrollTop + offset + 1);
     icon.style.left = rtl
-        ? Pixels((left + scrollLeft) + offset)
+        ? Pixels(left + scrollLeft + offset)
         : Pixels(left + scrollLeft + field.offsetWidth - size - offset);
 };
 


### PR DESCRIPTION
Fixed the coordinate shift caused by css:zoom
#### keepassxc-browser/content/ui.js
```
 + kpxcUI.browserVerUpon128
 # kpxcUI.setIconPosition()
```
#### keepassxc-browser/content/autocomplete.js
```
# kpxcUI.setIconPosition()
```
#### keepassxc-browser/content/custom-fields-banner.js
```
# kpxcCustomLoginFieldsBanner.markFields()
# kpxcCustomLoginFieldsBanner.setSelectionPosition()
```