### PR TITLE
Allow label on observer

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -35,6 +35,7 @@ const PREDEFINED_SITELIST = [
 ];
 
 const IMPROVED_DETECTION_PREDEFINED_SITELIST = [
+    'https://www.reddit.com/',
     'https://secure.chase.com/*',
     'https://www.icloud.com/'
 ];

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -18,7 +18,6 @@ kpxcObserverHelper.ignoredNodeNames = [
     'A',
     'HEAD',
     'HTML',
-    'LABEL',
     'LINK',
     'SCRIPT',
     'SPAN',


### PR DESCRIPTION
Sites made with React often put input fields under `label` element, which is ignored by the Observer Helper. This should be allowed for greater compatibility.

Also adds reddit.com to the improved input fields sites list.

Fixes login popup with e.g. reddit.com.