### PR TITLE
Fix topmost element check with Shadow DOM

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -418,10 +418,11 @@ kpxcFields.isTopElement = function(elem, rect) {
 
     // Check topmost element from three points inside the input
     const verticalMiddle = rect.top + (rect.height / 2);
+    const rootNode = elem.getRootNode() ?? document;
     if (matchesWithNodeName(elem, 'INPUT') && [
-        document.elementFromPoint(rect.left + (rect.width / 4), verticalMiddle), // First third
-        document.elementFromPoint(rect.left + (rect.width / 2), verticalMiddle), // Middle
-        document.elementFromPoint(rect.left + (rect.width / 1.33), verticalMiddle), // Last third
+        rootNode.elementFromPoint(rect.left + (rect.width / 4), verticalMiddle), // First third
+        rootNode.elementFromPoint(rect.left + (rect.width / 2), verticalMiddle), // Middle
+        rootNode.elementFromPoint(rect.left + (rect.width / 1.33), verticalMiddle), // Last third
     ].some((e) => e !== elem)) {
         return false;
     }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Input fields inside Shadow DOM are not allowed because the topmost element check does not check the element root correctly.

Fixes #2658

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually by going to https://www.reddit.com/login/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
