### PR TITLE
Fix Custom Login Fields with topmost element check

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -534,7 +534,7 @@ kpxcFields.useCustomLoginFields = async function() {
     // Get all input fields from the page without any extra filters
     const inputFields = [];
     document.body.querySelectorAll('input, select, textarea').forEach(e => {
-        if (e.type !== 'hidden' && !e.disabled && kpxcFields.isTopElement(e, e?.getBoundingClientRect())) {
+        if (e.type !== 'hidden' && !e.disabled) {
             inputFields.push(e);
         }
     });


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Custom Login Fields should be allowed even if the topmost element check fails. User must have a possibility to choose the fields manually and override the checks.

Fixes #2671

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Try using Custom Login Fields with https://gui.easy-client.de/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
