### PR TITLE
Fix overlap checks with labels

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -479,7 +479,7 @@ kpxcFields.isTopElement = function(elem, rect) {
         const topElement = rootNode.elementFromPoint(x, elementRect.top + (elementRect.height / 2));
         return element?.labels &&
             element.labels[0] === topElement &&
-            isElementInside(elementRect, topElement.getBoundingClientRect())
+            elementsOverlap(elementRect, topElement.getBoundingClientRect())
             ? element
             : topElement;
     };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If an input field has a label element attached to it, we currently check only if the label is inside the input, and accept if that condition is met when checking the topmost element. In reality, the label can be partially outside the input (see the screenshot). We should allow related labels also if they are partially overlapping the input field.

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )
<img width="575" height="474" alt="Screenshot 2025-10-23 at 21 44 17" src="https://github.com/user-attachments/assets/c55774aa-c758-46be-b9c2-e835d7590359" />

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using the page https://banking.dkb.de/login

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
