### PR TITLE
Disable passkeys script injection if site is ignored

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -264,6 +264,7 @@ kpxcEvent.messageHandlers = {
     'init_http_auth': kpxcEvent.initHttpAuth,
     'is_connected': kpxcEvent.getIsKeePassXCAvailable,
     'is_iframe_allowed': page.isIframeAllowed,
+    'is_site_ignored': page.isSiteIgnored,
     'load_keyring': kpxcEvent.onLoadKeyRing,
     'load_settings': kpxcEvent.onLoadSettings,
     'lock_database': kpxcEvent.lockDatabase,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -320,6 +320,22 @@ page.fillHttpAuth = async function(tab, credentials) {
     }
 };
 
+page.isSiteIgnored = async function(tab, currentLocation) {
+    if (!page?.settings?.sitePreferences || !currentLocation) {
+        return false;
+    }
+
+    for (const site of page.settings.sitePreferences) {
+        if (siteMatch(site.url, currentLocation) || site.url === currentLocation) {
+            if (site.ignore === IGNORE_FULL) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+};
+
 // Update context menu for attribute filling
 page.updateContextMenu = async function(tab, credentials) {
     // Remove any old attribute items

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -981,6 +981,8 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             }
         } else if (req.action === 'ignore_site') {
             kpxc.ignoreSite(req.args);
+        } else if (req.action === 'is_site_ignored') {
+            return await kpxc.siteIgnored();
         } else if (req.action === 'redetect_fields') {
             const response = await sendMessage('load_settings');
             kpxc.settings = response;

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -99,6 +99,11 @@ const initContent = async () => {
         return;
     }
 
+    if (await chrome.runtime.sendMessage({ action: 'is_site_ignored', args: window.self.location.href })) {
+        console.log('This site is ignored in Site Preferences.');
+        return;
+    }
+
     if (settings.passkeys) {
         kpxcPasskeysUtils.debugLogging = settings?.debugLogging;
         kpxcPasskeysUtils.passkeysFallback = settings?.passkeysFallback;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If a page has been entered to Site Preferences and all features are disabled, the extension should not inject the passkey script to the page.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using https://webauthn.io

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue))
