### PR TITLE
Autofill preferred user on multiple matches

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -1098,6 +1098,10 @@
         "message": "Ignore",
         "description": "Site Preferences list column title."
     },
+    "optionsColumnPreferredUser": {
+        "message": "Preferred username",
+        "description": "Preferred username if there are multiple matches."
+    },
     "optionsColumnUsernameOnly": {
         "message": "Username-only Detection",
         "description": "Site Preferences list column title."

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -79,6 +79,21 @@ kpxcFill.fillFromCombination = async function(elem, passOnly) {
 
 // Fill requested by Auto-Fill
 kpxcFill.fillFromAutofill = async function() {
+
+    // Fill preferred user if available
+    if (kpxc.credentials.length > 1) {
+        const sitePreference = kpxc.settings.sitePreferences.find(preference => preference.url === document.location.href);
+        if(sitePreference && sitePreference.preferredUser) {
+            const credential = kpxc.credentials.find(credential => credential.login === sitePreference.preferredUser);
+            if(credential) {
+                await sendMessage('page_set_login_id', credential.uuid);
+                const index = kpxc.combinations.length - 1;
+                kpxcFill.fillInCredentials(kpxc.combinations[index], credential.login, credential.uuid);
+                return;
+            }
+        }
+    }
+
     if (kpxc.credentials.length !== 1 || kpxc.combinations.length === 0) {
         logDebug('Error: Credential list is empty or contains more than one entry.');
         return;

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -501,10 +501,11 @@ kpxc.prepareCredentials = async function() {
         logDebug('Error: No combination found.');
         return;
     }
-
-    if (kpxc.settings.autoFillSingleEntry && kpxc.credentials.length === 1) {
-        kpxcFill.fillFromAutofill();
-        return;
+    const sitePreference = kpxc.settings.sitePreferences.find(preference => preference.url === document.location.href);
+    if ((kpxc.settings.autoFillSingleEntry && kpxc.credentials.length === 1) || 
+         (sitePreference && sitePreference.preferredUser && kpxc.credentials.find(credential => credential.login === sitePreference.preferredUser))) {
+            kpxcFill.fillFromAutofill();
+            //return;
     }
 
     kpxc.initLoginPopup();

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -749,6 +749,7 @@
                         <tr>
                           <th scope="col"><span data-i18n="optionsColumnPageURL"></span></th>
                           <th scope="col"><span data-i18n="optionsColumnIgnore"></span></th>
+                          <th scope="col"><span data-i18n="optionsColumnPreferredUser"></span></th>
                           <th scope="col"><span data-i18n="optionsColumnUsernameOnly"></span></th>
                           <th scope="col"><span data-i18n="optionsColumnImprovedInputFieldDetection"></span></th>
                           <th scope="col"><span data-i18n="optionsColumnAllowIframes"></span></th>
@@ -785,6 +786,7 @@
                               <option value="ignoreFull" data-i18n="optionsSelectionFull"></option>
                             </select>
                           </td>
+                          <td><input class="form-control form-control-sm" type="text" name="preferredUser" value="" data-i18n="[title]optionsColumnPreferredUser"></td>
                           <td><input class="form-check-input" type="checkbox" name="usernameOnly" value="false" data-i18n="[title]optionsColumnUsernameOnly"></td>
                           <td><input class="form-check-input" type="checkbox" name="improvedFieldDetection" value="false" data-i18n="[title]optionsColumnImprovedInputFieldDetection"></td>
                           <td><input class="form-check-input" type="checkbox" name="allowIframes" value="false" data-i18n="[title]optionsColumnAllowIframes"></td>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -589,7 +589,9 @@ options.initSitePreferences = function() {
 
         for (const site of options.settings['sitePreferences']) {
             if (site.url === url) {
-                if (this.name === 'usernameOnly') {
+                if (this.name === 'preferredUser') {
+                    site.preferredUser = this.value;
+                } else if (this.name === 'usernameOnly') {
                     site.usernameOnly = this.checked;
                 } else if (this.name === 'improvedFieldDetection') {
                     site.improvedFieldDetection = this.checked;
@@ -615,7 +617,7 @@ options.initSitePreferences = function() {
         options.saveSettings();
     };
 
-    const addNewRow = function(rowClone, newIndex, url, ignore, usernameOnly, improvedFieldDetection, allowIframes) {
+    const addNewRow = function(rowClone, newIndex, url, ignore, preferredUser, usernameOnly, improvedFieldDetection, allowIframes) {
         const row = rowClone.cloneNode(true);
         row.setAttribute('url', url);
         row.setAttribute('id', 'tr-scf' + newIndex);
@@ -650,13 +652,15 @@ options.initSitePreferences = function() {
         );
         row.children[1].children[0].value = ignore;
         row.children[1].children[0].addEventListener('change', selectionChanged);
-        row.children[2].children['usernameOnly'].checked = usernameOnly;
-        row.children[2].children['usernameOnly'].addEventListener('change', checkboxClicked);
-        row.children[3].children['improvedFieldDetection'].checked = improvedFieldDetection;
-        row.children[3].children['improvedFieldDetection'].addEventListener('change', checkboxClicked);
-        row.children[4].children['allowIframes'].checked = allowIframes;
-        row.children[4].children['allowIframes'].addEventListener('change', checkboxClicked);
-        row.children[5].addEventListener('click', removeButtonClicked);
+        row.children[2].children['preferredUser'].value = preferredUser;
+        row.children[2].children['preferredUser'].addEventListener('input', checkboxClicked);
+        row.children[3].children['usernameOnly'].checked = usernameOnly;
+        row.children[3].children['usernameOnly'].addEventListener('change', checkboxClicked);
+        row.children[4].children['improvedFieldDetection'].checked = improvedFieldDetection;
+        row.children[4].children['improvedFieldDetection'].addEventListener('change', checkboxClicked);
+        row.children[5].children['allowIframes'].checked = allowIframes;
+        row.children[5].children['allowIframes'].addEventListener('change', checkboxClicked);
+        row.children[6].addEventListener('click', removeButtonClicked);
 
         $('#tab-site-preferences table tbody').append(row);
     };
@@ -716,7 +720,7 @@ options.initSitePreferences = function() {
         const rowClone = $('#tab-site-preferences table tr.clone').cloneNode(true);
         rowClone.classList.remove('clone', 'd-none');
 
-        addNewRow(rowClone, newIndex, value, IGNORE_NOTHING, false, false, false);
+        addNewRow(rowClone, newIndex, value, IGNORE_NOTHING, undefined, false, false, false);
         $('#tab-site-preferences table tbody tr.empty').hide();
 
         options.settings['sitePreferences'].push({
@@ -740,6 +744,7 @@ options.initSitePreferences = function() {
                 counter,
                 site.url,
                 site.ignore,
+                site.preferredUser,
                 site.usernameOnly,
                 site.improvedFieldDetection,
                 site.allowIframes,


### PR DESCRIPTION
This PR adds the feature to autofill credentials of a preferred user if there are multiple matches for a specific site.
The selection menu for users still works in that case.

This helps me a lot in scenarios where I usually login with a default user but in rare cases have to choose a different user which I would otherwise have to search for in the keepassxc app manually.

The preferred user can be configured in the site preferences settings.

(!) The implementation is only done for form logins.
(!) Translations for the options label are still missing