### PR TITLE
Add submit button exception for OpenAI login page

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -207,6 +207,8 @@ kpxcSites.formSubmitButtonExceptionFound = function(form) {
     } else if (!form && document.location.href.includes('reddit.com/settings')) {
         // Reddit change password popup
         return $('.button[slot=primary-button]');
+    } else if (form?.action === 'https://auth.openai.com/log-in/password') {
+        return form.querySelector('button[class*=_primary_]');
     }
 
     return undefined;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds a submit button exception for OpenAI login page. When entering the password, Apple's button is selected by default.

Fixes #2541

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. The site accepts any email and password.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
