### PR TITLE
Add all_urls permission to manifest files

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -159,6 +159,7 @@
         "extension_pages": "script-src 'self'"
     },
     "host_permissions": [
+        "<all_urls>",
         "https://*/*",
         "http://*/*"
     ],

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -147,6 +147,7 @@
         "content/passkeys.js"
     ],
     "permissions": [
+        "<all_urls>",
         "activeTab",
         "clipboardWrite",
         "contextMenus",

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -147,7 +147,6 @@
         "content/passkeys.js"
     ],
     "permissions": [
-        "<all_urls>",
         "activeTab",
         "clipboardWrite",
         "contextMenus",

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -148,6 +148,7 @@
         "content/passkeys.js"
     ],
     "permissions": [
+        "<all_urls>",
         "activeTab",
         "clipboardWrite",
         "contextMenus",


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Google wants this permission to be added. The permission is not listed in https://developer.chrome.com/docs/extensions/reference/permissions-list but handled under `host_permissions`: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns#special. They didn't provide any detailed info where this should be set, so this is the best bet.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Maintenance