### PR TITLE
Add support for checkboxes with Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -698,7 +698,7 @@ kpxc.setPasswordFilled = async function(state) {
     await sendMessage('password_set_filled', state);
 };
 
-// Special handling for settings value to select element
+// Special handling for setting value to select and checkbox elements
 kpxc.setValue = function(field, value, forced = false) {
     if (field.matches('select')) {
         value = value.toLowerCase().trim();
@@ -712,6 +712,8 @@ kpxc.setValue = function(field, value, forced = false) {
         }
 
         return;
+    } else if (field.getLowerCaseAttribute('type') === 'checkbox' && value?.toLowerCase() === 'true') {
+        field.checked = true;
     }
 
     kpxc.setValueWithChange(field, value, forced);


### PR DESCRIPTION
Add support for selecting checkbox elements with Custom Login Fields.

Two different input query patterns are used, where only the String Fields selection allows checkboxes. Added `:not([disabled])` to prevent selecting disabled checkboxes.
The checkbox selection overlay is fixed size, and centered to the element.
`KPH` value `true` (any case is accepted) will be used for the element's `checked` attribute. Other values are ignored.

For testing:
- Go to GitLab's login page: https://gitlab.com/users/sign_in
- Select Custom Login Fields for username and password, plus a String Field for the checkbox.
- Add `KPH: checkbox` with value `true` to the entry attributes in KeePassXC.
- Go to the login page and fill the credentials. The checkbox should be checked after fill.

Fixes #2050.