### PR TITLE
Implement toJSON() for createPublicKeyCredential

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -32,6 +32,8 @@
         return window.btoa(str).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
     };
 
+    // Returns the PublicKeyCredential as JSON
+    // See: https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
     const kpxcPublicKeyCredentialJson = function (credential, publicKey) {
         const clientExtensionResults = credential.getClientExtensionResults();
         const type = credential.type;
@@ -45,7 +47,7 @@
                 authenticatorData: publicKey.response.authenticatorData,
                 transports: credential.response.getTransports(),
                 publicKey: responsePublicKey ? kpxcArrayBufferToBase64(responsePublicKey) : null,
-                publicKeyAlgorithm: publicKey.response.publicKeyAlgorithm,
+                publicKeyAlgorithm: credential.response.getPublicKeyAlgorithm(),
                 attestationObject: publicKey.response.attestationObject,
             };
         }

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -26,6 +26,49 @@
         return kpxcStringToArrayBuffer(window.atob(str?.replaceAll('-', '+').replaceAll('_', '/')));
     };
 
+    // From ArrayBuffer to URL encoded base64 string
+    const kpxcArrayBufferToBase64 = function(buf) {
+        const str = [ ...new Uint8Array(buf) ].map(c => String.fromCharCode(c)).join('');
+        return window.btoa(str).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+    };
+
+    const kpxcPublicKeyCredentialJson = function (credential, publicKey) {
+        const clientExtensionResults = credential.getClientExtensionResults();
+        const type = credential.type;
+        const authenticatorAttachment = credential.authenticatorAttachment;
+        let response;
+
+        if (credential.response instanceof AuthenticatorAttestationResponse) {
+            const responsePublicKey = credential.response.getPublicKey();
+            response = {
+                clientDataJSON: publicKey.response.clientDataJSON,
+                authenticatorData: publicKey.response.authenticatorData,
+                transports: credential.response.getTransports(),
+                publicKey: responsePublicKey ? kpxcArrayBufferToBase64(responsePublicKey) : null,
+                publicKeyAlgorithm: publicKey.response.publicKeyAlgorithm,
+                attestationObject: publicKey.response.attestationObject,
+            };
+        }
+
+        if (credential.response instanceof AuthenticatorAssertionResponse) {
+            response = {
+                clientDataJSON: publicKey.response.clientDataJSON,
+                authenticatorData: publicKey.response.authenticatorData,
+                signature: publicKey.response.signature,
+                userHandle: publicKey.response?.userHandle || undefined,
+            };
+        }
+
+        return {
+            id: publicKey.id,
+            rawId: publicKey.id,
+            response,
+            authenticatorAttachment,
+            clientExtensionResults,
+            type,
+        };
+    };
+
     // Wraps response to AuthenticatorAttestationResponse object
     const createAttestationResponse = function(publicKey) {
         const response = {
@@ -63,7 +106,8 @@
             response: authenticatorResponse,
             type: publicKey.type,
             clientExtensionResults: () => publicKey?.response?.clientExtensionResults || {},
-            getClientExtensionResults: () => publicKey?.response?.clientExtensionResults || {}
+            getClientExtensionResults: () => publicKey?.response?.clientExtensionResults || {},
+            toJSON: () => kpxcPublicKeyCredentialJson(publicKeyCredential, publicKey)
         };
 
         return Object.setPrototypeOf(publicKeyCredential, PublicKeyCredential.prototype);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Overrides and simplifies the stalled PR https://github.com/keepassxreboot/keepassxc-browser/pull/2613. Adds support for ´.toJSON()` with the PublicKeyCredential prototype override.

* Fixes #2298

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Passkey creation and authentication should work without issues at https://passkeys-demo.appspot.com/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
