### PR TITLE
Remove span element from ignored nodes

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -20,7 +20,6 @@ kpxcObserverHelper.ignoredNodeNames = [
     'HTML',
     'LINK',
     'SCRIPT',
-    'SPAN',
     'VIDEO',
 ];
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Removes the <span> element from ignored nodes list. Input fields can be used inside of those elements.

Fixes #2396.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually:
_Go to https://magyarorszag.hu/, switch to English (upper right corner), then click "Login" (on the left side). On the appearing page, choose "Client gate". The appearing page now displays in Hungarian, but the upper input field is the username, the lower is the password field. These fields are completely undetected._

Improved Input Field Detection must be enabled for `https://idp.gov.hu/*`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
