### PR TITLE
Fix isFirefox() check

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -83,7 +83,7 @@ browserAction.generateIconName = async function(iconType) {
             style = page.settings.colorTheme;
         }
     }
-    const filetype = (isFirefox() ? 'svg' : 'png');
+    const filetype = page.isFirefox ? 'svg' : 'png';
     return `/icons/toolbar/${style}/${name}.${filetype}`;
 };
 

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -241,6 +241,10 @@ kpxcEvent.sendBackToTabs = async function(tab, args = []) {
     }
 };
 
+kpxcEvent.isFirefox = async function(tab) {
+    return page.isFirefox;
+};
+
 // All methods named in this object have to be declared BEFORE this!
 kpxcEvent.messageHandlers = {
     'add_credentials': keepass.addCredentials,
@@ -271,6 +275,7 @@ kpxcEvent.messageHandlers = {
     'iframe_detected': kpxcEvent.onIframeDetected,
     'init_http_auth': kpxcEvent.initHttpAuth,
     'is_connected': kpxcEvent.getIsKeePassXCAvailable,
+    'is_firefox': kpxcEvent.isFirefox,
     'is_iframe_allowed': page.isIframeAllowed,
     'is_site_ignored': page.isSiteIgnored,
     'load_keyring': kpxcEvent.onLoadKeyRing,

--- a/keepassxc-browser/background/httpauth.js
+++ b/keepassxc-browser/background/httpauth.js
@@ -9,7 +9,7 @@ httpAuth.init = function() {
     let handleReq = httpAuth.handleRequestPromise;
     let reqType = 'blocking';
 
-    if (!isFirefox()) {
+    if (!page.isFirefox) {
         handleReq = httpAuth.handleRequestCallback;
         reqType = 'asyncBlocking';
     }

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -10,12 +10,6 @@ const contextMenuItems = [
     { title: tr('contextMenuRequestGlobalAutoType'), action: 'request_autotype' }
 ];
 
-const menuContexts = [ 'editable' ];
-    
-if (isFirefox()) {
-    menuContexts.push('password');
-}
-
 const initListeners = async function() {
     /**
      * Generate information structure for created tab and invoke all needed
@@ -161,13 +155,17 @@ const initListeners = async function() {
 };
 
 const initContextMenuItems = async function() { 
+    if (page.isFirefox) {
+        page.menuContexts.push('password');
+    }
+
     // Create context menu items
     await browser.contextMenus.removeAll();
     for (const item of contextMenuItems) {
         try {
             await browser.contextMenus.create({
                 title: item.title,
-                contexts: menuContexts,
+                contexts: page.menuContexts,
                 visible: item.visible,
                 id: item.id || item.action
             });
@@ -180,6 +178,7 @@ const initContextMenuItems = async function() {
 (async () => {
     try {
         await keepass.migrateKeyRing();
+        await page.initBrowser();
         await page.initSettings();
         await page.initSitePreferences();
         await page.initOpenedTabs();

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -154,7 +154,8 @@ const initListeners = async function() {
     });
 };
 
-const initContextMenuItems = async function() { 
+const initContextMenuItems = async function() {
+    page.menuContexts = [ 'editable' ];
     if (page.isFirefox) {
         page.menuContexts.push('password');
     }

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -49,7 +49,9 @@ page.blockedTabs = [];
 page.clearCredentialsTimeout = null;
 page.currentRequest = {};
 page.currentTabId = -1;
+page.isFirefox = false;
 page.manualFill = ManualFill.NONE;
+page.menuContexts = [ 'editable' ];
 page.passwordFilled = false;
 page.redirectCount = 0;
 page.submitted = false;
@@ -61,12 +63,19 @@ page.popupData = {
     popup: 'popup'
 };
 
+page.initBrowser = async function() {
+    page.isFirefox =
+        navigator.userAgent.indexOf('Firefox') !== -1
+        || navigator.userAgent.indexOf('Gecko/') !== -1
+        || typeof browser.runtime.getBrowserInfo === 'function';
+};
+
 page.initSettings = async function() {
     try {
         const item = await browser.storage.local.get({ 'settings': {} });
 
         // Load managed settings if found
-        if (isFirefox() && typeof(browser.storage.managed) === 'object') {
+        if (page.isFirefox && typeof(browser.storage.managed) === 'object') {
             try {
                 const managedSettings = await browser.storage.managed.get('settings');
                 if (managedSettings?.settings) {
@@ -74,16 +83,16 @@ page.initSettings = async function() {
                     item.settings = managedSettings.settings;
                 }
             } catch (err) {
-                logError('page.initSettings: ' + err);
+                debugLogMessage('page.initSettings: ' + err);
             }
-        } else if (typeof(chrome.storage.managed) === 'object') {
+        } else if (typeof chrome.storage.managed === 'object') {
             chrome.storage.managed.get('settings').then((managedSettings) => {
                 if (managedSettings?.settings) {
                     debugLogMessage('Managed settings found.');
                     item.settings = managedSettings.settings;
                 }
             }).catch((err) => {
-                logError('page.initSettings: ' + err);
+                debugLogMessage('page.initSettings: ' + err);
             });
         }
 

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -170,10 +170,10 @@ const trimURL = function(url) {
 };
 
 const debugLogMessage = function(message, extra) {
-    console.log(`[Debug ${getFileAndLine()}] ${EXTENSION_NAME} - ${message}`);
+    console.debug(`[Debug ${getFileAndLine()}] ${EXTENSION_NAME} - ${message}`);
 
     if (extra) {
-        console.log(extra);
+        console.debug(extra);
     }
 };
 

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -62,7 +62,7 @@ kpxcBanner.create = async function(credentials = {}) {
     const bannerInfo = kpxcUI.createElement('div', 'banner-info');
     const bannerButtons = kpxcUI.createElement('div', 'banner-buttons');
 
-    const className = (isFirefox() ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon');
+    const className = kpxc.isFirefox ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
     const icon = kpxcUI.createElement('span', className, { 'alt': 'logo' });
 
     const infoText = kpxcUI.createElement('span', '', {}, tr('rememberInfoText'));

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -89,7 +89,7 @@ kpxcCustomLoginFieldsBanner.create = async function() {
     const bannerInfo = kpxcUI.createElement('div', 'banner-info');
     const bannerButtons = kpxcUI.createElement('div', 'banner-buttons');
 
-    const iconClassName = isFirefox() ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
+    const iconClassName = kpxc.isFirefox ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
     const icon = kpxcUI.createElement('span', iconClassName);
     const infoText = kpxcUI.createElement('span', '', {}, tr('defineChooseCustomLoginFieldText'));
     const separator = kpxcUI.createElement('div', 'kpxc-separator');

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -21,6 +21,7 @@ kpxc.databaseState = DatabaseState.DISCONNECTED;
 kpxc.detectedFields = 0;
 kpxc.improvedFieldDetectionEnabledForPage = false;
 kpxc.inputs = [];
+kpxc.isFirefox;
 kpxc.settings = {};
 kpxc.singleInputEnabledForPage = false;
 kpxc.submitUrl = null;
@@ -904,6 +905,7 @@ const initContentScript = async function() {
         }
 
         kpxc.settings = settings;
+        kpxc.isFirefox = await sendMessage('is_firefox');
 
         if (await kpxc.siteIgnored()) {
             logDebug('This site is ignored in Site Preferences.');

--- a/keepassxc-browser/content/passkeys-utils.js
+++ b/keepassxc-browser/content/passkeys-utils.js
@@ -48,7 +48,7 @@ kpxcPasskeysUtils.sendPasskeysResponse = function(publicKey, errorCode, errorMes
     const response = errorCode
         ? { errorCode: errorCode, errorMessage: errorMessage, fallback: kpxcPasskeysUtils?.passkeysFallback }
         : { publicKey: publicKey, fallback: kpxcPasskeysUtils?.passkeysFallback };
-    const details = isFirefox() ? cloneInto(response, document.defaultView) : response;
+    const details = kpxc.isFirefox ? cloneInto(response, document.defaultView) : response;
     document.dispatchEvent(new CustomEvent('kpxc-passkeys-response', { detail: details }));
 };
 

--- a/keepassxc-browser/content/pwgen.js
+++ b/keepassxc-browser/content/pwgen.js
@@ -49,7 +49,7 @@ PasswordIcon.prototype.initField = function(field) {
 };
 
 PasswordIcon.prototype.createIcon = function(field) {
-    const className = (isFirefox() ? 'key-moz' : 'key');
+    const className = kpxc.isFirefox ? 'key-moz' : 'key';
     const size = this.calculateIconSize(field);
 
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-pwgen-icon ' + className,

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -139,7 +139,7 @@ TOTPFieldIcon.prototype.initField = async function(field, segmented) {
 };
 
 TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
-    const className = (isFirefox() ? 'moz' : 'default');
+    const className = kpxc.isFirefox ? 'moz' : 'default';
     const size = this.calculateIconSize(field);
 
     const icon = kpxcUI.createElement('div', 'kpxc kpxc-totp-icon ' + className,

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -363,7 +363,7 @@ kpxcUI.createNotification = function(type, message) {
     const notification = kpxcUI.createElement('div', 'kpxc-notification kpxc-notification-' + type, {});
     type = type.charAt(0).toUpperCase() + type.slice(1) + '!';
 
-    const className = (isFirefox() ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon');
+    const className = kpxc.isFirefox ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
     const icon = kpxcUI.createElement('span', className, { 'alt': 'logo' });
     const label = kpxcUI.createElement('span', 'kpxc-label', {}, type);
     const msg = kpxcUI.createElement('span', '', {}, message);

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -147,12 +147,12 @@ const iconClicked = async function(field, icon) {
 
 const getIconClassName = function(state = DatabaseState.UNLOCKED) {
     if (state === DatabaseState.LOCKED) {
-        return (isFirefox() ? 'lock-moz' : 'lock');
+        return kpxc.isFirefox ? 'lock-moz' : 'lock';
     } else if (state === DatabaseState.DISCONNECTED) {
-        return (isFirefox() ? 'disconnected-moz' : 'disconnected');
+        return kpxc.isFirefox ? 'disconnected-moz' : 'disconnected';
     }
 
-    return (isFirefox() ? 'unlock-moz' : 'unlock');
+    return kpxc.isFirefox ? 'unlock-moz' : 'unlock';
 };
 
 const getIconText = function(state) {

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -2,6 +2,7 @@
 
 const options = {};
 options.dropdownButton = null;
+options.isFirefox = false;
 
 const $ = function(elem) {
     return document.querySelector(elem);
@@ -207,7 +208,7 @@ options.initGeneralSettings = async function() {
     });
 
     $('#configureCommands').addEventListener('click', function() {
-        if (isFirefox()) {
+        if (options.isFirefox) {
             if (typeof(browser.commands.openShortcutSettings) === 'function') {
                 browser.commands.openShortcutSettings();
             } else {
@@ -982,6 +983,8 @@ window.addEventListener('scroll', function() {
 
         const keyRing = await browser.runtime.sendMessage({ action: 'load_keyring' });
         options.keyRing = keyRing;
+        options.isFirefox = await browser.runtime.sendMessage({ action: 'is_firefox' });
+
         options.initMenu();
         await options.initGeneralSettings();
         options.initConnectedDatabases();

--- a/keepassxc-browser/popups/popup_functions.js
+++ b/keepassxc-browser/popups/popup_functions.js
@@ -16,7 +16,8 @@ async function initSettings() {
     });
 
     const customLoginFieldsButton = document.body.querySelector('#settings #choose-custom-login-fields-button');
-    if (isFirefox()) {
+    const isFirefox = browser.runtime.sendMessage({ action: 'is_firefox' });
+    if (isFirefox) {
         customLoginFieldsButton.id = 'choose-custom-login-fields-button-moz';
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Fixes `isFirefox()` by setting the variable during extension start. Content scripts only request the already parsed value. Additional check for `browser.runtime.getBrowserInfo()` is added to the check, because this API call only exists in Firefox and currently it's the only way to distinquish Firefox if user has changed the browser user agent to something else.

Also moved few log messages to `console.debug()` instead, and changed `debugLogMessage()` to pass calls to that function. Especially the `page.js` spammed a lot of console messages because of the managed settings check.

* Fixes #2672

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
