### PR TITLE
Fix browser integration doc link id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This browser extension was first supported in KeePassXC 2.3.0 (release end of 20
 
 Get the extension for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) or [Chrome/Chromium](https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk) or [Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo) (requires KeePassXC 2.5.3 or newer).
 
-Please see this [document](https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_setup_browser_integration) for instructions how to configure KeePassXC in order to connect the database correctly.
+Please see this [document](https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_browser_integration) for instructions how to configure KeePassXC in order to connect the database correctly.
 
 ## How it works
 

--- a/keepassxc-browser/popups/popup.html
+++ b/keepassxc-browser/popups/popup.html
@@ -41,7 +41,7 @@
         <div id="getting-started-guide" class="alert alert-info alert-dismissible">
           <span data-i18n="popupGettingStartedText"></span>
           <br>
-          <a target="_blank" class="alert-link" href="https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_setup_browser_integration"><span data-i18n="popupGettingStartedLinkText"></span></a>
+          <a target="_blank" class="alert-link" href="https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_browser_integration"><span data-i18n="popupGettingStartedLinkText"></span></a>
           <button type="button" id="getting-started-alert-close-button" class="btn-close" data-bs-dismiss="alert" data-i18n="[title]popupAlertHide"></button>
         </div>
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

In the following popup:

<img width="455" alt="image" src="https://github.com/user-attachments/assets/08fddc9e-4681-47e8-a0aa-5c18c85a4a66" />

This link points to id "#_setup_browser_integration" in the "KeePassXC_GettingStarted" document. Currently, the id attribute for the "Browser Integration" section is "#_browser_integration". This commit fixes that.

Also updated the link the README.

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )
Same screenshot as above.


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Tested by navigating to https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_browser_integration directly.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Documentation (non-code change)
