### PR TITLE
Add configuration option for modifying the passkeys default group

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -714,6 +714,10 @@
         "message": "Separate the group with slashes, for example: Group/ChildGroup.",
         "description": "Default group help text."
     },
+    "optionsLabelDefaultPasskeyGroup": {
+        "message": "Default group for saving new passkeys:",
+        "description": "Default passkey group options text."
+    },
     "optionsLabelDefaultGroupCheckboxText": {
         "message": "Always ask where to save new credentials",
         "description": "Default group checkbox help text."

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -608,15 +608,13 @@ keepass.passkeysRegister = async function(tab, args = []) {
 
         const kpAction = kpActions.PASSKEYS_REGISTER;
         const nonce = keepassClient.getNonce();
-
-        // Parse publicKey
-        const publicKey = args[0];
-        const origin = args[1];
+        const [ publicKey, origin ] = args;
 
         const messageData = {
             action: kpAction,
             publicKey: JSON.parse(JSON.stringify(publicKey)),
             origin: origin,
+            groupName: page?.settings?.defaultPasskeyGroup,
             keys: keepass.getCryptoKeys()
         };
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -16,6 +16,7 @@ const defaultSettings = {
     credentialSorting: SORT_BY_GROUP_AND_TITLE,
     debugLogging: false,
     defaultGroup: '',
+    defaultPasskeyGroup: '',
     defaultGroupAlwaysAsk: false,
     downloadFaviconAfterSave: false,
     passkeys: false,

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -370,7 +370,7 @@
                   </div>
 
                   <!-- Default group for saving passkeys -->
-                  <div class="form-group pb-2">
+                  <div class="form-group pb-2" id="passkeysDefaultGroup">
                     <label for="defaultPasskeyGroup" class="pb-2" data-i18n="optionsLabelDefaultPasskeyGroup"></label>
                     <div class="input-group w-75">
                       <input class="form-control form-control-sm" type="text" id="defaultPasskeyGroup" placeholder="KeePassXC-Browser Passkeys">

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -368,6 +368,23 @@
                       <div class="form-text help-text" data-i18n="optionsPasskeysEnableFallbackHelpText"></div>
                     </div>
                   </div>
+
+                  <!-- Default group for saving passkeys -->
+                  <div class="form-group pb-2">
+                    <label for="defaultPasskeyGroup" class="pb-2" data-i18n="optionsLabelDefaultPasskeyGroup"></label>
+                    <div class="input-group w-75">
+                      <input class="form-control form-control-sm" type="text" id="defaultPasskeyGroup" placeholder="KeePassXC-Browser Passkeys">
+                      <button class="btn btn-sm btn-primary" type="button" id="defaultPasskeyGroupButton">
+                        <i class="fa fa-save" aria-hidden="true"></i>
+                        <span data-i18n="optionsButtonSave"></span>
+                      </button>
+                      <button class="btn btn-sm btn-danger" type="button" id="defaultPasskeyGroupButtonReset">
+                        <i class="fa fa-remove" aria-hidden="true"></i>
+                        <span data-i18n="optionsButtonReset"></span>
+                      </button>
+                    </div>
+                    <div class="form-text help-text" data-i18n="optionsDefaultGroupHelpText"></div>
+                  </div>
                 </div>
               </div>
 

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -355,6 +355,17 @@ options.showKeePassXCVersions = async function(response) {
     if (!version277Result) {
         $('#tab-general-settings #passkeysOptionsCard').hide();
     }
+
+    const version2710Result = await browser.runtime.sendMessage({
+        action: 'compare_version',
+        args: [ '2.7.10', response.current ]
+    });
+
+    // Hide passkeys default group option with KeePassXC version < 2.7.10
+    if (!version2710Result) {
+        $('#tab-general-settings #passkeysDefaultGroup').hide();
+    }
+
 };
 
 options.getPartiallyHiddenKey = function(key) {

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -112,6 +112,7 @@ options.initGeneralSettings = async function() {
     $('#tab-general-settings select#afterFillSorting').value = options.settings['afterFillSorting'];
     $('#tab-general-settings select#afterFillSortingTotp').value = options.settings['afterFillSortingTotp'];
     $('#tab-general-settings input#defaultGroup').value = options.settings['defaultGroup'];
+    $('#tab-general-settings input#defaultPasskeyGroup').value = options.settings['defaultPasskeyGroup'];
     $('#tab-general-settings input#clearCredentialTimeout').value = options.settings['clearCredentialsTimeout'];
 
     const generalSettingsRadioInputs = document.querySelectorAll('#tab-general-settings input[type=radio]');
@@ -203,6 +204,7 @@ options.initGeneralSettings = async function() {
         });
     });
 
+    // Default group
     $('#defaultGroupButton').addEventListener('click', async function() {
         const value = $('#defaultGroup').value;
         options.settings['defaultGroup'] = (value.length > 0 ? value : '');
@@ -212,6 +214,19 @@ options.initGeneralSettings = async function() {
     $('#defaultGroupButtonReset').addEventListener('click', async function() {
         $('#defaultGroup').value = '';
         options.settings['defaultGroup'] = '';
+        await options.saveSettings();
+    });
+
+    // Default passkey group
+    $('#defaultPasskeyGroupButton').addEventListener('click', async function() {
+        const value = $('#defaultPasskeyGroup').value;
+        options.settings['defaultPasskeyGroup'] = (value.length > 0 ? value : '');
+        await options.saveSettings();
+    });
+
+    $('#defaultPasskeyGroupButtonReset').addEventListener('click', async function() {
+        $('#defaultPasskeyGroup').value = '';
+        options.settings['defaultPasskeyGroup'] = '';
         await options.saveSettings();
     });
 

--- a/keepassxc-protocol.md
+++ b/keepassxc-protocol.md
@@ -483,6 +483,7 @@ Unencrypted message:
     "action": "passkeys-register",
     "publicKey": PublicKeyCredentialCreationOptions,
     "origin": "tZvLrBzkQ9GxXq9PvKJj4iAnfPT0VZ3Q",
+    "groupName": "<optional, KeePassXC 2.7.10 and newer>",
     "keys: [
         {
             "id": "<saved database identifier received from associate>",


### PR DESCRIPTION
Extension side implementation of https://github.com/keepassxreboot/keepassxc/pull/11260. Adds a new input field for configuring the default group where passkeys are stored.
<img width="670" alt="Screenshot 2024-09-21 at 12 03 42" src="https://github.com/user-attachments/assets/375cb328-201a-471a-b847-f726e11e65d2">

Will be only enabled for KeePassXC 2.7.10 and newer.