### PR TITLE
Update ignoreRegex to include promo codes

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ignoreRegex = /(bank|coupon|postal|user|zip|promo|promotional).*code|(en|de)code(d|r)*|comment|author|error/i;
+const ignoreRegex = /(bank|coupon|postal|user|zip|promo).*code|(en|de)code(d|r)*|comment|author|error/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
 const allowedInputTypes = [ 'number', 'password', 'tel', 'text' ];
 

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ignoreRegex = /(bank|coupon|postal|user|zip).*code|(en|de)code(d|r)*|comment|author|error/i;
+const ignoreRegex = /(bank|coupon|postal|user|zip|promo|promotional).*code|(en|de)code(d|r)*|comment|author|error/i;
 const ignoredTypes = [ 'email', 'password', 'username' ];
 const allowedInputTypes = [ 'number', 'password', 'tel', 'text' ];
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -60,6 +60,8 @@ async function testTotpFields() {
         [ '', { id: '2fa', type: 'text', maxLength: '6' }, 'Generic 2FA field', true ],
         [ '', { id: '2fa', type: 'text', maxLength: '4' }, 'Ignore if field maxLength too small', false ],
         [ '', { id: '2fa', type: 'text', maxLength: '12' }, 'Ignore if field maxLength too long', false ],
+        [ '', { id: 'promocode', type: 'text', }, 'promocode id is not acceptable', false ],
+        [ '', { id: 'Promotional Code', type: 'text', }, 'Promotional Code id is not acceptable', false ],
         [ '', { id: 'encode', type: 'text', }, 'encode id is not acceptable', false ],
         [ '', { id: 'encodedText', type: 'text', }, 'encodedText is not acceptable', false ],
         [ '', { id: 'decoder', type: 'text', }, 'decoder id is not acceptable', false ],


### PR DESCRIPTION
Prevent a few more false-positives for the TOTP code detector.

After seeing a false positive and finding https://github.com/keepassxreboot/keepassxc-browser/issues/2282, I thought I'd propose another exception.

I suppose this is  somewhere between a bug fix and a new feature.  I have not tested this.

