### PR TITLE
Fix detecting existing combination

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -100,6 +100,9 @@ kpxcSites.exceptionFound = function(identifier, field) {
     } else if (document.location.origin === 'https://id.atlassian.com' &&
                 Array.isArray(identifier) && identifier?.contains('password-field')) {
         return true;
+    } else if (document.location.origin === 'https://app.fastmail.com'
+        && identifier?.contains('u-space-y-5') && field?.id === 'v25') {
+        return true;
     }
 
     return false;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -103,6 +103,8 @@ kpxcFields.getExistingCombination = function(combination) {
         existingCombination.password ??= combination.password;
         if (existingCombination.passwordInputs?.length === 0) {
             existingCombination.passwordInputs = combination.passwordInputs;
+        } else {
+            existingCombination.passwordInputs.push(combination.password);
         }
 
         return existingCombination;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -29,7 +29,7 @@ kpxcFields.getAllCombinations = async function(inputs) {
                 form: input.form
             };
 
-            combinations.push(combination);
+            combinations.push(kpxcFields.getExistingCombination(combination));
             usernameField = null;
         } else if (kpxcTOTPIcons.isValid(input)) {
             // Dynamically added TOTP field
@@ -91,6 +91,24 @@ kpxcFields.getCombinationFromAllInputs = function() {
     }
 
     return kpxc.combinations[0];
+};
+
+// Checks if existing combination is found and recognized fields are added to it
+kpxcFields.getExistingCombination = function(combination) {
+    // Lookup existing combinations that use the same form
+    const existingCombination = kpxc.combinations?.find(c => c.form === combination?.form);
+    if (existingCombination) {
+        // Replace values to the existing combination
+        existingCombination.username ??= combination.username;
+        existingCombination.password ??= combination.password;
+        if (existingCombination.passwordInputs?.length === 0) {
+            existingCombination.passwordInputs = combination.passwordInputs;
+        }
+
+        return existingCombination;
+    }
+
+    return combination;
 };
 
 // Adds segmented TOTP fields to the combination if found


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If a password field is dynamically set to visible after username fill, the extension does not check if there's already a combination with the same form where the password input(s) can be appended. This causes the extension to handle the password input as a separate combination and Username Icon or Popup fill will not work, because those always seek the combination related to the active/first input. The only workaround without this fix is to click the password input field and select the password from a separate Autocomplete Menu, and that is not very fluent.

Added Fastmail to Predefined Sites list. Otherwise the password input is not detected normally. With both sites password 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using:
https://app.fastmail.com/
https://www.patreon.com/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
