### PR TITLE
Fix filling wrapped input fields

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -116,9 +116,9 @@ kpxcForm.getNewPassword = function(passwordInputs = []) {
     }
 
     // Choose the last three password fields. The first ones are almost always for something else
-    const current = passwordInputs[passwordInputs.length - 3].value;
-    const newPass = passwordInputs[passwordInputs.length - 2].value;
-    const repeatNew = passwordInputs[passwordInputs.length - 1].value;
+    const current = passwordInputs[passwordInputs.length - 3]?.value;
+    const newPass = passwordInputs[passwordInputs.length - 2]?.value;
+    const repeatNew = passwordInputs[passwordInputs.length - 1]?.value;
 
     if ((newPass === repeatNew && current !== newPass && current !== repeatNew)
         || (current === newPass && repeatNew !== newPass && repeatNew !== current)) {

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -749,7 +749,7 @@ kpxc.setValue = function(field, value, forced = false) {
 
 // Sets a new value to input field and triggers necessary events
 kpxc.setValueWithChange = function(field, value, forced = false) {
-    if (field && field.readOnly && !forced) {
+    if (!field || (field?.readOnly && !forced)) {
         return;
     }
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -736,12 +736,20 @@ kpxc.setValue = function(field, value, forced = false) {
         field.checked = true;
     }
 
+    // Make sure the input is not wrapped inside another element (custom INPUT element)
+    if (field?.nodeName !== 'INPUT' && field?.nodeName?.includes('INPUT')) {
+        const childInput = field?.querySelector('input');
+        const fieldsFromShadowDOM = kpxcObserverHelper.findInputsFromShadowDOM(field);
+        field = childInput ?? fieldsFromShadowDOM[0];
+    }
+
+
     kpxc.setValueWithChange(field, value, forced);
 };
 
 // Sets a new value to input field and triggers necessary events
 kpxc.setValueWithChange = function(field, value, forced = false) {
-    if (!forced && field.readOnly) {
+    if (field && field.readOnly && !forced) {
         return;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Some pages wrap the actual input field as a child element, and when using the fill from active element (context menu or keyboard shortcut), the fill is made to the wrapper element instead. Added a new method before the fill that can check the possible child elements from a custom `INPUT` element.

Also fixed an exception from `passwordInputs` in `form.js`. Reddit sometimes triggered this check because an iframe had two password fields.

* Fixes #2684

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using Reddit's login page and 2FA field from context menu or keyboard shortcut. The actual input is not filled without the fix.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
