### PR TITLE
Ignore elements with animations when using dynamic input field detection

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -101,7 +101,10 @@ kpxcObserverHelper.initObserver = async function() {
 // Stores mutation style to an cache array
 // If there's a single style mutation, it's safe to calculate it
 kpxcObserverHelper.cacheStyle = function(mut, styleMutations, mutationCount) {
-    if (mut.attributeName !== 'style') {
+    // Do not cache elements with animations
+    if (mut?.attributeName !== 'style'
+        || mut?.target?.style?.transform !== ''
+        || mut?.target?.style?.transformStyle !== '') {
         return;
     }
 


### PR DESCRIPTION
If a page has elements that have animation CSS defined, the `MutationObserver` will trigger with each small change. Without this change `getComputedStyle()` will be called to those changes, and it can cause performance issues.

This could potentially break some sites, but we can always add exceptions for those.

Fixes #2363.