### PR TITLE
Query form on savedForms check

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -48,7 +48,12 @@ kpxcForm.formIdentified = function(form) {
 kpxcForm.getCredentialFieldsFromForm = function(form) {
     for (const savedForm of kpxcForm.savedForms) {
         if (savedForm.form === form) {
-            return [ savedForm.username, savedForm.password, savedForm.passwordInputs, savedForm.totp ];
+            // If savedForm has no values, query the form instead
+            return [
+                savedForm.username || form?.querySelector('input[type=text]'),
+                savedForm.password || form?.querySelector('input[type=password]'),
+                savedForm.passwordInputs,
+                savedForm.totp ];
         }
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Some login pages have an identical form when password field is present, and the username field is no longer in the form (even if visible on the page). In these cases there are two saved forms extension detects, and the previously saved one doesn't hold the correct data. If that data is missing from the identical saved form, make a query to the current form.

Fixes #2565 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually, with existing credentials on a database that doesn't have them.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)