### PR TITLE
Improve username input detection with Credential Banner

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -229,7 +229,11 @@ kpxcForm.onSubmit = async function(e) {
     }
 
     const [ usernameField, passwordField, passwordInputs ] = kpxcForm.getCredentialFieldsFromForm(form);
-    const usernameValue = await kpxcForm.getUsernameValue(usernameField);
+    
+    // Use the first text field in the form if only username input is missing
+    const usernameValue = await kpxcForm.getUsernameValue(!usernameField && passwordField
+        ? form?.querySelector('input[type=text]')
+        : usernameField);
     await kpxcForm.activateCredentialBanner(usernameValue, passwordInputs, passwordField);
 };
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When `onSubmit()` is triggered on form, the username field is not always present in the input field list even if it's inside the form object. In this case try to use the first `type=text` input in the form so Credential Banner can be showed after login.

Fixes #2460.

Might also fix another sites that have problems showing the Credential Banner.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. Created a temporary email address for temu.com.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
