### PR TITLE
Add support for WebSocket connection method

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig([globalIgnores(["**/*.min.js"]), {
             CHECK_UPDATE_THREE_DAYS: "readonly",
             cloneInto: "readonly",
             compareVersion: "readonly",
+            ConnectionMethod: "readonly",
             createResult: "readonly",
             createStylesheet: "readonly",
             DatabaseState: "readonly",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -874,6 +874,22 @@
         "message": "Allow filling HTTP Basic Auth credentials",
         "description": "Allow filling HTTP Basic Auth credentials checkbox text."
     },
+    "optionsConnectionMethod": {
+        "message": "Connection method",
+        "description": "Connection method selection text."
+    },
+    "optionsConnectionMethodHelpText": {
+        "message": "If native messaging is blocked in your browser, you can switch to a direct WebSocket sonnection. The feature must be enabled from KeePassXC side to work. Browser restart is required.",
+        "description": "Connection method help text."
+    },
+    "optionsConnectionMethodNativeMessaging": {
+        "message": "Native messaging",
+        "description": "Native messaging option for Connection method."
+    },
+    "optionsConnectionMethodWebSocket": {
+        "message": "WebSocket",
+        "description": "WebSocket option for Connection method."
+    },
     "optionsDebugLogging": {
         "message": "Debug logging",
         "description": "Debug logging checkbox text."

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -5,6 +5,9 @@ keepassClient.keySize = 24;
 keepassClient.messageTimeout = 500; // Milliseconds
 keepassClient.nativeHostName = 'org.keepassxc.keepassxc_browser';
 keepassClient.nativePort = null;
+keepassClient.webSocket = null;
+
+const WEBSOCKET_PORT = 7580;
 
 const kpErrors = {
     UNKNOWN_ERROR: 0,
@@ -157,7 +160,10 @@ class Message {
 //--------------------------------------------------------------------------
 
 keepassClient.sendNativeMessage = async function(request, enableTimeout = false, timeoutValue) {
-    if (!keepassClient.nativePort) {
+    if (page?.settings?.connectionMethod === ConnectionMethod.WEBSOCKET && !keepassClient.webSocket) {
+        logError('No WebSocket defined.');
+        return;
+    } else if (page?.settings?.connectionMethod === ConnectionMethod.NATIVE_MESSAGING && !keepassClient.nativePort) {
         logError('No native messaging port defined.');
         return;
     }
@@ -167,7 +173,11 @@ keepassClient.sendNativeMessage = async function(request, enableTimeout = false,
         messageBuffer.addMessage(message);
     });
 
-    keepassClient.nativePort.postMessage(request);
+    if (page?.settings?.connectionMethod === ConnectionMethod.WEBSOCKET) {
+        keepassClient.webSocket.send(JSON.stringify(request));
+    } else {
+        keepassClient.nativePort.postMessage(request);
+    }
 
     const response = await message.promise;
 
@@ -412,4 +422,43 @@ keepassClient.onNativeMessage = function(response) {
 
     // Generic response handling
     keepassClient.handleNativeMessage(response);
+};
+
+//--------------------------------------------------------------------------
+// WebSocket related
+//--------------------------------------------------------------------------
+
+keepassClient.connectToWebSocket = async function() {
+    return new Promise((resolve, reject) => {
+        if (keepassClient.webSocket) {
+            keepassClient.webSocket.close();
+        }
+    
+        console.log(`${EXTENSION_NAME}: Connecting to WebSocket`);
+    
+        try {
+            keepassClient.webSocket = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}`);
+            keepassClient.webSocket.addEventListener('close', (event) => {
+                logError('Close WebSocket:', event);
+                onDisconnected();
+                reject();
+            });
+            keepassClient.webSocket.addEventListener('error', (event) => {
+                logError('WebSocket error:', event);
+                onDisconnected();
+                reject();
+            });
+            keepassClient.webSocket.addEventListener('message', (event) => {
+                keepassClient.onNativeMessage(JSON.parse(event?.data));
+            });
+            keepassClient.webSocket.addEventListener('open', (event) => {
+                console.log(`${EXTENSION_NAME}: WebSocket connected`);
+                keepass.isConnected = true;
+                resolve();
+            });
+        } catch (e) {
+            keepassClient.webSocket = null;
+            onDisconnected();
+        }
+    });
 };

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -456,7 +456,7 @@ keepassClient.connectToWebSocket = async function() {
                 keepass.isConnected = true;
                 resolve();
             });
-        } catch (e) {
+        } catch (_e) {
             keepassClient.webSocket = null;
             onDisconnected();
         }

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -9,6 +9,7 @@ keepass.featuresList = {
     passkeys: false,
     passkeysDefaultGroup: false,
     requiredKeePassXCVersionFound: false,
+    webSocket: false
 };
 keepass.cacheTimeout = 30 * 1000; // Milliseconds
 keepass.clientID = '';
@@ -822,7 +823,12 @@ keepass.disableAutomaticReconnect = function() {
 };
 
 keepass.reconnect = async function(tab = null, connectionTimeout = 1500) {
-    keepassClient.connectToNative();
+    if (page?.settings?.connectionMethod === ConnectionMethod.WEBSOCKET) {
+        await keepassClient.connectToWebSocket();
+    } else {
+        keepassClient.connectToNative();
+    }
+    
     keepass.generateNewKeyPair();
     const keyChangeResult = await keepass
         .changePublicKeys(tab, !!connectionTimeout, connectionTimeout)
@@ -1016,6 +1022,7 @@ keepass.updateFeaturesList = function (currentVersion) {
         passkeys: versionResults['2.7.7'],
         passkeysDefaultGroup: versionResults['2.7.10'],
         requiredKeePassXCVersionFound: versionResults[keepass.requiredKeePassXC],
+        webSocket: false // TODO: Enable when released in KeePassXC
     };
 };
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const ConnectionMethod = {
+    NATIVE_MESSAGING: 'nativemessaging',
+    WEBSOCKET: 'websocket',
+};
+
 const defaultSettings = {
     afterFillSorting: SORT_BY_MATCHING_CREDENTIALS_SETTING,
     afterFillSortingTotp: SORT_BY_RELEVANT_ENTRY,
@@ -15,6 +20,7 @@ const defaultSettings = {
     checkUpdateKeePassXC: CHECK_UPDATE_NEVER,
     clearCredentialsTimeout: 10,
     colorTheme: 'system',
+    connectionMethod: ConnectionMethod.NATIVE_MESSAGING,
     credentialSorting: SORT_BY_GROUP_AND_TITLE,
     debugLogging: false,
     defaultGroup: '',

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -537,6 +537,18 @@
                     <div class="form-text" data-i18n="optionsClearCredentialsTimeoutHelpText"></div>
                   </div>
 
+                  <!-- Connection method -->
+                  <div class="form-group col-sm-3 pb-2 py-2" id="connectionMethodOptions">
+                    <label for="connectionMethod" class="form-label" data-i18n="optionsConnectionMethod"></label>
+                    <select class="form-select form-select-sm col-md-3 col-lg-2" id="connectionMethod" data-i18n="[title]optionsConnectionMethodSelection">
+                      <option value="nativemessaging" data-i18n="optionsConnectionMethodNativeMessaging"></option>
+                      <option value="websocket" data-i18n="optionsConnectionMethodWebSocket"></option>
+                    </select>
+                  </div>
+                  <div>
+                    <span class="form-text text-muted" data-i18n="optionsConnectionMethodHelpText"></span>
+                  </div>
+
                   <!-- Debug logging -->
                   <div class="form-group mt-2 pb-1">
                     <div class="form-check form-switch">

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -67,7 +67,7 @@
         </nav>
 
         <main class="col-md-9 col-lg-10 offset-md-3 offset-lg-2 px-4 mt-5 mt-md-0">
-          <div class="content">
+          <div class="content" id="main-content">
 
             <!-- General Settings -->
             <div class="tab" id="tab-general-settings">

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -1003,5 +1003,6 @@ window.addEventListener('scroll', function() {
         }, 200);
     } catch (err) {
         console.log('Error loading options page: ' + err);
+        $('#main-content').hide();
     }
 })();

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -226,6 +226,13 @@ options.initGeneralSettings = async function() {
         });
     });
 
+    // Connection method
+    $('#tab-general-settings select#connectionMethod').value = options.settings['connectionMethod'];
+    $('#tab-general-settings select#connectionMethod').addEventListener('change', async function(e) {
+        options.settings['connectionMethod'] = e.currentTarget.value;
+        await options.saveSettings();
+    });
+
     // Default group
     $('#defaultGroupButton').addEventListener('click', async function() {
         const value = $('#defaultGroup').value;
@@ -384,6 +391,10 @@ options.showKeePassXCVersions = async function(response) {
 
     if (!featureList?.passkeysDefaultGroup) {
         $('#tab-general-settings #passkeysDefaultGroup').hide();
+    }
+
+    if (!featureList?.webSocket) {
+        $('#tab-general-settings #connectionMethodOptions').hide();
     }
 };
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds support for connecting to KeePassXC directly via WebSocket instead of native messaging.
Corresponding KeePassXC PR: https://github.com/keepassxreboot/keepassxc/pull/12170

The feature is disabled until KeePassXC side is merged.

## Screenshots
<img width="1110" height="173" alt="Screenshot 2026-05-30 at 9 09 10" src="https://github.com/user-attachments/assets/59222031-d464-413a-b290-5ecc9b182571" />

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

