### PR TITLE
Do not allow sandboxed iframes

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -1028,6 +1028,13 @@ kpxc.reconnect = async function() {
 
 const isIframeAllowed = async function() {
     sendMessage('iframe_detected', false);
+
+    // Don't allow sandboxed iframes
+    if (self.origin === null || self.origin === 'null') {
+        logDebug('Error: Sandboxed iframes are not allowed');
+        return false;
+    }
+
     try {
         // Check for Cross-domain security error when inspecting window.top.location.href
         const currentLocation = window.top.location.href;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Sandboxed iframes have `self.origin` set to `null`. Those iframes must not be allowed to fill any credentials.

Fixes #2647

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using a localhost HTTP server. I can send the files for testing if necessary.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
