### PR TITLE
Add support for opening Firefox shortcut settings page

### DIFF
--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -200,9 +200,21 @@ options.initGeneralSettings = async function() {
     });
 
     $('#configureCommands').addEventListener('click', function() {
+        if (isFirefox()) {
+            if (typeof(browser.commands.openShortcutSettings) === 'function') {
+                browser.commands.openShortcutSettings();
+            } else {
+                // TODO: Remove internal shortcuts page after Firefox ESR has support for openShortcutSettings()
+                browser.tabs.create({
+                    url: browser.runtime.getURL('options/shortcuts.html')
+                });
+            }
+            return;
+        }
+
         const scheme = isEdge() ? 'edge' : 'chrome';
         browser.tabs.create({
-            url: isFirefox() ? browser.runtime.getURL('options/shortcuts.html') : `${scheme}://extensions/shortcuts`
+            url: `${scheme}://extensions/shortcuts`
         });
     });
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Firefox 137 and newer finally support opening extension shortcut pages: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/commands/openShortcutSettings.

The internal shortcuts page must be removed when support for `openShortcutSettings()` hits the Firefox ESR.

Fixes #389.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
