### PR TITLE
Add checks for TreeWalker filter

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -329,8 +329,11 @@ const getShadowDOM = function(elem) {
 
 // Filter for TreeWalker
 const treeWalkerFilter = function(node) {
-    return !node || node.disabled || node.getLowerCaseAttribute('type') === 'hidden'
-        ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    return !node ||
+        node?.disabled ||
+        (typeof node?.getAttribute !== 'undefined' && node?.getLowerCaseAttribute('type') === 'hidden')
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT;
 };
 
 // Traverses all child elements, looking for input fields inside Shadow DOM


### PR DESCRIPTION
Adds some additional checks for the functions. Node here can be something else than `Element`, and `getAttribute()` used inside the lowercasewrapper might not be found.

Fixes #2410.