### PR TITLE
Fixes for page object checks and context menu item creation

### DIFF
--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -4,7 +4,7 @@ const kpxcEvent = {};
 
 kpxcEvent.onMessage = async function(request, sender) {
     if (request.action in kpxcEvent.messageHandlers) {
-        if (!Object.hasOwn(sender, 'tab') || sender.tab.id < 1) {
+        if (!Object.hasOwn(sender, 'tab') || sender?.tab?.id < 1) {
             sender.tab = {};
             sender.tab.id = page.currentTabId;
         }
@@ -158,8 +158,10 @@ kpxcEvent.onLoginPopup = async function(tab, logins) {
         popup: 'popup_login'
     };
 
-    page.tabs[tab.id].loginList = logins;
-    await browserAction.show(tab, popupData);
+    if (tab?.id) {
+        page.tabs[tab.id].loginList = logins;
+        await browserAction.show(tab, popupData);
+    }
 };
 
 kpxcEvent.initHttpAuth = async function() {
@@ -177,11 +179,15 @@ kpxcEvent.onHTTPAuthPopup = async function(tab, data) {
 };
 
 kpxcEvent.onUsernameFieldDetected = async function(tab, detected) {
-    page.tabs[tab.id].usernameFieldDetected = detected;
+    if (tab?.id) {
+        page.tabs[tab.id].usernameFieldDetected = detected;
+    }
 };
 
 kpxcEvent.onIframeDetected = async function(tab, detected) {
-    page.tabs[tab.id].iframeDetected = detected;
+    if (tab?.id) {
+        page.tabs[tab.id].iframeDetected = detected;
+    }
 };
 
 kpxcEvent.passwordGetFilled = async function() {
@@ -201,7 +207,7 @@ kpxcEvent.pageGetRedirectCount = async function() {
 };
 
 kpxcEvent.pageClearLogins = async function(tab, alreadyCalled) {
-    if (!alreadyCalled) {
+    if (!alreadyCalled && tab?.id) {
         page.clearLogins(tab.id);
     }
 };
@@ -230,7 +236,9 @@ kpxcEvent.hideTroubleshootingGuideAlert = async function(tab) {
 
 // Bounce message back to all frames
 kpxcEvent.sendBackToTabs = async function(tab, args = []) {
-    await browser.tabs.sendMessage(tab.id, { action: 'frame_message', args: args });
+    if (tab?.id) {
+        await browser.tabs.sendMessage(tab.id, { action: 'frame_message', args: args });
+    }
 };
 
 // All methods named in this object have to be declared BEFORE this!

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -1,113 +1,5 @@
 'use strict';
 
-(async () => {
-    try {
-        await keepass.migrateKeyRing();
-        await page.initSettings();
-        await page.initSitePreferences();
-        await page.initOpenedTabs();
-        await httpAuth.init();
-        await keepass.reconnect(null, 5000); // 5 second timeout for the first connect
-        await keepass.enableAutomaticReconnect();
-        await keepass.updateDatabase();
-    } catch (e) {
-        logError('init.js failed');
-    }
-})();
-
-/**
- * Generate information structure for created tab and invoke all needed
- * functions if tab is created in foreground
- * @param {object} tab
- */
-browser.tabs.onCreated.addListener((tab) => {
-    if (tab?.id > 0 && tab?.selected) {
-        page.currentTabId = tab.id;
-
-        if (!page.tabs[tab.id]) {
-            page.createTabEntry(tab.id);
-        }
-
-        page.switchTab(tab);
-    }
-});
-
-/**
- * Remove information structure of closed tab for freeing memory
- * @param {integer} tabId
- * @param {object} removeInfo
- */
-browser.tabs.onRemoved.addListener(async function(tabId, removeInfo) {
-    if (page.currentTabId === tabId) {
-        const currentTab = await getCurrentTab();
-        page.currentTabId = currentTab ? currentTab.id : -1;
-    }
-    delete page.tabs[tabId];
-});
-
-/**
- * Remove stored credentials on switching tabs.
- * Invoke functions to retrieve credentials for focused tab
- * @param {object} activeInfo
- */
-browser.tabs.onActivated.addListener(async function(activeInfo) {
-    try {
-        const info = await browser.tabs.get(activeInfo.tabId);
-        if (info && info.id) {
-            page.currentTabId = info.id;
-            if (info.status === 'complete') {
-                if (!page.tabs[info.id]) {
-                    page.createTabEntry(info.id);
-                }
-                page.switchTab(info);
-            }
-        }
-    } catch (err) {
-        logError(err.message);
-    }
-});
-
-/**
- * Update browserAction on every update of the page
- * @param {integer} tabId
- * @param {object} changeInfo
- * @param {object} tab
- */
-browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    // If the tab URL has changed (e.g. logged in) clear credentials
-    if (changeInfo.url) {
-        page.clearLogins(tabId);
-    }
-
-    if (changeInfo.status === 'complete') {
-        browserAction.showDefault(tab);
-        if (!page.tabs[tab.id]) {
-            page.createTabEntry(tab.id);
-        }
-    }
-});
-
-/**
- * Detects page redirects and increases the count. Count is reset after a normal navigation event.
- * Form submit is counted as one.
- * @param {object} details
- */
-browser.webNavigation.onCommitted.addListener((details) => {
-    if (details.transitionQualifiers?.[0] === 'client_redirect' || details.transitionType === 'form_submit') {
-        page.redirectCount += 1;
-        return;
-    }
-
-    // Clear credentials on reload so a new retrieval can be made
-    if (details.transitionType === 'reload') {
-        page.clearLogins(details.tabId);
-    }
-
-    page.redirectCount = 0;
-});
-
-browser.runtime.onMessage.addListener(kpxcEvent.onMessage);
-
 const contextMenuItems = [
     { title: tr('contextMenuFillUsernameAndPassword'), action: 'fill_username_password' },
     { title: tr('contextMenuFillPassword'), action: 'fill_password' },
@@ -119,53 +11,176 @@ const contextMenuItems = [
 ];
 
 const menuContexts = [ 'editable' ];
-
+    
 if (isFirefox()) {
     menuContexts.push('password');
 }
 
-// Create context menu items
-for (const item of contextMenuItems) {
-    browser.contextMenus.create({
-        title: item.title,
-        contexts: menuContexts,
-        visible: item.visible,
-        id: item.id || item.action
-    });
-}
+const initListeners = async function() {
+    /**
+     * Generate information structure for created tab and invoke all needed
+     * functions if tab is created in foreground
+     * @param {object} tab
+     */
+    browser.tabs.onCreated.addListener((tab) => {
+        if (tab?.id > 0 && tab?.selected) {
+            page.currentTabId = tab.id;
 
-// Listen for keyboard shortcuts specified by user
-browser.commands.onCommand.addListener(async (command) => {
-    if (contextMenuItems.some(e => e.action === command)
-        || command === 'redetect_fields'
-        || command === 'choose_credential_fields'
-        || command === 'retrive_credentials_forced'
-        || command === 'reload_extension') {
-        const tab = await getCurrentTab();
-        if (tab) {
-            browser.tabs.sendMessage(tab.id, { action: command });
+            if (!page.tabs[tab.id]) {
+                page.createTabEntry(tab.id);
+            }
+
+            page.switchTab(tab);
         }
-    }
-});
+    });
 
-browser.contextMenus.onClicked.addListener(async (item, tab) => {
-    if (item?.menuItemId?.startsWith('fill_attribute')) {
-        const menuItem = page.attributeMenuItems.find(i => i?.action === item?.menuItemId);
-        if (menuItem) {
-            browser.tabs.sendMessage(tab.id, {
-                action: 'fill_attribute',
-                args: menuItem?.args
-            }).catch((err) => {
-                logError(err);
+    /**
+     * Remove information structure of closed tab for freeing memory
+     * @param {integer} tabId
+     * @param {object} removeInfo
+     */
+    browser.tabs.onRemoved.addListener(async function(tabId, removeInfo) {
+        if (page.currentTabId === tabId) {
+            const currentTab = await getCurrentTab();
+            page.currentTabId = currentTab ? currentTab.id : -1;
+        }
+        delete page.tabs[tabId];
+    });
+
+    /**
+     * Remove stored credentials on switching tabs.
+     * Invoke functions to retrieve credentials for focused tab
+     * @param {object} activeInfo
+     */
+    browser.tabs.onActivated.addListener(async function(activeInfo) {
+        try {
+            const info = await browser.tabs.get(activeInfo.tabId);
+            if (info && info.id) {
+                page.currentTabId = info.id;
+                if (info.status === 'complete') {
+                    if (!page.tabs[info.id]) {
+                        page.createTabEntry(info.id);
+                    }
+                    page.switchTab(info);
+                }
+            }
+        } catch (err) {
+            logError(err.message);
+        }
+    });
+
+    /**
+     * Update browserAction on every update of the page
+     * @param {integer} tabId
+     * @param {object} changeInfo
+     * @param {object} tab
+     */
+    browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+        // If the tab URL has changed (e.g. logged in) clear credentials
+        if (changeInfo.url) {
+            page.clearLogins(tabId);
+        }
+
+        if (changeInfo.status === 'complete' && tab?.id) {
+            browserAction.showDefault(tab);
+            if (!page.tabs[tab.id]) {
+                page.createTabEntry(tab.id);
+            }
+        }
+    });
+
+    /**
+     * Detects page redirects and increases the count. Count is reset after a normal navigation event.
+     * Form submit is counted as one.
+     * @param {object} details
+     */
+    browser.webNavigation.onCommitted.addListener((details) => {
+        if (details.transitionQualifiers?.[0] === 'client_redirect' || details.transitionType === 'form_submit') {
+            page.redirectCount += 1;
+            return;
+        }
+
+        // Clear credentials on reload so a new retrieval can be made
+        if (details.transitionType === 'reload') {
+            page.clearLogins(details.tabId);
+        }
+
+        page.redirectCount = 0;
+    });
+
+    browser.runtime.onMessage.addListener(kpxcEvent.onMessage);
+
+    // Listen for keyboard shortcuts specified by user
+    browser.commands.onCommand.addListener(async (command) => {
+        if (contextMenuItems.some(e => e.action === command)
+            || command === 'redetect_fields'
+            || command === 'choose_credential_fields'
+            || command === 'retrive_credentials_forced'
+            || command === 'reload_extension') {
+            const tab = await getCurrentTab();
+            if (tab?.id) {
+                browser.tabs.sendMessage(tab.id, { action: command });
+            }
+        }
+    });
+
+    browser.contextMenus.onClicked.addListener(async (item, tab) => {
+        if (!tab?.id) {
+            return;
+        }
+
+        if (item?.menuItemId?.startsWith('fill_attribute')) {
+            const menuItem = page.attributeMenuItems.find(i => i?.action === item?.menuItemId);
+            if (menuItem) {
+                browser.tabs.sendMessage(tab.id, {
+                    action: 'fill_attribute',
+                    args: menuItem?.args
+                }).catch((err) => {
+                    logError(err);
+                });
+            }
+
+            return;
+        }
+
+        browser.tabs.sendMessage(tab.id, {
+            action: item.menuItemId
+        }).catch((err) => {
+            logError(err);
+        });
+    });
+};
+
+const initContextMenuItems = async function() { 
+    // Create context menu items
+    await browser.contextMenus.removeAll();
+    for (const item of contextMenuItems) {
+        try {
+            await browser.contextMenus.create({
+                title: item.title,
+                contexts: menuContexts,
+                visible: item.visible,
+                id: item.id || item.action
             });
-        }
-
-        return;
+        } catch (e) {
+            logError(e);
+        } 
     }
+};
 
-    browser.tabs.sendMessage(tab.id, {
-        action: item.menuItemId
-    }).catch((err) => {
-        logError(err);
-    });
-});
+(async () => {
+    try {
+        await keepass.migrateKeyRing();
+        await page.initSettings();
+        await page.initSitePreferences();
+        await page.initOpenedTabs();
+        await initListeners();
+        await initContextMenuItems();
+        await httpAuth.init();
+        await keepass.reconnect(null, 5000); // 5 second timeout for the first connect
+        await keepass.enableAutomaticReconnect();
+        await keepass.updateDatabase();
+    } catch (e) {
+        logError('init.js failed');
+    }
+})();

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -929,7 +929,7 @@ keepass.updateDatabase = async function() {
 keepass.updateDatabaseHashToContent = async function() {
     try {
         const tab = await getCurrentTab();
-        if (tab) {
+        if (tab?.id) {
             // Send message to content script
             browser.tabs.sendMessage(tab.id, {
                 action: 'check_database_hash',

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -179,7 +179,7 @@ const getFileAndLine = function() {
 
 const getCurrentTab = async function() {
     const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-    return tabs.length > 0 ? tabs[0] : undefined;
+    return tabs?.length > 0 ? tabs[0] : undefined;
 };
 
 // Exports for tests


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Sometimes `page.settings` is not loaded before other scripts are doing their job. This can happen on browser launch, after browser update etc. Additional checks are added.

There's some strange delay after browser start before the toolbar icons update. The whole reason for this behavior is kind of weird. When browser starts for the first time, the scripts are initialized in a different order. If the extension is reloaded using `edge://extensions` the order is again the correct one. These changes should ensure the order is kept intact.

Fixes #2507.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually by restarting the browser and inspecting the service worker, plus reloading the extension on-the-fly. Using Microsoft Edge.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
