### PR TITLE
Update observer-helper.js to handle mutations with multiple elements

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -80,7 +80,8 @@ kpxcObserverHelper.initObserver = async function() {
                     mut.addedNodes.forEach(function (node) {
                         kpxcObserverHelper.handleObserverAdd(node);
                     });
-                } else if (mut.removedNodes.length > 0) {
+                }
+                if (mut.removedNodes.length > 0) {
                     mut.removedNodes.forEach(function (node) {
                         kpxcObserverHelper.handleObserverRemove(node);
                     });

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -76,16 +76,12 @@ kpxcObserverHelper.initObserver = async function() {
             kpxcObserverHelper.cacheStyle(mut, styleMutations, mutations.length);
 
             if (mut.type === 'childList') {
-                if (mut.addedNodes.length > 0) {
-                    mut.addedNodes.forEach(function (node) {
-                        kpxcObserverHelper.handleObserverAdd(node);
-                    });
-                }
-                if (mut.removedNodes.length > 0) {
-                    mut.removedNodes.forEach(function (node) {
-                        kpxcObserverHelper.handleObserverRemove(node);
-                    });
-                }
+                mut.addedNodes.forEach(function (node) {
+                    kpxcObserverHelper.handleObserverAdd(node);
+                });
+                mut.removedNodes.forEach(function (node) {
+                    kpxcObserverHelper.handleObserverRemove(node);
+                });
             } else if (mut.type === 'attributes' && (mut.attributeName === 'class' || mut.attributeName === 'style')) {
                 // Only accept targets with forms
                 const forms = matchesWithNodeName(mut.target, 'FORM')

--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -77,9 +77,13 @@ kpxcObserverHelper.initObserver = async function() {
 
             if (mut.type === 'childList') {
                 if (mut.addedNodes.length > 0) {
-                    kpxcObserverHelper.handleObserverAdd(mut.addedNodes[0]);
+                    mut.addedNodes.forEach(function (node) {
+                        kpxcObserverHelper.handleObserverAdd(node);
+                    });
                 } else if (mut.removedNodes.length > 0) {
-                    kpxcObserverHelper.handleObserverRemove(mut.removedNodes[0]);
+                    mut.removedNodes.forEach(function (node) {
+                        kpxcObserverHelper.handleObserverRemove(node);
+                    });
                 }
             } else if (mut.type === 'attributes' && (mut.attributeName === 'class' || mut.attributeName === 'style')) {
                 // Only accept targets with forms


### PR DESCRIPTION
On dynamic pages, a single MutationRecord can contain multiple elements in the addNodes / removedNodes properties.

https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord


## Testing strategy
Example form where username/password field detection was not working as expected (even after choosing the Custom Login Fields): https://account.demandware.com


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
