### PR TITLE
Script modifications for development/debugging

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -33,7 +33,7 @@
     "background": {
         "service_worker": "background/background_service.js"
     },
-   "content_scripts": [
+    "content_scripts": [
         {
             "matches": [
                 "<all_urls>"
@@ -129,30 +129,32 @@
             "description": "__MSG_popupReloadButton__"
         }
     },
-    "web_accessible_resources": [{
-        "resources": [
-            "icons/disconnected.svg",
-            "icons/help.svg",
-            "icons/keepassxc.svg",
-            "icons/key.svg",
-            "icons/locked.svg",
-            "icons/otp.svg",
-            "css/autocomplete.css",
-            "css/banner.css",
-            "css/button.css",
-            "css/colors.css",
-            "css/define.css",
-            "css/notification.css",
-            "css/pwgen.css",
-            "css/username.css",
-            "css/totp.css",
-            "content/passkeys.js"
-        ],
-        "matches": [
-            "https://*/*",
-            "http://*/*"
-        ]
-    }],
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "icons/disconnected.svg",
+                "icons/help.svg",
+                "icons/keepassxc.svg",
+                "icons/key.svg",
+                "icons/locked.svg",
+                "icons/otp.svg",
+                "css/autocomplete.css",
+                "css/banner.css",
+                "css/button.css",
+                "css/colors.css",
+                "css/define.css",
+                "css/notification.css",
+                "css/pwgen.css",
+                "css/username.css",
+                "css/totp.css",
+                "content/passkeys.js"
+            ],
+            "matches": [
+                "https://*/*",
+                "http://*/*"
+            ]
+        }
+    ],
     "permissions": [
         "activeTab",
         "clipboardWrite",
@@ -177,7 +179,7 @@
         "http://*/*"
     ],
     "storage": {
-      "managed_schema": "managed_storage.json"
+        "managed_schema": "managed_storage.json"
     },
     "default_locale": "en"
 }

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -183,7 +183,7 @@
         }
     },
     "storage": {
-      "managed_schema": "managed_storage.json"
+        "managed_schema": "managed_storage.json"
     },
     "default_locale": "en"
 }

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "KeePassXC-Browser",
     "version": "1.9.7",
     "version_name": "1.9.7",
@@ -13,7 +13,7 @@
         "96": "icons/keepassxc_96x96.png",
         "128": "icons/keepassxc_128x128.png"
     },
-    "browser_action": {
+    "action": {
         "default_icon": {
             "16": "icons/keepassxc_16x16.png",
             "18": "icons/keepassxc_18x18.png",
@@ -31,21 +31,7 @@
         "open_in_tab": true
     },
     "background": {
-        "scripts": [
-            "common/browser-polyfill.min.js",
-            "common/global.js",
-            "common/sites.js",
-            "background/nacl.min.js",
-            "background/nacl-util.min.js",
-            "background/client.js",
-            "background/keepass.js",
-            "background/httpauth.js",
-            "background/offscreen.js",
-            "background/browserAction.js",
-            "background/page.js",
-            "background/event.js",
-            "background/init.js"
-        ]
+        "service_worker": "background/background_service.js"
     },
     "content_scripts": [
         {
@@ -106,8 +92,8 @@
         "fill_password": {
             "description": "__MSG_contextMenuFillPassword__",
             "suggested_key": {
-                "default": "Alt+Shift+I",
-                "mac": "MacCtrl+Shift+I"
+                "default": "Alt+Shift+P",
+                "mac": "MacCtrl+Shift+P"
             }
         },
         "fill_totp": {
@@ -144,48 +130,56 @@
         }
     },
     "web_accessible_resources": [
-        "icons/disconnected.svg",
-        "icons/help.svg",
-        "icons/keepassxc.svg",
-        "icons/key.svg",
-        "icons/locked.svg",
-        "icons/otp.svg",
-        "css/autocomplete.css",
-        "css/banner.css",
-        "css/button.css",
-        "css/colors.css",
-        "css/define.css",
-        "css/notification.css",
-        "css/pwgen.css",
-        "css/username.css",
-        "css/totp.css",
-        "content/passkeys.js"
+        {
+            "resources": [
+                "icons/disconnected.svg",
+                "icons/help.svg",
+                "icons/keepassxc.svg",
+                "icons/key.svg",
+                "icons/locked.svg",
+                "icons/otp.svg",
+                "css/autocomplete.css",
+                "css/banner.css",
+                "css/button.css",
+                "css/colors.css",
+                "css/define.css",
+                "css/notification.css",
+                "css/pwgen.css",
+                "css/username.css",
+                "css/totp.css",
+                "content/passkeys.js"
+            ],
+            "matches": [
+                "https://*/*",
+                "http://*/*"
+            ]
+        }
     ],
     "permissions": [
-        "<all_urls>",
         "activeTab",
         "clipboardWrite",
         "contextMenus",
         "cookies",
         "nativeMessaging",
         "notifications",
+        "offscreen",
         "storage",
         "tabs",
         "webNavigation",
         "webRequest",
-        "webRequestBlocking",
-        "https://*/*",
-        "http://*/*",
-        "https://api.github.com/"
+        "webRequestAuthProvider",
+        "webRequestBlocking"
     ],
-    "applications": {
-        "gecko": {
-            "id": "keepassxc-browser@keepassxc.org",
-            "strict_min_version": "96.0"
-        }
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'"
     },
+    "host_permissions": [
+        "<all_urls>",
+        "https://*/*",
+        "http://*/*"
+    ],
     "storage": {
-      "managed_schema": "managed_storage.json"
+        "managed_schema": "managed_storage.json"
     },
     "default_locale": "en"
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "scripts": {
     "build": "node build.js",
+    "debug:chromium": "cp dist/manifest_chromium.json keepassxc-browser/manifest.json",
+    "debug:firefox": "cp dist/manifest_firefox.json keepassxc-browser/manifest.json",
     "lint": "npx eslint keepassxc-browser/**/*.js",
     "tests": "npx playwright test"
   },


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
We have been using a "common" `manifest.json` for years for development/debugging that has been working with all browsers. Now when Chromium based browsers have disabled the support for Manifest V2 extensions, this method cannot be no longer used. The following changes are needed:
- Use Chromium's manifest file as the default one.
- Add script command `debug:chromium` for switching to Chromium based V3 manifest file.
- Add script command `debug:firefox` for switching to Firefox based V2 manifest file.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
