### PR TITLE
Clear password manager permission when disabled

### DIFF
--- a/keepassxc-browser/common/global_ui.js
+++ b/keepassxc-browser/common/global_ui.js
@@ -16,13 +16,14 @@ const updateDefaultPasswordManager = async function() {
     }
 
     const passwordSavingEnabled = await browser.privacy.services.passwordSavingEnabled.get({});
-    if ((passwordSavingEnabled?.levelOfControl === 'controlled_by_this_extension'
-        || passwordSavingEnabled?.levelOfControl === 'controllable_by_this_extension')
-    ) {
+    if (passwordSavingEnabled?.levelOfControl === 'controllable_by_this_extension') {
         await browser.privacy.services.passwordSavingEnabled.set({
-            value: !passwordSavingEnabled.value,
+            value: false,
         });
+        return true;
+    } else if (passwordSavingEnabled?.levelOfControl === 'controlled_by_this_extension') {
+        await browser.privacy.services.passwordSavingEnabled.clear({});
     }
 
-    return passwordSavingEnabled.value;
+    return false;
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When enabling the default password manager for the first time, the `levelOfControl` is set to `controllable_by_this_extension`. After setting the password saving option to `false`, the `levelOfControl` changes so `controlled_by_this_extension`.

If the setting is changed after that, the extension is released from holding the password saving option with `.clear()`. This returns the level of control to `controllable_by_this_extension`.

Now everything should work correctly, and the extension doesn't hold the password manager option forever.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually via `web-ext`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
