### PR TITLE
Load managed settings always when found

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -63,17 +63,15 @@ page.initSettings = async function() {
     try {
         const item = await browser.storage.local.get({ 'settings': {} });
 
-        // Load managed settings if found when extension is started for the first time
-        if (Object.keys(item.settings).length === 0) {
-            try {
-                const managedSettings = await browser.storage.managed.get('settings');
-                if (managedSettings?.settings) {
-                    console.log('Managed settings found.');
-                    item.settings = managedSettings.settings;
-                }
-            } catch (err) {
-                logError('page.initSettings error: ' + err);
+        // Load managed settings if found
+        try {
+            const managedSettings = await browser.storage.managed.get('settings');
+            if (managedSettings?.settings) {
+                console.log('Managed settings found.');
+                item.settings = managedSettings.settings;
             }
+        } catch (err) {
+            logError('page.initSettings error: ' + err);
         }
 
         page.settings = item.settings;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Continued from https://github.com/keepassxreboot/keepassxc-browser/pull/2366. If managed settings are found, those should be always used, not just when the extension is started for the first time.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
