### PR TITLE
Add support for Creating a new credential manually

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -350,6 +350,14 @@
         "message": "Choose a Custom Login Field",
         "description": "Help text for Custom Login Field banner."
     },
+    "url": {
+        "message": "URL",
+        "description": "General text for URL."
+    },
+    "group": {
+        "message": "Group",
+        "description": "General text for group."
+    },
     "username": {
         "message": "Username",
         "description": "General text for username."
@@ -413,6 +421,22 @@
     "popupSettingsText": {
         "message": "Settings",
         "description": "Popup Settings button text."
+    },
+    "popupAddCredentialsText": {
+        "message": "Add a new credential",
+        "description": "Popup add a new credential text."
+    },
+    "popupAddCredentialsPasswordText": {
+        "message": "If empty, KeePassXC generates the password automatically.",
+        "description": "Popup add a new credential password help text."
+    },
+    "popupAddCredentialGroupText": {
+        "message": "Separate the group with slashes. For example: Group/ChildGroup. If empty, the default group is used.",
+        "description": "Popup add a new credential group help text."
+    },
+    "popupAddCredentialsTitlePlaceholder": {
+        "message": "Title",
+        "description": "Title placeholder."
     },
     "popupChooseCredentialsText": {
         "message": "Choose Custom Login Fields",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -267,6 +267,7 @@ kpxcEvent.messageHandlers = {
     'load_keyring': kpxcEvent.onLoadKeyRing,
     'load_settings': kpxcEvent.onLoadSettings,
     'lock_database': kpxcEvent.lockDatabase,
+    'page_add_new_credential': page.addNewCredential,
     'page_clear_logins': kpxcEvent.pageClearLogins,
     'page_clear_submitted': page.clearSubmittedCredentials,
     'page_get_autosubmit_performed': page.getAutoSubmitPerformed,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -40,6 +40,7 @@ const defaultSettings = {
 };
 
 const AUTO_SUBMIT_TIMEOUT = 5000;
+const DEFAULT_BROWSER_GROUP = 'KeePassXC-Browser Passwords';
 
 const page = {};
 page.autoSubmitPerformed = false;
@@ -147,6 +148,79 @@ page.switchTab = async function(tab) {
     browser.tabs.sendMessage(tab.id, { action: 'activated_tab' }).catch((e) => {
         logError('Cannot send activated_tab message: ' + e.message);
     });
+};
+
+// Adds a new credential and handles setting/creating the group
+page.addNewCredential = async function(tab, args) {
+    if (!tab || !page.tabs[tab.id]) {
+        return;
+    }
+
+    // Traverse the groups and ensure all paths are found
+    const getDefaultGroup = function(groups, defaultGroup) {
+        const getGroup = function(group, splitted, depth = -1) {
+            ++depth;
+            for (const g of group) {
+                if (g.name === splitted[depth]) {
+                    if (splitted.length === (depth + 1)) {
+                        return [ g.name, g.uuid ];
+                    }
+                    return getGroup(g.children, splitted, depth);
+                }
+            }
+            return [ '', '' ];
+        };
+
+        const splitted = defaultGroup.split('/');
+        return getGroup(groups, splitted);
+    };
+
+    const saveToDefaultGroup = async function(creds) {
+        const args = [ creds.username, creds.password, creds.url, creds.group ];
+        const res = await keepass.addCredentials(tab, args);
+        return res;
+    };
+
+    const result = await keepass.getDatabaseGroups(tab);
+    if (!result || !result.groups) {
+        const res = await saveToDefaultGroup(args);
+        return res;
+    }
+
+    // Group has not been set
+    if (args?.group === ''
+        || (!args?.group && (result.defaultGroup === '' || result.defaultGroup === DEFAULT_BROWSER_GROUP))) {
+        const res = await saveToDefaultGroup(args);
+        return res;
+    }
+
+    // A specified group is used
+    const [ groupName, groupUUID ] = getDefaultGroup(result.groups[0].children, args.group || result.defaultGroup);
+    if (groupName === '' && groupUUID === '') {
+        // Create a new group
+        const newGroup = await keepass.createNewGroup(tab, [ args.group || result.defaultGroup ]);
+        if (newGroup.name && newGroup.uuid) {
+            const res = await keepass.addCredentials(tab, [
+                args.username,
+                args.password,
+                args.url,
+                newGroup.name,
+                newGroup.uuid,
+            ]);
+            return res;
+        }
+
+        return 'canceled';
+    }
+
+    const res = await await keepass.addCredentials(tab, [
+        args.username,
+        args.password,
+        args.url,
+        groupName,
+        groupUUID,
+    ]);
+    return res;
 };
 
 page.clearCredentials = async function(tabId, complete) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -945,6 +945,9 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             kpxc.triggerActivatedTab();
         } else if (req.action === 'add_allow_iframes_option') {
             kpxc.addToSitePreferences('allowIframes');
+        } else if (req.action === 'add_new_credential') {
+            const res = await sendMessage('page_add_new_credential', req.args);
+            kpxcBanner.verifyResult(res, req.args.username);
         } else if (req.action === 'add_username_only_option') {
             kpxc.addToSitePreferences('usernameOnly', true);
         } else if (req.action === 'check_database_hash' && 'hash' in req) {

--- a/keepassxc-browser/popups/popup.css
+++ b/keepassxc-browser/popups/popup.css
@@ -130,7 +130,7 @@ code {
     display: none;
 }
 
-#options-button {
+#options-button, #add-credentials-button {
     height: 31px;
     width: 2.5rem;
 }
@@ -204,4 +204,9 @@ code {
     #login-filter {
         color: var(--kpxc-text-color) !important;
     }
+}
+
+/* Add new credentials */
+.help-text {
+    margin-inline-start: 1.725em;
 }

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -23,6 +23,9 @@
             <i class="fa fa-cog" aria-hidden="true"></i>
           </button>
           <button id="choose-custom-login-fields-button" class="btn btn-sm btn-warning" data-i18n="[title]popupChooseCredentialsText"></button>
+          <button id="add-credentials-button" class="btn btn-sm btn-warning" data-i18n="[title]popupAddCredentialsText" style="display: none">
+            <i class="fa fa-user-plus" aria-hidden="true"></i>
+          </button>
         </div>
         <div class="lock-button-area">
           <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase">
@@ -142,6 +145,56 @@
           </button>
         </div>
       </div>
+
+      <div id="add-credentials" style="display: none">
+        <hr>
+        <span data-i18n="popupAddCredentialsText"></span>
+        <form>
+          <div class="content pt-2 pb-2">
+            <div class="pb-2">
+              <input class="form-control form-control-sm" type="text" id="add-credentials-title" data-i18n="[placeholder]popupAddCredentialsTitlePlaceholder" required>
+            </div>
+            <div class="pb-2">
+              <input type="text" class="form-control form-control-sm" id="add-credentials-username" data-i18n="[placeholder]username" required>
+            </div>
+            <div class="pb-2">
+              <input type="password" class="form-control form-control-sm" id="add-credentials-password"data-i18n="[placeholder]password" required>
+              <div class="form-text help-text" id="add-credentials-password-help-text">
+                <span data-i18n="popupAddCredentialsPasswordText"></span>
+              </div>
+            </div>
+            <div class="pb-2">
+              <input type="url" class="form-control form-control-sm" id="add-credentials-url" data-i18n="[placeholder]url" required>
+            </div>
+            <div class="pb-2">
+              <input type="text" class="form-control form-control-sm" id="add-credentials-group" data-i18n="[placeholder]group">
+              <div class="form-text help-text" id="add-credentials-group-help-text">
+                <span data-i18n="popupAddCredentialGroupText"></span>
+              </div>
+            </div>
+            <!-- TODO: Protocol V2
+            <div class="input-group input-group-sm pb-2">
+              <label class="input-group-text" for="add-credentials-database">Database</label>
+              <select class="form-select form-select-sm" id="add-credentials-database">
+                <option value="1">Database 1</option>
+                <option value="2">...</option>
+              </select>
+            </div>
+            -->
+          </div>
+          <div class="content right-align pt-2 pb-2">
+            <button class="btn btn-sm btn-primary me-1" type="submit" id="add-credentials-save-button" data-i18n="[title]optionsButtonSave">
+              <i class="fa fa-save" aria-hidden="true"></i>
+              <span data-i18n="optionsButtonSave"></span>
+            </button>
+            <button class="btn btn-sm btn-danger" type="button" id="add-credentials-cancel-button" data-i18n="[title]optionsButtonCancel">
+              <i class="fa fa-remove" aria-hidden="true"></i>
+              <span data-i18n="optionsButtonCancel"></span>
+            </button>
+          </div>
+        </form>
+      </div>
+
     </div>
   </body>
 </html>

--- a/keepassxc-browser/popups/popup.js
+++ b/keepassxc-browser/popups/popup.js
@@ -10,7 +10,7 @@ HTMLElement.prototype.hide = function() {
     this.style.display = 'none';
 };
 
-function statusResponse(r) {
+async function statusResponse(r) {
     $('#initial-state').hide();
     $('#error-encountered').hide();
     $('#need-reconfigure').hide();
@@ -20,6 +20,7 @@ function statusResponse(r) {
     $('#lock-database-button').hide();
     $('#getting-started-guide').hide();
     $('#database-not-opened').hide();
+    $('#add-credentials-button').hide();
 
     if (!r.keePassXCAvailable) {
         $('#error-message').textContent = r.error;
@@ -52,6 +53,7 @@ function statusResponse(r) {
         $('#configured-and-associated').show();
         $('#associated-identifier').textContent = r.identifier;
         $('#lock-database-button').show();
+        $('#add-credentials-button').show();
 
         if (r.usernameFieldDetected) {
             $('#username-field-detected').show();

--- a/keepassxc-browser/popups/popup_login.html
+++ b/keepassxc-browser/popups/popup_login.html
@@ -23,6 +23,9 @@
             <i class="fa fa-cog" aria-hidden="true"></i>
           </button>
           <button id="choose-custom-login-fields-button" class="btn btn-sm btn-warning" data-i18n="[title]popupChooseCredentialsText"></button>
+          <button id="add-credentials-button" class="btn btn-sm btn-warning" data-i18n="[title]popupAddCredentialsText">
+            <i class="fa fa-user-plus" aria-hidden="true"></i>
+          </button>
         </div>
         <div class="lock-button-area">
           <button id="lock-database-button" class="btn btn-sm btn-danger" data-i18n="[title]lockDatabase">
@@ -46,7 +49,7 @@
         <div id="login-list" class="list-group"></div>
       </div>
 
-       <div id="database-not-opened">
+      <div id="database-not-opened">
         <p data-i18n="popupErrorEncountered"></p>
         <p style="margin-left: 1em">
           <code id="database-error-message"></code>
@@ -58,6 +61,55 @@
           </button>
         </div>
       </div>
+
+      <div id="add-credentials" style="display: none">
+        <span data-i18n="popupAddCredentialsText"></span>
+        <form>
+          <div class="content pt-2 pb-2">
+            <div class="pb-2">
+              <input class="form-control form-control-sm" type="text" id="add-credentials-title" data-i18n="[placeholder]popupAddCredentialsTitlePlaceholder" required>
+            </div>
+            <div class="pb-2">
+              <input type="text" class="form-control form-control-sm" id="add-credentials-username" data-i18n="[placeholder]username" required>
+            </div>
+            <div class="pb-2">
+              <input type="password" class="form-control form-control-sm" id="add-credentials-password"data-i18n="[placeholder]password" required>
+              <div class="form-text help-text" id="add-credentials-password-help-text">
+                <span data-i18n="popupAddCredentialsPasswordText"></span>
+              </div>
+            </div>
+            <div class="pb-2">
+              <input type="url" class="form-control form-control-sm" id="add-credentials-url" data-i18n="[placeholder]url" required>
+            </div>
+            <div class="pb-2">
+              <input type="text" class="form-control form-control-sm" id="add-credentials-group" data-i18n="[placeholder]group">
+              <div class="form-text help-text" id="add-credentials-group-help-text">
+                <span data-i18n="popupAddCredentialGroupText"></span>
+              </div>
+            </div>
+            <!-- TODO: Protocol V2
+            <div class="input-group input-group-sm pb-2">
+              <label class="input-group-text" for="add-credentials-database">Database</label>
+              <select class="form-select form-select-sm" id="add-credentials-database">
+                <option value="1">Database 1</option>
+                <option value="2">...</option>
+              </select>
+            </div>
+            -->
+          </div>
+          <div class="content right-align pt-2 pb-2">
+            <button class="btn btn-sm btn-primary me-1" type="submit" id="add-credentials-save-button" data-i18n="[title]optionsButtonSave">
+              <i class="fa fa-save" aria-hidden="true"></i>
+              <span data-i18n="optionsButtonSave"></span>
+            </button>
+            <button class="btn btn-sm btn-danger" type="button" id="add-credentials-cancel-button" data-i18n="[title]optionsButtonCancel">
+              <i class="fa fa-remove" aria-hidden="true"></i>
+              <span data-i18n="optionsButtonCancel"></span>
+            </button>
+          </div>
+        </form>
+      </div>
+
     </div>
   </body>
 </html>

--- a/keepassxc-browser/popups/popup_login.js
+++ b/keepassxc-browser/popups/popup_login.js
@@ -68,6 +68,8 @@
         $('#credentialsList').hide();
         $('#database-not-opened').show();
         $('#lock-database-button').hide();
+        $('#add-credentials').hide();
+        $('#add-credentials-button').hide();
         $('#database-error-message').textContent = tr('errorMessageDatabaseNotOpened');
     });
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds a new section to the extension popup that allows user to create a new credential manually. It's possible to set a specific group, or use the default when left empty. The new section is available with both unlocked/normal and login popup statuses.

A separate database selection input can be added with Protocol V2.

Fixes #1234

TODO:
- [ ] Generate a password automatically if left empty

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )
<img width="495" alt="Screenshot 2025-03-16 at 16 06 59" src="https://github.com/user-attachments/assets/76a4be29-eaaf-43e6-9431-9961f2b2db42" />

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
