### PR TITLE
Passkeys: fix navigator.credentials.store override

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -188,6 +188,9 @@ const throwError = function(errorCode, errorMessage) {
             }
 
             return createPublicKeyCredential(response.publicKey);
+        },
+        async store(credential) {
+            return originalCredentials.store(credential);
         }
     };
 


### PR DESCRIPTION
We are overriding `navigator.credentials` but the `store()` function is not handled at all. It must be called normally from the original API endpoint.

Fixes account creation on X/Twitter that throws an exception because the function is not found.