### PR TITLE
Modifications to Redetect Fields

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -24,13 +24,12 @@ kpxcEvent.showStatus = async function(tab, configured, internalPoll) {
         browserAction.showDefault(tab);
     }
 
-    const errorMessage = page.tabs[tab.id]?.errorMessage ?? undefined;
-    const usernameFieldDetected = page.tabs[tab.id]?.usernameFieldDetected ?? false;
-    const iframeDetected = page.tabs[tab.id]?.iframeDetected ?? false;
+    const errorMessage = await page.getTabErrorMessage(tab);
+    const usernameFieldDetected = await page.isUsernameFieldDetected(tab);
+    const iframeDetected = await page.isIframeDetected(tab);
 
     return {
         associated: keepass.isAssociated(),
-
         configured: configured,
         databaseClosed: keepass.isDatabaseClosed,
         encryptionKeyUnrecognized: keepass.isEncryptionKeyUnrecognized,
@@ -117,8 +116,7 @@ kpxcEvent.lockDatabase = async function(tab) {
 };
 
 kpxcEvent.onGetTabInformation = async function(tab) {
-    const id = tab?.id || page.currentTabId;
-    return page.tabs[id];
+    return await page.getTabInformation(tab);
 };
 
 kpxcEvent.onGetConnectedDatabase = async function() {
@@ -176,8 +174,8 @@ kpxcEvent.onHTTPAuthPopup = async function(tab, data) {
     await browserAction.show(tab, popupData);
 };
 
-kpxcEvent.onUsernameFieldDetected = async function(tab, detected) {
-    page.tabs[tab.id].usernameFieldDetected = detected;
+kpxcEvent.onUsernameFieldDetected = async function(tab, args = []) {
+    await page.setUsernameFieldDetected(tab, args[0], args[1]);
 };
 
 kpxcEvent.onIframeDetected = async function(tab, detected) {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -385,6 +385,30 @@ page.isIframeAllowed = async function(tab, args = []) {
     return hostname.endsWith(baseDomain) && tabUrl.hostname?.endsWith(baseDomain);
 };
 
+page.isIframeDetected = async function(tab) {
+    return page.tabs[tab.id]?.iframeDetected ?? false;
+};
+
+page.isUsernameFieldDetected = async function(tab) {
+    return page.tabs[tab.id]?.usernameFieldDetected ?? false;
+};
+
+// Only set if the content script URL matches
+page.setUsernameFieldDetected = async function(tab, detected, url) {
+    if (url === tab?.url) {
+        page.tabs[tab.id].usernameFieldDetected = detected;
+    }
+};
+
+page.getTabErrorMessage = async function(tab) {
+    return page.tabs[tab.id]?.errorMessage ?? undefined;
+};
+
+page.getTabInformation = async function(tab) {
+    const id = tab?.id || page.currentTabId;
+    return page.tabs[id];
+};
+
 /**
  * Gets the top level domain from URL.
  * @param {string} domain   Current iframe's hostname

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -215,9 +215,9 @@ kpxcFields.getAllPageInputs = async function(previousInputs = []) {
     if (!kpxc.singleInputEnabledForPage
         && ((fields.length === 1 && fields[0].getLowerCaseAttribute('type') !== 'password')
         || (previousInputs.length === 1 && previousInputs[0].getLowerCaseAttribute('type') !== 'password'))) {
-        sendMessage('username_field_detected', true);
+        await sendMessage('username_field_detected', [ true, document.location.href ]);
     } else {
-        sendMessage('username_field_detected', false);
+        await sendMessage('username_field_detected', [ false, document.location.href ]);
     }
 
     await kpxc.initCombinations(inputs);

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -125,7 +125,8 @@ const sendMessageToTab = async function(message) {
         }
 
         statusResponse(await browser.runtime.sendMessage({
-            action: 'get_status'
+            action: 'get_status',
+            args: [ true ]
         }));
     });
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Noticed that the `get_status` request after Redetect Fields was not an internal call, but it requested status from KeePassXC that is not even needed here. It is enough to update the `page` variables and refresh the popup with new data directly.

Other improvements:
- Replace direct calls to `page` with proper functions.
- Only set username field detected when the content script URL matches the page URL. Otherwise any iframes (from Google etc.) would set the username field detected variable back to `false`.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. For example Patreon's login page can be used when Predefined Sites is disabled in the extension settings.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
