### PR TITLE
Add support for autocomplete=username

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -46,7 +46,11 @@ kpxcFields.getAllCombinations = async function(inputs) {
         }
     }
 
-    if (kpxc.singleInputEnabledForPage && combinations.length === 0 && usernameField) {
+    // Allow single input if autocomplete="username" is present, or Username-Only Detection is enabled for the page
+    const autoComplete = usernameField?.getLowerCaseAttribute('autocomplete');
+    if (combinations.length === 0 && usernameField &&
+        (kpxc.singleInputEnabledForPage || autoComplete?.includes('username') || autoComplete?.includes('email'))
+    ) {
         const combination = {
             username: usernameField,
             password: null,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Currently we only support single input fields if those are explicitly allowed via `Username-Only Detection`. Those fields should be also allowed when `autocomplete="username"` attribute is included, or if it contains `email`. Some sites use multiple values here, separated by spaces.

Fixes #2436.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. Disable Predefined Sites in the extension settings and go to https://www.adobe.com/ and login.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
