### PR TITLE
Fix Global Auto-Type search param

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -582,7 +582,7 @@ keepass.requestAutotype = async function(tab, args = []) {
 
     const kpAction = kpActions.REQUEST_AUTOTYPE;
     const nonce = keepassClient.getNonce();
-    const search = page.getTopLevelDomainFromUrl(args[0]);
+    const search = await page.getBaseDomainFromUrl(args[0]);
 
     const messageData = {
         action: kpAction,

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1003,7 +1003,10 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
         } else if (req.action === 'show_password_generator') {
             kpxcPasswordGenerator.showPasswordGenerator();
         } else if (req.action === 'request_autotype') {
-            sendMessage('request_autotype', [ window.location.hostname ]);
+            // All frames can perform this. Ignore iframes that are not allowed.
+            if (await isIframeAllowed()) {
+                sendMessage('request_autotype', [ window.location.hostname ]);
+            }
         }
     }
 });


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
The URL passed to Global Auto-Type was incorrect. The function name has been changed while ago, and `getBaseDomainFromUrl()` must be used instead.
The context menu item triggers the command from all iframes in the page, including Google ads etc. It must be restricted with `isIframeAllowed()`. Otherwise the client triggers multiple Global Auto-Type commands to KeePassXC.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
