### PR TITLE
Add overlay exceptions feature

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -236,6 +236,20 @@ kpxcSites.popupExceptionFound = function(combinations) {
 };
 
 /**
+ * Handles exceptions where a certain element is set as a popover, and it prevents input field detections.
+ * @param {object} elem     Popover element
+ * @returns {boolean}       True if exception found
+ */
+kpxcSites.overlayExceptionFound = function(elem) {
+    if (document.location.href?.startsWith('https://github.com/login')
+        && elem?.nodeName === 'TOOL-TIP' && elem?.baseURI === 'https://github.com/login') {
+        return true;
+    }
+
+    return false;
+};
+
+/**
  * Handles a few exceptions for certain sites where Username Icon is not placed properly.
  * @param {number} left         Absolute left position of the icon
  * @param {number} top          Absolute top position of the icon

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -495,6 +495,10 @@ kpxcFields.isTopElement = function(elem, rect) {
 
     // Check for popup overlays
     for (const overlay of kpxcFields.overlays ?? []) {
+        if (kpxcSites.overlayExceptionFound(overlay)) {
+            continue;
+        }
+
         const overlayRect = overlay?.getBoundingClientRect();
         if (overlayRect && elementsOverlap(rect, overlayRect)) {
             return false;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Sadly there are some common sites that have a popup overlay template set for the whole page, and the latest DOM clickjacking preventions now ignore the input fields. The change introduces a similar kind of exception list for certain sites in `sites.js`.

* Fixes #2688

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using https://github.com/login

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
