### PR TITLE
Fixed values of constants

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const PASSKEYS_NO_LOGINS_FOUND = 15;
-const PASSKEYS_WAIT_FOR_LIFETIMER = 21;
-const PASSKEYS_CREDENTIAL_IS_EXCLUDED = 30;
+const PASSKEYS_CREDENTIAL_IS_EXCLUDED = 21;
+const PASSKEYS_WAIT_FOR_LIFETIMER = 30;
 
 // Contains already called method names
 const _called = {};


### PR DESCRIPTION
Fixed values of constants as in [BrowserMessageBuilder.h](https://github.com/keepassxreboot/keepassxc/blob/f2ed4e38409ddc3ae208c57f0015e9c2de9e87de/src/browser/BrowserMessageBuilder.h#L53) or [/background/client.js](https://github.com/keepassxreboot/keepassxc-browser/blob/a277d6c8b9079762d11a23c80584997bd2099766/keepassxc-browser/background/client.js#L31)

Currently the bug does not affect add-on's logic.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
