### PR TITLE
Add exceptions for Shadow DOM input query

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -101,6 +101,16 @@ kpxcSites.exceptionFound = function(identifier, field) {
     return false;
 };
 
+// Forbids using Shadow DOM query with some sites unless a login dialog has been identified
+kpxcSites.isShadowDomQueryAllowed = function(nodeName) {
+    if (document.location.href?.startsWith('https://www.reddit.com')
+        && nodeName !== 'BODY'
+        && !document.querySelector('auth-flow-manager[step-name=login]')) {
+        return false;
+    }
+    return true;
+};
+
 /**
  * Handles a few exceptions for certain sites where 2FA field is not regognized properly.
  * @param {object} field   Input field Element

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -170,7 +170,7 @@ kpxcObserverHelper.getInputs = function(target, ignoreVisibility = false) {
         inputFields.push(target);
     }
 
-    if (kpxc.improvedFieldDetectionEnabledForPage) {
+    if (kpxc.improvedFieldDetectionEnabledForPage && kpxcSites.isShadowDomQueryAllowed(target?.nodeName)) {
         const inputFieldsFromShadowDOM = kpxcObserverHelper.findInputsFromShadowDOM(target);
         if (inputFieldsFromShadowDOM.length > 0) {
             logDebug('Input fields from Shadow DOM found:', inputFieldsFromShadowDOM);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
A new feature, and a regression from https://github.com/keepassxreboot/keepassxc-browser/pull/2391. Reddit creates a lot of content dynamically while scrolling the page. If possible, Shadow DOM input field query must be restricted on some sites to prevent any slowdowns in the browser.
There could be a better solution for the problem, so this is probably just a temporary workaround.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using a long thread from www.reddit.com.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
