### PR TITLE
Fix opacity checks

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -413,6 +413,12 @@ kpxcFields.isSearchField = function(target) {
 
 // Returns true if element is visible on the page
 kpxcFields.isVisible = function(elem) {
+    // Returns true if opacity is not set, otherwise check the limits
+    const isOpacityAllowed = (opacity) => {
+        const opac = Number(opacity);
+        return opacity === '' || (opac >= MIN_OPACITY && opac <= MAX_OPACITY);
+    };
+
     // Check element position and size
     const rect = elem.getBoundingClientRect();
     if (rect.x < 0
@@ -426,16 +432,15 @@ kpxcFields.isVisible = function(elem) {
 
     // Check CSS visibility
     const elemStyle = getComputedStyle(elem);
-    const opacity = Number(elemStyle.opacity);
     if (elemStyle.visibility && (elemStyle.visibility === 'hidden' || elemStyle.visibility === 'collapse')
-        || (opacity < MIN_OPACITY || opacity > MAX_OPACITY)
+        || !isOpacityAllowed(elemStyle.opacity)
         || parseInt(elemStyle.width, 10) <= MIN_INPUT_FIELD_WIDTH_PX
         || parseInt(elemStyle.height, 10) <= MIN_INPUT_FIELD_WIDTH_PX) {
         return false;
     }
 
     // Check for parent opacity
-    if (kpxcFields.traverseParents(elem, f => f.style.opacity === '0')) {
+    if (kpxcFields.traverseParents(elem, f => !isOpacityAllowed(f.style.opacity))) {
         return false;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Fixes checking parent opacity when performing `isVisible()` to input fields. Previously parent forms/divs where ignored only when the `opacity` was set to zero. With parents `MIN_OPACITY` (0.7) and `MAX_OPACITY` (1.0) values must be used instead.
This fixes a possible clickjacking vulnerability with invisible forms or iframes.

Fixes #1367

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using the following sites with auto-fill enabled:
https://websecurity.dev/password-managers/login/
https://websecurity.dev/password-managers/clickjacking/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
