### PR TITLE
Fix retrieving credentials from changed DB in unlock dialog

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -678,7 +678,7 @@ kpxc.retrieveCredentialsCallback = async function(credentials) {
 
 // If credentials are not received, request them again
 kpxc.receiveCredentialsIfNecessary = async function() {
-    if (kpxc.credentials.length === 0 && !_called.retrieveCredentials) {
+    if (kpxc.credentials.length === 0) {
         if (!await isIframeAllowed()) {
             return [];
         }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If user triggers the KeePassXC unlock dialog from the Username Icon and switches the database that will be opened, credentials are not immediately returned to the content scripts. The `_called.retrieveCredentials` state should be only used with the Mutation Observer and no longer with the plain credential retrieval. The credentials are cached for a while in the background script.

Fixes #2468

[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. Steps to reproduce:
- Have two databases in KeePassXC. Only one is connected to the extension. Activate the non-connected DB tab in KeePassXC.
- Go to a web page and trigger the unlock dialog from Username Icon.
- Non-connected DB should be active in the dialog. Switch the tab to the connected DB and unlock it with your password.
- No credentials are returned to the content scripts. Refreshing the page or clicking Username Icon again fills them, or shows the Autocomplete Menu.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
