### PR TITLE
Fix JavaScript error in console

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -201,12 +201,14 @@
     // select a software authenticator. This could be removed in the future.
     try {
         Object.defineProperty(navigator, 'credentials', { value: passkeysCredentials });
-        Object.defineProperty(window.PublicKeyCredential, 'isConditionalMediationAvailable', {
-            value: isConditionalMediationAvailable,
-        });
-        Object.defineProperty(window.PublicKeyCredential, 'isUserVerifyingPlatformAuthenticatorAvailable', {
-            value: isUserVerifyingPlatformAuthenticatorAvailable,
-        });
+        if (window.PublicKeyCredential) {
+            Object.defineProperty(window.PublicKeyCredential, 'isConditionalMediationAvailable', {
+                value: isConditionalMediationAvailable,
+            });
+            Object.defineProperty(window.PublicKeyCredential, 'isUserVerifyingPlatformAuthenticatorAvailable', {
+                value: isUserVerifyingPlatformAuthenticatorAvailable,
+            });
+        }
     } catch (err) {
         console.log('Cannot override navigator.credentials: ', err);
     }


### PR DESCRIPTION
This extension causes an annoying log message that tells me about an error that was caught in the extension itself. It could easily be avoided in the first place by adding appropriate checks rather than running into the exception each time and happily telling me about it.

Error message:
Cannot override navigator.credentials:  TypeError: undefined is not a non-null object in passkeys.js:211:17
    <anonymous> moz-extension://25853ed3-e2b0-47d6-ad17-2b172340068c/content/passkeys.js:204
    <anonymous> moz-extension://25853ed3-e2b0-47d6-ad17-2b172340068c/content/passkeys.js:213

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
