### PR TITLE
Move privacy to optional permissions

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -162,13 +162,15 @@
         "nativeMessaging",
         "notifications",
         "offscreen",
-        "privacy",
         "storage",
         "tabs",
         "webNavigation",
         "webRequest",
         "webRequestAuthProvider",
         "webRequestBlocking"
+    ],
+    "optional_permissions": [
+        "privacy"
     ],
     "content_security_policy": {
         "extension_pages": "script-src 'self'"

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -166,7 +166,6 @@
         "cookies",
         "nativeMessaging",
         "notifications",
-        "privacy",
         "storage",
         "tabs",
         "webNavigation",
@@ -175,6 +174,9 @@
         "https://*/*",
         "http://*/*",
         "https://api.github.com/"
+    ],
+    "optional_permissions": [
+        "privacy"
     ],
     "applications": {
         "gecko": {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -19,6 +19,7 @@ const defaultSettings = {
     debugLogging: false,
     defaultGroup: '',
     defaultPasskeyGroup: '',
+    defaultPasswordManager: false,
     defaultGroupAlwaysAsk: false,
     downloadFaviconAfterSave: false,
     passkeys: false,

--- a/keepassxc-browser/common/global_ui.js
+++ b/keepassxc-browser/common/global_ui.js
@@ -10,6 +10,11 @@ HTMLElement.prototype.hide = function() {
 
 // Disables the browser's internal password manager and let the extension take the control
 const updateDefaultPasswordManager = async function() {
+    const permissionResponse = await browser.permissions.request({ permissions: [ 'privacy' ] });
+    if (!permissionResponse) {
+        return false;
+    }
+
     const passwordSavingEnabled = await browser.privacy.services.passwordSavingEnabled.get({});
     if ((passwordSavingEnabled?.levelOfControl === 'controlled_by_this_extension'
         || passwordSavingEnabled?.levelOfControl === 'controllable_by_this_extension')
@@ -18,4 +23,6 @@ const updateDefaultPasswordManager = async function() {
             value: !passwordSavingEnabled.value,
         });
     }
+
+    return passwordSavingEnabled.value;
 };

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -162,13 +162,15 @@
         "nativeMessaging",
         "notifications",
         "offscreen",
-        "privacy",
         "storage",
         "tabs",
         "webNavigation",
         "webRequest",
         "webRequestAuthProvider",
         "webRequestBlocking"
+    ],
+    "optional_permissions": [
+        "privacy"
     ],
     "content_security_policy": {
         "extension_pages": "script-src 'self'"

--- a/keepassxc-browser/options/getting_started.js
+++ b/keepassxc-browser/options/getting_started.js
@@ -9,11 +9,12 @@ const $ = function(elem) {
 const initPage = async function() {
     const changeCheckboxValue = async function(e) {
         const name = e.currentTarget.name;
-        const isChecked = e.currentTarget.checked;
+        let isChecked = e.currentTarget.checked;
 
         if (name === 'defaultPasswordManager') {
-            await updateDefaultPasswordManager();
-            return;
+            const isDefaultPasswordManagerSet = await updateDefaultPasswordManager();
+            isChecked = isDefaultPasswordManagerSet;
+            e.target.checked = isDefaultPasswordManagerSet;
         }
 
         options.settings[name] = isChecked;
@@ -23,14 +24,7 @@ const initPage = async function() {
     // Switch/checkboxes
     const checkboxes = document.querySelectorAll('#tab-getting-started input[type=checkbox]');
     for (const checkbox of checkboxes) {
-        if (checkbox.name === 'defaultPasswordManager') {
-            const passwordSavingEnabled = await browser.privacy.services.passwordSavingEnabled.get({});
-            checkbox.checked = (passwordSavingEnabled?.levelOfControl === 'controlled_by_this_extension'
-                && !passwordSavingEnabled.value) || false;
-        } else {
-            checkbox.checked = options.settings[checkbox.name];
-        }
-
+        checkbox.checked = options.settings[checkbox.name];
         checkbox.addEventListener('click', changeCheckboxValue);
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Moves the new `privacy` permission to `optional_permissions` list. This needs a new setting that is in sync with the permission, otherwise the page tries to use the permission every time on load and would trigger the prompt when querying the default password manager setting from browser. The permission prompt is shown only when trying to change the option for the first time, or denying it and trying again.

I didn't add this option to managed settings.

Related issue thread: #2588

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually. Using Firefox with `web-ext` resets the permissions every time.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Breaking change (causes existing functionality to change)
