### PR TITLE
toJSON implementation for createPublicKeyCredential

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -64,6 +64,30 @@
         };
     }
 
+    const kpxcPublicKeyCredentialJson = function (credential) {
+        const clientExtensionResults = credential.getClientExtensionResults();
+        const type = credential.type;
+        const authenticatorAttachment = credential.authenticatorAttachment;
+        let response;
+
+        if (credential.response instanceof AuthenticatorAttestationResponse) {
+            response = kpxcAuthenticatorAttestationResponseJson(credential.response);
+        }
+
+        if (credential.response instanceof AuthenticatorAssertionResponse) {
+            response = kpxcAuthenticatorAssertionResponseJson(credential.response);
+        }
+
+        return {
+            id: kpxcArrayBufferToBase64Url(credential.rawId),
+            rawId: kpxcArrayBufferToBase64Url(credential.rawId),
+            response,
+            authenticatorAttachment,
+            clientExtensionResults,
+            type,
+        };
+    }
+
     // Wraps response to AuthenticatorAttestationResponse object
     const createAttestationResponse = function(publicKey) {
         const response = {
@@ -72,8 +96,7 @@
             getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
             getPublicKey: () => null,
             getPublicKeyAlgorithm: () => publicKey.response?.publicKeyAlgorithm,
-            getTransports: () => [ 'internal' ],
-            toJSON: () => kpxcAuthenticatorAttestationResponseJson(response)
+            getTransports: () => [ 'internal' ]
         };
         return Object.setPrototypeOf(response, AuthenticatorAttestationResponse.prototype);
     };
@@ -84,8 +107,7 @@
             authenticatorData: kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
             clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response?.clientDataJSON),
             signature: kpxcBase64ToArrayBuffer(publicKey.response?.signature),
-            userHandle: publicKey.response?.userHandle ? kpxcBase64ToArrayBuffer(publicKey.response?.userHandle) : null,
-            toJSON: () => kpxcAuthenticatorAssertionResponseJson(response)
+            userHandle: publicKey.response?.userHandle ? kpxcBase64ToArrayBuffer(publicKey.response?.userHandle) : null
         };
 
         return Object.setPrototypeOf(response, AuthenticatorAssertionResponse.prototype);
@@ -103,7 +125,8 @@
             response: authenticatorResponse,
             type: publicKey.type,
             clientExtensionResults: () => publicKey?.response?.clientExtensionResults || {},
-            getClientExtensionResults: () => publicKey?.response?.clientExtensionResults || {}
+            getClientExtensionResults: () => publicKey?.response?.clientExtensionResults || {},
+            toJSON: () => kpxcPublicKeyCredentialJson(publicKeyCredential)
         };
 
         return Object.setPrototypeOf(publicKeyCredential, PublicKeyCredential.prototype);

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -26,6 +26,44 @@
         return kpxcStringToArrayBuffer(window.atob(str?.replaceAll('-', '+').replaceAll('_', '/')));
     };
 
+    const kpxcArrayBufferToBase64Url = function (buff) {
+        const str = new Uint8Array(buff).reduce((acc, x) => (acc += String.fromCharCode(x)), "");
+        return window.btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=*$/g, "");
+    };
+
+    const kpxcAuthenticatorAttestationResponseJson = function(response) {
+        const authData = response.getAuthenticatorData();
+        const responsePk = response.getPublicKey();
+
+        let publicKey;
+        if (responsePk === null) {
+            publicKey = null;
+        } else {
+            publicKey = kpxcArrayBufferToBase64Url(responsePk);
+        }
+
+        return {
+            clientDataJSON: kpxcArrayBufferToBase64Url(response.clientDataJSON),
+            authenticatorData: kpxcArrayBufferToBase64Url(authData),
+            transports: response.getTransports(),
+            publicKey,
+            publicKeyAlgorithm: response.getPublicKeyAlgorithm(),
+            attestationObject: kpxcArrayBufferToBase64Url(response.attestationObject),
+        };
+    }
+
+    const kpxcAuthenticatorAssertionResponseJson = function(response) {
+        const userHandle = response.userHandle
+            ? kpxcArrayBufferToBase64Url(response.userHandle)
+            : undefined;
+        return {
+            clientDataJSON: kpxcArrayBufferToBase64Url(response.clientDataJSON),
+            authenticatorData: kpxcArrayBufferToBase64Url(response.authenticatorData),
+            signature: kpxcArrayBufferToBase64Url(response.signature),
+            userHandle,
+        };
+    }
+
     // Wraps response to AuthenticatorAttestationResponse object
     const createAttestationResponse = function(publicKey) {
         const response = {
@@ -34,7 +72,8 @@
             getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
             getPublicKey: () => null,
             getPublicKeyAlgorithm: () => publicKey.response?.publicKeyAlgorithm,
-            getTransports: () => [ 'internal' ]
+            getTransports: () => [ 'internal' ],
+            toJSON: () => kpxcAuthenticatorAttestationResponseJson(response)
         };
         return Object.setPrototypeOf(response, AuthenticatorAttestationResponse.prototype);
     };
@@ -45,7 +84,8 @@
             authenticatorData: kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
             clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response?.clientDataJSON),
             signature: kpxcBase64ToArrayBuffer(publicKey.response?.signature),
-            userHandle: publicKey.response?.userHandle ? kpxcBase64ToArrayBuffer(publicKey.response?.userHandle) : null
+            userHandle: publicKey.response?.userHandle ? kpxcBase64ToArrayBuffer(publicKey.response?.userHandle) : null,
+            toJSON: () => kpxcAuthenticatorAssertionResponseJson(response)
         };
 
         return Object.setPrototypeOf(response, AuthenticatorAssertionResponse.prototype);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Fixes #2298 

`createPublicKeyCredential` doesn't implement toJSON method from PublicKeyCredential prototype [PublicKeyCredential: toJSON method at developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/toJSON)

This PR implements that method by manually mapping `PublicKeyCredentialJSON` model

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

[Repro at webauthn-tojson.cybergulag.today](https://webauthn-tojson.cybergulag.today/)

I patched Webauthn.NET demo to use `PublicKeyCredential.toJSON` method on `completeAuthentication` and `completeRegistration` steps
[WebAuthn.NET lib.js](https://github.com/dodobrands/WebAuthn.Net/blob/94f6c47f4e8fa783e24d50de079f623a9fb7f39c/demo/WebAuthn.Net.Demo.Mvc/wwwroot/js/lib.js#L131)

Passwordless and Usernameless flow should work fine on PR version

1.9.9.1 release will fail on missing toJSON method as mentioned in #2298 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
