### PR TITLE
Requery form if password input has changed

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -251,8 +251,7 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
         const formInputs = kpxcObserverHelper.getInputs(combination.form);
         const newPasswordField = formInputs?.find((formInput) =>
             formInput?.getLowerCaseAttribute('type') === 'password');
-        if (newPasswordField && areNamedNodeMapsEqual(combination.password.attributes, newPasswordField.attributes)
-        ) {
+        if (newPasswordField && areNamedNodeMapsEqual(combination.password.attributes, newPasswordField.attributes)) {
             combination.password = newPasswordField;
         }
     }
@@ -446,15 +445,15 @@ const areNamedNodeMapsEqual = function(currentNodeMap, newNodeMap) {
         return false;
     }
 
-    const passwordFieldAttributes = Array.from(currentNodeMap);
-    const newPasswordFieldAttributes = Array.from(newNodeMap);
+    const fieldAttributes = Array.from(currentNodeMap);
+    const newFieldAttributes = Array.from(newNodeMap);
 
-    if (passwordFieldAttributes.length !== newPasswordFieldAttributes.length) {
+    if (fieldAttributes.length !== newFieldAttributes.length) {
         return false;
     }
 
-    for (const attr of passwordFieldAttributes) {
-        const newAttr = newPasswordFieldAttributes.find((newAttr) => newAttr?.name === attr?.name);
+    for (const attr of fieldAttributes) {
+        const newAttr = newFieldAttributes.find((newAttr) => newAttr?.name === attr?.name);
         if (!newAttr || newAttr?.value !== attr?.value) {
             return false;
         }

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -245,6 +245,18 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
         skipAutoSubmit = selectedCredentials.skipAutoSubmit === 'true';
     }
 
+    // Update the password field if form has been updated with a new identical element (Moodle).
+    // If found, replace the new input field to the combination.
+    if (combination?.form && combination?.password && !combination.form.contains(combination.password)) {
+        const formInputs = kpxcObserverHelper.getInputs(combination.form);
+        const newPasswordField = formInputs?.find((formInput) =>
+            formInput?.getLowerCaseAttribute('type') === 'password');
+        if (newPasswordField && areNamedNodeMapsEqual(combination.password.attributes, newPasswordField.attributes)
+        ) {
+            combination.password = newPasswordField;
+        }
+    }
+
     // Fill password
     if (combination.password && matchesWithNodeName(combination.password, 'INPUT')) {
         // Show a notification if password length exceeds the length defined in input
@@ -426,4 +438,27 @@ const showErrorNotification = async function(errorMessage, notificationType = 'e
     } else {
         kpxcUI.createNotification(notificationType, errorMessage);
     }
+};
+
+// Checks if two NamedNodeMaps (attribute lists) are equal
+const areNamedNodeMapsEqual = function(currentNodeMap, newNodeMap) {
+    if (!currentNodeMap || !newNodeMap) {
+        return false;
+    }
+
+    const passwordFieldAttributes = Array.from(currentNodeMap);
+    const newPasswordFieldAttributes = Array.from(newNodeMap);
+
+    if (passwordFieldAttributes.length !== newPasswordFieldAttributes.length) {
+        return false;
+    }
+
+    for (const attr of passwordFieldAttributes) {
+        const newAttr = newPasswordFieldAttributes.find((newAttr) => newAttr?.name === attr?.name);
+        if (!newAttr || newAttr?.value !== attr?.value) {
+            return false;
+        }
+    }
+
+    return true;
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If login form has a password input field that has been replaced by the page script with an identical input element, the extension still tries to fill the old one and fails.
If the password input in the combination differs from the form saved in the combination, query the form again and identify the identical field. If found, replace the combination's password input with the new one.

A rare case (and a bit hacky), but it might fix some other sites as well.

* Fixes #2737

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Test with page: https://sandbox.moodledemo.net/login/index.php

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
