### PR TITLE
Fix checking input width with segmented TOTP fields

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -60,9 +60,11 @@ kpxcTOTPIcons.isAcceptedTOTPField = function(field) {
         return false;
     }
 
+    const includeCheck = (f) => id?.includes(f) || (name?.includes(f) || placeholder?.includes(f));
+
     // Checks if the field id, name or placeholder includes some of the acceptedOTPFields but not any from ignoredTypes
-    if ((acceptedOTPFields.some(f => id?.includes(f) || (name?.includes(f) || placeholder?.includes(f))) || acceptedParents.some(s => field.closest(s)))
-        && !ignoredTypes.some(f => id?.includes(f) || (name?.includes(f) || placeholder?.includes(f)))) {
+    if ((acceptedOTPFields.some(f => includeCheck(f)) || acceptedParents.some(s => field.closest(s)))
+        && !ignoredTypes.some(f => includeCheck(f))) {
         return true;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds an extra check for input field's `offsetWidth` when detecting segmented TOTP fields. Fields that are too wide should be ignored because of possible false positives.

Also did some code cleaning so the accetp/ignore stuff is easier to read.

Fixes #2467

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using a local test file, while modifying input field widths.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
