### PR TITLE
Updated Translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Check [keepassxc-protocol](keepassxc-protocol.md) for the details about the mess
 
 ## Translations
 
-Translations are managed on [Transifex](https://www.transifex.com/keepassxc/keepassxc-browser/) which offers a web interface. Please join an existing language team or request a new one if there is none.
+Translations are managed on [Transifex](https://explore.transifex.com/keepassxc/keepassxc-browser/) which offers a web interface. Please join an existing language team or request a new one if there is none.
 
 ## Development and testing
 


### PR DESCRIPTION
Translation Contribution link to Transifex results in 404 #2610
Simply updated of the out-link


## Type of change
- ✅ Documentation (non-code change)
