### PR TITLE
Prevent style changes to wrapper divs

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -117,6 +117,7 @@ class Autocomplete {
             this.container.append(this.list);
             this.shadowRoot.append(this.container);
             document.body.append(this.wrapper);
+            kpxcUI.observeWrapper(this.wrapper);
 
             // Add a footer message for auto-submit
             if (this.autoSubmit) {

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -165,6 +165,7 @@ kpxcBanner.create = async function(credentials = {}) {
 
     if (window.self === window.top && !kpxcBanner.created) {
         window.parent.document.body.appendChild(wrapper);
+        kpxcUI.observeWrapper(wrapper);
         kpxcBanner.created = true;
     }
 };

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -159,6 +159,7 @@ kpxcCustomLoginFieldsBanner.create = async function() {
 
     if (!kpxcCustomLoginFieldsBanner.created) {
         window.self.document.body.appendChild(wrapper);
+        kpxcUI.observeWrapper(wrapper);
         kpxcCustomLoginFieldsBanner.created = true;
     }
 

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -69,6 +69,7 @@ class Icon {
         this.shadowRoot.append(styleSheet);
         this.shadowRoot.append(this.icon);
         document.body.append(wrapper);
+        kpxcUI.observeWrapper(wrapper);
     }
 
     switchIcon(state, uuid) {
@@ -394,6 +395,22 @@ kpxcUI.createButton = function(color, textContent, callback) {
     return button;
 };
 
+// Observe and prevent style changes to wrapper div elements
+kpxcUI.createWrapperObserver = function() {
+    kpxcUI.wrapperObserver = new MutationObserver(function(mutations, obs) {
+        for (const mut of mutations) {
+            if (mut.target.style.cssText !== 'all: unset;') {
+                mut.target.removeAttribute('style');
+                mut.target.style.all = 'unset';
+            }
+        }
+    });
+};
+
+kpxcUI.observeWrapper = function(elem) {
+    kpxcUI.wrapperObserver.observe(elem, { attributes: true, attributeFilter: [ 'style' ] });
+};
+
 const DOMRectToArray = function(domRect) {
     return [ domRect.bottom, domRect.height, domRect.left, domRect.right, domRect.top, domRect.width, domRect.x, domRect.y ];
 };
@@ -438,6 +455,8 @@ document.addEventListener('mouseup', function(e) {
 
     kpxcUI.mouseDown = false;
 });
+
+document.addEventListener('DOMContentLoaded', kpxcUI.createWrapperObserver());
 
 HTMLDivElement.prototype.appendMultiple = function(...args) {
     for (const a of args) {

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -399,7 +399,7 @@ kpxcUI.createButton = function(color, textContent, callback) {
 kpxcUI.createWrapperObserver = function() {
     kpxcUI.wrapperObserver = new MutationObserver(function(mutations, obs) {
         for (const mut of mutations) {
-            if (mut.target.style.cssText !== 'all: unset;') {
+            if (mut?.target && mut.target.style?.cssText !== 'all: unset;') {
                 mut.target.removeAttribute('style');
                 mut.target.style.all = 'unset';
             }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Creates a new MutationObserver that listens wrapper elements the extension is using for closed Shadow DOM content. If a style change is detected for the wrapper, the extension prevents it and unsets all CSS variables again.

Fixes the Extension Element vulnerability described at:
https://marektoth.com/blog/dom-based-extension-clickjacking/#extension-element

Related issue #2645 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually trying to modify the div style via script or from Web Inspector.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
