### PR TITLE
Add Disable passkeys for Site Preferences features

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -120,6 +120,7 @@
         "IGNORE_FULL": "readonly",
         "IGNORE_NORMAL": "readonly",
         "IGNORE_NOTHING": "readonly",
+        "IGNORE_PASSKEYS": "readonly",
         "importScripts": "readonly",
         "IMPROVED_DETECTION_PREDEFINED_SITELIST": "readonly",
         "initColorTheme": "readonly",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -1118,8 +1118,8 @@
         "message": "Page URL",
         "description": "Site Preferences list column title."
     },
-    "optionsColumnIgnore": {
-        "message": "Ignore",
+    "optionsColumnFeatures": {
+        "message": "Features",
         "description": "Site Preferences list column title."
     },
     "optionsColumnUsernameOnly": {
@@ -1148,6 +1148,10 @@
     },
     "optionsSelectionAutoSubmit": {
         "message": "Disable Auto-Submit",
+        "description": "Site Preferences option selection."
+    },
+    "optionsSelectionPasskeys": {
+        "message": "Disable passkeys",
         "description": "Site Preferences option selection."
     },
     "optionsSelectionFull": {

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -335,14 +335,15 @@ page.fillHttpAuth = async function(tab, credentials) {
     }
 };
 
-page.isSiteIgnored = async function(tab, currentLocation) {
+page.isSiteIgnored = async function(tab, args = []) {
+    const [ currentLocation, checkPasskeys ] = args;
     if (!page?.settings?.sitePreferences || !currentLocation) {
         return false;
     }
 
     for (const site of page.settings.sitePreferences) {
         if (siteMatch(site.url, currentLocation) || site.url === currentLocation) {
-            if (site.ignore === IGNORE_FULL) {
+            if (site.ignore === IGNORE_FULL || (checkPasskeys && site.ignore === IGNORE_PASSKEYS)) {
                 return true;
             }
         }

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -6,6 +6,7 @@ const EXTENSION_NAME = 'KeePassXC-Browser';
 const IGNORE_NOTHING = 'ignoreNothing';
 const IGNORE_NORMAL = 'ignoreNormal';
 const IGNORE_AUTOSUBMIT = 'ignoreAutoSubmit';
+const IGNORE_PASSKEYS = 'ignorePasskeys';
 const IGNORE_FULL = 'ignoreFull';
 
 // Credential sorting options

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -99,7 +99,7 @@ const initContent = async () => {
         return;
     }
 
-    if (await chrome.runtime.sendMessage({ action: 'is_site_ignored', args: window.self.location.href })) {
+    if (await chrome.runtime.sendMessage({ action: 'is_site_ignored', args: [ window.self.location.href, true ] })) {
         console.log('This site is ignored in Site Preferences.');
         return;
     }

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -762,7 +762,7 @@
                         <tr>
                           <th scope="col"><span data-i18n="optionsColumnPageURL"></span></th>
                           <th scope="col"></th>
-                          <th scope="col"><span data-i18n="optionsColumnIgnore"></span></th>
+                          <th scope="col"><span data-i18n="optionsColumnFeatures"></span></th>
                           <th scope="col"></th>
                         </tr>
                       </thead>
@@ -798,6 +798,7 @@
                               <option value="ignoreNothing" data-i18n="optionsSelectionNothing"></option>
                               <option value="ignoreNormal" data-i18n="optionsSelectionNormal"></option>
                               <option value="ignoreAutoSubmit" data-i18n="optionsSelectionAutoSubmit"></option>
+                              <option value="ignorePasskeys" data-i18n="optionsSelectionPasskeys"></option>
                               <option value="ignoreFull" data-i18n="optionsSelectionFull"></option>
                             </select>
                           </td>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds a new option under Features column (previously "Ignore") that allows user to disable passkey script injection for a site.

Related issue: #2494

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Used https://webauthn.io for testing passkeys, and URLs from the related issue to test if the page loads normally when passkeys are disabled.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
