### PR TITLE
Fix topmost input element check with labels

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -124,6 +124,7 @@
         "IMPROVED_DETECTION_PREDEFINED_SITELIST": "readonly",
         "initColorTheme": "readonly",
         "isEdge": "readonly",
+        "isElementInside": "readonly",
         "isFirefox": "readonly",
         "keepass": "readonly",
         "keepassClient": "readonly",

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -182,11 +182,13 @@ const getCurrentTab = async function() {
     return tabs?.length > 0 ? tabs[0] : undefined;
 };
 
+// Check if element b is inside a
+const isElementInside = (a, b) => (b.x >= a.x || b.right <= a.right) && (b.y >= a.y || b.bottom <= a.bottom);
+
 // Check if two elements overlap
 const elementsOverlap = function(rect1, rect2) {
-    const isInside = (a, b) => (b.x >= a.x || b.right <= a.right) && (b.y >= a.y || b.bottom <= a.bottom);
     const overlaps = (a, b) => !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
-    return isInside(rect1, rect2) || overlaps(rect1, rect2);
+    return isElementInside(rect1, rect2) || overlaps(rect1, rect2);
 };
 
 // Exports for tests

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -418,17 +418,22 @@ kpxcFields.isTopElement = function(elem, rect) {
 
     const rootNode = elem.getRootNode() ?? document;
 
-    // Returns the topmost element from point x,y. If the input has a label as the top element, allow it.
-    const getTopmostElement = (x) => {
-        const topElement = rootNode.elementFromPoint(x, rect.top + (rect.height / 2));
-        return elem?.labels && elem.labels[0] === topElement ? elem : topElement;
+    // Returns the topmost element from point x, height/2
+    // If the input has a label as the top element and it's inside the input, allow it.
+    const getTopmostElement = (element, x, elementRect) => {
+        const topElement = rootNode.elementFromPoint(x, elementRect.top + (elementRect.height / 2));
+        return element?.labels &&
+            element.labels[0] === topElement &&
+            isElementInside(elementRect, topElement.getBoundingClientRect())
+            ? element
+            : topElement;
     };
 
     // Check topmost element from three points inside the input
     if (matchesWithNodeName(elem, 'INPUT') && [
-        getTopmostElement(rect.left + (rect.width / 4)), // First third
-        getTopmostElement(rect.left + (rect.width / 2)), // Middle
-        getTopmostElement(rect.left + (rect.width / 1.33)), // Last third
+        getTopmostElement(elem, rect.left + (rect.width / 4), rect), // First third
+        getTopmostElement(elem, rect.left + (rect.width / 2), rect), // Middle
+        getTopmostElement(elem, rect.left + (rect.width / 1.33), rect), // Last third
     ].some((e) => e !== elem)) {
         return false;
     }

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -416,13 +416,19 @@ kpxcFields.isTopElement = function(elem, rect) {
         return false;
     }
 
-    // Check topmost element from three points inside the input
-    const verticalMiddle = rect.top + (rect.height / 2);
     const rootNode = elem.getRootNode() ?? document;
+
+    // Returns the topmost element from point x,y. If the input has a label as the top element, allow it.
+    const getTopmostElement = (x) => {
+        const topElement = rootNode.elementFromPoint(x, rect.top + (rect.height / 2));
+        return elem?.labels && elem.labels[0] === topElement ? elem : topElement;
+    };
+
+    // Check topmost element from three points inside the input
     if (matchesWithNodeName(elem, 'INPUT') && [
-        rootNode.elementFromPoint(rect.left + (rect.width / 4), verticalMiddle), // First third
-        rootNode.elementFromPoint(rect.left + (rect.width / 2), verticalMiddle), // Middle
-        rootNode.elementFromPoint(rect.left + (rect.width / 1.33), verticalMiddle), // Last third
+        getTopmostElement(rect.left + (rect.width / 4)), // First third
+        getTopmostElement(rect.left + (rect.width / 2)), // Middle
+        getTopmostElement(rect.left + (rect.width / 1.33)), // Last third
     ].some((e) => e !== elem)) {
         return false;
     }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
At some pages the input element has a `<label>` that is returned as the topmost element. Inputs have a separate property `.labels` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/labels)) that can be used to check if the label element is actually related to the input we are checking.

A few pages might use a non-standard label, e.g. `<span>` element, but those cannot be checked reliably, and are ignored.

Fixes #2664

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using the URLs in the issue thread.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
