### PR TITLE
Remove XML URL from exclude list

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -39,7 +39,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -52,7 +52,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -39,7 +39,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
URLs containing `.xml` can cause content scripts to be ignored, even if the MIME type is plain HTML. `keepassxc-browser.js` already checks the `contentType` from the document, so it should be enough to rely on that.

Fixes #2505

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
