### PR TITLE
Add extra check for TOTP field input type

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -2,6 +2,7 @@
 
 const ignoreRegex = /(bank|coupon|postal|user|zip).*code|(en|de)code(d|r)*|comment|author|error/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
+const allowedInputTypes = [ 'number', 'password', 'tel', 'text' ];
 
 const acceptedOTPFields = [
     '2fa',
@@ -52,6 +53,12 @@ kpxcTOTPIcons.isAcceptedTOTPField = function(field) {
     const id = field.getLowerCaseAttribute('id');
     const name = field.getLowerCaseAttribute('name');
     const placeholder = field.getLowerCaseAttribute('placeholder');
+    const type = field.getLowerCaseAttribute('type');
+
+    // Checks if input type is allowed
+    if (!allowedInputTypes.some(t => type === t)) {
+        return false;
+    }
 
     // Checks if the field id, name or placeholder includes some of the acceptedOTPFields but not any from ignoredTypes
     if ((acceptedOTPFields.some(f => id?.includes(f) || (name?.includes(f) || placeholder?.includes(f))) || acceptedParents.some(s => field.closest(s)))


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds an extra check for HTML input `type` when accepting TOTP fields.

Fixes #2444.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
