### PR TITLE
Fix Predefined Sites for some pages

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -35,7 +35,8 @@ const PREDEFINED_SITELIST = [
 ];
 
 const IMPROVED_DETECTION_PREDEFINED_SITELIST = [
-    'https://secure.chase.com/*'
+    'https://secure.chase.com/*',
+    'https://www.icloud.com/'
 ];
 
 const googleUrl = 'https://accounts.google.com';
@@ -87,7 +88,8 @@ kpxcSites.exceptionFound = function(identifier, field) {
               || document.location.origin.startsWith('https://mail.protonmail.com')
               && identifier === 'mailboxPassword') {
         return true;
-    } else if (document.location.origin === 'https://www.patreon.com' && field?.name === 'current-password') {
+    } else if (document.location.origin === 'https://www.patreon.com' &&
+               (field?.name === 'current-password' || field?.innerHTML?.includes('current-password'))) {
         return true;
     } else if (document.location.origin === 'https://wordpress.com' && identifier?.value === 'login__form-password') {
         return true;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -105,7 +105,7 @@ kpxcFields.getSegmentedTOTPFields = function(inputs, combinations) {
                 totpInputs.length === DEFAULT_SEGMENTED_TOTP_FIELDS) &&
             totpInputs.every(
                 input =>
-                    (input.inputMode === 'numeric' && input.pattern.includes('0-9')) ||
+                    ((input.inputMode === 'numeric' || input.inputMode === '') && input.pattern.includes('0-9')) ||
                     ((input.type === 'text' || input.type === 'number') && input.maxLength === 1) ||
                     input.type === 'tel'
             )


### PR DESCRIPTION
Fixes the following pages in Predefined Sites:
- Apple iCloud login page (cross-origin iframe)
- PayPal's segmented TOTP (patterns stays the same but `inputMode` is not set, we should allow this combination too)
- Patreon's password fill (the content can be wrapped to `innerHTML` instead)