### PR TITLE
Fix using popovers with Firefox ESR 115

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -130,7 +130,9 @@ class Autocomplete {
 
         this.updateList();
         this.container.classList.add('kpxcAutocomplete-container--visible');
-        this.container.showPopover({ source: inputField });
+        if (kpxcFields.popoverSupported) {
+            this.container.showPopover({ source: inputField });
+        }
         this.updatePosition();
     }
 
@@ -238,7 +240,9 @@ class Autocomplete {
         }
 
         this.container.classList.remove('kpxcAutocomplete-container--visible');
-        this.container.hidePopover();
+        if (kpxcFields.popoverSupported) {
+            this.container.hidePopover();
+        }
     }
 
     getAllItems() {

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -9,6 +9,7 @@ const MAX_SEGMENTED_FIELD_LENGTH = 100;
  * Provides methods for input field handling.
  */
 const kpxcFields = {};
+kpxcFields.popoverSupported = true;
 
 // Returns all username & password combinations detected from the inputs.
 // After username field is detected, first password field found after that will be saved as a combination.
@@ -438,6 +439,7 @@ kpxcFields.discoverOverlays = function() {
     } catch (e) {
         // Ignore SyntaxError (e.g., unsupported selector)
         if (!(e instanceof SyntaxError)) {
+            kpxcFields.popoverSupported = false;
             logError(e);
         }
     }
@@ -450,6 +452,7 @@ kpxcFields.hasOverlay = function(elem) {
     } catch (e) {
         // Ignore SyntaxError (e.g., unsupported selector)
         if (!(e instanceof SyntaxError)) {
+            kpxcFields.popoverSupported = false;
             logError(e);
         }
     }

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -60,7 +60,11 @@ PasswordIcon.prototype.createIcon = function(field) {
             'popover': 'manual'
         });
 
-    icon.style.margin = 0;
+    if (kpxcFields.popoverSupported) {
+        icon.style.margin = 0;
+    } else {
+        icon.style.zIndex = '10000000';
+    }
     icon.style.width = Pixels(size);
     icon.style.height = Pixels(size);
 
@@ -74,7 +78,11 @@ PasswordIcon.prototype.createIcon = function(field) {
         }
 
         if (e.shiftKey) {
-            icon.hidePopover();
+            if (kpxcFields.popoverSupported) {
+                icon.hidePopover();
+            } else {
+                icon.style.display = 'none';
+            }
             return;
         }
 
@@ -88,7 +96,9 @@ PasswordIcon.prototype.createIcon = function(field) {
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
     this.createWrapper('css/pwgen.css');
-    icon.showPopover();
+    if (kpxcFields.popoverSupported) {
+        icon.showPopover();
+    }
 };
 
 

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -148,7 +148,12 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
             'size': size,
             'popover': 'manual'
         });
-    icon.style.margin = 0;
+
+    if (kpxcFields.popoverSupported) {
+        icon.style.margin = 0;
+    } else {
+        icon.style.zIndex = '10000000';
+    }
     icon.style.width = Pixels(size);
     icon.style.height = Pixels(size);
 
@@ -164,7 +169,11 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
         }
 
         if (e.shiftKey) {
-            icon.hidePopover();
+            if (kpxcFields.popoverSupported) {
+                icon.hidePopover();
+            } else {
+                icon.style.display = 'none';
+            }
             return;
         }
 
@@ -179,5 +188,7 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
     kpxcUI.setIconPosition(icon, field, this.rtl, segmented);
     this.icon = icon;
     this.createWrapper('css/totp.css');
-    icon.showPopover();
+    if (kpxcFields.popoverSupported) {
+        icon.showPopover();
+    }
 };

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -83,7 +83,12 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
             'kpxc-pwgen-field-id': field.getAttribute('data-kpxc-id'),
             'popover': 'manual'
         });
-    icon.style.margin = 0;
+    
+    if (kpxcFields.popoverSupported) {
+        icon.style.margin = 0;
+    } else {
+        icon.style.zIndex = '10000000';
+    }
     icon.style.width = Pixels(size);
     icon.style.height = Pixels(size);
 
@@ -93,7 +98,11 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
         }
 
         if (e.shiftKey) {
-            icon.hidePopover();
+            if (kpxcFields.popoverSupported) {
+                icon.hidePopover();
+            } else {
+                icon.style.display = 'none';
+            }
             return;
         }
 
@@ -107,7 +116,9 @@ UsernameFieldIcon.prototype.createIcon = function(field) {
     kpxcUI.setIconPosition(icon, field, this.rtl);
     this.icon = icon;
     this.createWrapper('css/username.css');
-    icon.showPopover();
+    if (kpxcFields.popoverSupported) {
+        icon.showPopover();
+    }
 };
 
 const iconClicked = async function(field, icon) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Extends https://github.com/keepassxreboot/keepassxc-browser/pull/2687 and adds compatibility with Firefox ESR 115 where Popover API is not supported.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Should show transparent non-popover icons with these sites:
https://websecurity.dev/dom-based-extension-clickjacking/keepassxc-browser/1.9.9.6/login/
https://websecurity.dev/dom-based-extension-clickjacking/keepassxc-browser/1.9.9.6/login-visible/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
