### PR TITLE
Clear credentials if html/body/form opacity limit is met

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -161,6 +161,7 @@
         "MIN_TOTP_INPUT_LENGTH": "readonly",
         "module": "readonly",
         "nacl": "readonly",
+        "OBSERVER_OPTIONS": "readonly",
         "ORANGE_BUTTON": "readonly",
         "page": "readonly",
         "Pixels": "readonly",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -13,14 +13,14 @@ kpxcEvent.onMessage = async function(request, sender) {
     }
 };
 
-kpxcEvent.showStatus = async function(tab, configured, internalPoll) {
+kpxcEvent.showStatus = async function(tab, configured, internalPoll, forceShowDefault = false) {
     let keyId = null;
     if (configured && keepass.databaseHash !== ''
         && Object.hasOwn(keepass.keyRing, keepass.databaseHash)) {
         keyId = keepass.keyRing[keepass.databaseHash].id;
     }
 
-    if (!internalPoll) {
+    if (!internalPoll || forceShowDefault) {
         browserAction.showDefault(tab);
     }
 
@@ -76,7 +76,7 @@ kpxcEvent.onSaveSettings = async function(tab, settings) {
 kpxcEvent.onGetStatus = async function(tab, args = []) {
     // When internalPoll is true the event is triggered from content script in intervals -> don't poll KeePassXC
     try {
-        const [ internalPoll = false, triggerUnlock = false ] = args;
+        const [ internalPoll = false, triggerUnlock = false, forceShowDefault ] = args;
         if (!internalPoll) {
             const response = await keepass.testAssociation(tab, [ true, triggerUnlock ]);
             if (!response) {
@@ -85,7 +85,7 @@ kpxcEvent.onGetStatus = async function(tab, args = []) {
         }
 
         const configured = await keepass.isConfigured();
-        return kpxcEvent.showStatus(tab, configured, internalPoll);
+        return kpxcEvent.showStatus(tab, configured, internalPoll, forceShowDefault);
     } catch (err) {
         logError('No status shown: ' + err);
         return Promise.reject();

--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -166,6 +166,8 @@ kpxcForm.initForm = function(form, credentialFields) {
         if (submitButton) {
             submitButton.addEventListener('click', kpxcForm.onSubmit);
         }
+
+        kpxcUI.pageObserver.observe(form, OBSERVER_OPTIONS);
     }
 };
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -81,8 +81,9 @@ kpxc.clearAllFromPage = function() {
         kpxcUserAutocomplete.closeList();
     }
 
-    // Switch back to default popup
-    sendMessage('get_status', [ true ]); // This is an internal function call
+    // Clear logins from background and switch back to default popup
+    sendMessage('page_clear_logins');
+    sendMessage('get_status', [ true, false, true ]); // This is an internal function call, forceShowDefault
 };
 
 // Creates a new combination manually from active element
@@ -879,7 +880,7 @@ kpxc.usePredefinedSites = function(currentLocation) {
  * Content script initialization.
  */
 const initContentScript = async function() {
-    try {
+    try { 
         if (document?.documentElement?.ownerDocument?.contentType !== 'text/html'
             && document?.documentElement?.ownerDocument?.contentType !== 'application/xhtml+xml'
         ) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Prevents filling credentials by filling them if page's `<html>` or `<body>` element is transparent. Same applies to all forms that are identified with the extension.

Related issue: #2645

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using the following commands on any page that has login fields. Both values are under the minimum.
`document.documentElement.style.opacity = 0.4;`
`document.body.style.opacity = 0.3;`

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
