### PR TITLE
Handle window offsets for DOM content positioning

### DIFF
--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -99,7 +99,11 @@ const kpxcUI = {};
 kpxcUI.mouseDown = false;
 
 if (document.body) {
-    kpxcUI.bodyRect = document.body.getBoundingClientRect();
+    const bodyRect = document.body.getBoundingClientRect();
+    kpxcUI.bodyRect = {
+        left: bodyRect.left + window.pageXOffset,
+        top: bodyRect.top + window.pageYOffset
+    };
     kpxcUI.bodyStyle = getComputedStyle(document.body);
 }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Handles window offsets when storing the `document.body` rect internally. With the Humble Bundle's user settings page the `document.body` has an offset of -2000px or smaller. This causes the injected DOM elements to be out-of-place.

* Fixes #2697

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Use the change password page from Humble Bundle:
https://www.humblebundle.com/user/settings

This PR needs to be tested with multiple sites to verify the offset handling does't break anything.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
