### PR TITLE
Fix filling relevant credential entries

### DIFF
--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -257,11 +257,11 @@ page.retrieveCredentials = async function(tab, args = []) {
     return credentials;
 };
 
-page.getLoginId = async function(tab) {
+page.getLoginId = async function(tab, returnSingle = true) {
     const currentTab = page.tabs[tab.id];
 
     // If there's only one credential available and loginId is not set
-    if (currentTab && !currentTab.loginId && currentTab.credentials.length === 1) {
+    if (currentTab && returnSingle && !currentTab.loginId && currentTab.credentials.length === 1) {
         return currentTab.credentials[0].uuid;
     }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -519,7 +519,7 @@ kpxc.prepareCredentials = async function() {
     kpxc.initAutocomplete();
 
     if (kpxc.settings.autoFillRelevantCredential) {
-        const pageUuid = await sendMessage('page_get_login_id');
+        const pageUuid = await sendMessage('page_get_login_id', false);
         if (pageUuid) {
             const relevantCredential = kpxc.credentials.find(c => c.uuid === pageUuid);
             const combination = kpxc.combinations?.at(-1);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When option "Automatically fill in relevant credential entries"  is enabled, background script still returns the UUID of the first credential found. In this case the check must not return the UUID, and the `currentTab.loginId` must be set. The option expects that a previous fill has already happened.

* Fixes #2689

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually with any site that has a single credential, with the "Automatically fill in relevant credential entries"  option enabled.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
