### PR TITLE
Add support for reset all settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -107,6 +107,7 @@
         "createStylesheet": "readonly",
         "DatabaseState": "readonly",
         "debugLogMessage": "readonly",
+        "DEFINED_CUSTOM_FIELDS": "readonly",
         "elementsOverlap": "readonly",
         "EXTENSION_NAME": "readonly",
         "getCurrentTab": "readonly",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -734,6 +734,10 @@
         "message": "Export settings",
         "description": "Export settings button text."
     },
+    "optionsButtonResetSettings": {
+        "message": "Reset all settings",
+        "description": "Reset all settings button text."
+    },
     "optionsLabelDefaultGroup": {
         "message": "Default group for saving new passwords:",
         "description": "Default group options text."
@@ -1073,6 +1077,10 @@
     "optionsImportSettingsDialogText": {
         "message": "Current settings will be overridden. Do you really want to import the settings file?",
         "description": "Import settings confirmation dialog help text."
+    },
+    "optionsResetSettingsDialogText": {
+        "message": "All settings will be reset to defaults. Are you sure?",
+        "description": "Reset all settings dialog text."
     },
     "optionsConnectedDatabasesText": {
         "message": "Databases connected to KeePassXC-Browser.",

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -296,6 +296,7 @@ kpxcEvent.messageHandlers = {
     'reconnect': kpxcEvent.onReconnect,
     'remove_credentials_from_tab_information': kpxcEvent.onRemoveCredentialsFromTabInformation,
     'request_autotype': keepass.requestAutotype,
+    'reset_all_settings': page.resetAllSettings,
     'retrieve_credentials': page.retrieveCredentials,
     'show_default_browseraction': browserAction.showDefault,
     'update_credentials': keepass.updateCredentials,

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -138,6 +138,16 @@ page.initSitePreferences = async function() {
     await browser.storage.local.set({ 'settings': page.settings });
 };
 
+page.resetAllSettings = async function() {
+    for (const [ key, value ] of Object.entries(defaultSettings)) {
+        page.settings[key] = value;
+    }
+
+    page.settings[DEFINED_CUSTOM_FIELDS] = {};
+    page.settings.sitePreferences = [];
+    await browser.storage.local.set({ 'settings': page.settings });
+};
+
 page.switchTab = async function(tab) {
     // Clears Fill Attribute selection from context menu
     page.setFillAttributeContextMenuItemVisible(false);

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EXTENSION_NAME = 'KeePassXC-Browser';
+const DEFINED_CUSTOM_FIELDS = 'defined-custom-fields';
 
 // Site Preferences ignore options
 const IGNORE_NOTHING = 'ignoreNothing';

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -8,7 +8,6 @@ const STEP_SELECT_STRING_FIELDS = 4;
 
 const CHECKBOX_OVERLAY_SIZE = 20;
 
-const DEFINED_CUSTOM_FIELDS = 'defined-custom-fields';
 const FIXED_FIELD_CLASS = 'kpxcDefine-fixed-field';
 const DARK_FIXED_FIELD_CLASS = 'kpxcDefine-fixed-field-dark';
 const HOVER_FIELD_CLASS = 'kpxcDefine-fixed-hover-field';

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -559,6 +559,10 @@
                       <i class="fa fa-arrow-up" aria-hidden="true"></i>
                       <span data-i18n="optionsButtonExport"></span>
                     </button>
+                    <button class="btn btn-sm btn-danger ms-2" id="resetSettingsButton" data-i18n="[title]optionsButtonResetSettings">
+                      <i class="fa fa-undo" aria-hidden="true"></i>
+                      <span data-i18n="optionsButtonResetSettings"></span>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -581,6 +585,30 @@
                       <button class="btn btn-sm yes btn-success">
                         <i class="fa fa-check" aria-hidden="true"></i>
                         <span data-i18n="optionsButtonImport"></span>
+                      </button>
+                  </div>
+                  </div>
+                </div>
+              </div>
+
+              <div id="dialogResetSettings" class="modal fade" tabindex="-1" role="dialog">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title" id="myModalLabel" data-i18n="optionsButtonResetSettings"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body">
+                      <p data-i18n="optionsResetSettingsDialogText"></p>
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-secondary" data-bs-dismiss="modal" aria-hidden="true">
+                        <i class="fa fa-remove" aria-hidden="true"></i>
+                        <span data-i18n="optionsButtonCancel"></span>
+                      </button>
+                      <button class="btn btn-sm yes btn-danger">
+                        <i class="fa fa-check" aria-hidden="true"></i>
+                        <span data-i18n="optionsButtonReset"></span>
                       </button>
                   </div>
                   </div>

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -312,6 +312,24 @@ options.initGeneralSettings = async function() {
         }
     });
 
+    // Reset all settings modal
+    const dialogResetSettingsModal = new bootstrap.Modal('#dialogResetSettings',
+        { keyboard: true, focus: false, backdrop: true });
+
+    $('#dialogResetSettings').addEventListener('shown.bs.modal', function(modalEvent) {
+        modalEvent.currentTarget.querySelector('.modal-footer button.yes').focus();
+    });
+
+    $('#resetSettingsButton').addEventListener('click', function() {
+        dialogResetSettingsModal.show();
+    });
+
+    $('#dialogResetSettings .modal-footer button.yes').addEventListener('click', function(e) {
+        dialogResetSettingsModal.hide();
+        browser.runtime.sendMessage({ action: 'reset_all_settings' });
+        location.reload();
+    });
+
     $('#copyVersionToClipboard').addEventListener('click', function () {
         const copyText = document.getElementById('versionInfo').innerText;
         navigator.clipboard.writeText(copyText);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds a new button to the Import/Export Settings section that allows user to reset all settings back to the default without reinstalling the extension. Database connections are not removed.

* Fixes #2716

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )
<img width="497" height="125" alt="Screenshot 2025-10-06 at 20 04 24" src="https://github.com/user-attachments/assets/fb6c0425-2870-4b61-89bd-2394e98d1b2e" />
<img width="531" height="224" alt="Screenshot 2025-10-06 at 20 04 29" src="https://github.com/user-attachments/assets/5266c7a5-8a61-4ccf-aa85-3a8d364862ba" />

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
