### PR TITLE
Fix using custom function with elements in TreeWalker

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -330,7 +330,9 @@ const getShadowDOM = function(elem) {
 const treeWalkerFilter = function(node) {
     return !node ||
         node?.disabled ||
-        (typeof node?.getAttribute !== 'undefined' && node?.getLowerCaseAttribute('type') === 'hidden')
+        (node instanceof Element
+            && typeof node?.getAttribute === 'function'
+            && node?.getLowerCaseAttribute('type') === 'hidden')
         ? NodeFilter.FILTER_REJECT
         : NodeFilter.FILTER_ACCEPT;
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When using the TreeWalker filter, some HTML objects can have `.getAttribute()` function but the object is not an `Element`, causing an unhandled error.
The fix ensures the `node` is an `Element` before running any custom functions.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Go to https://www.reddit.com without any adblockers and press the Login button for the form to be displayed. Without the fix that function should give an error.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
