### PR TITLE
Fix incorrect fields variable

### DIFF
--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -674,7 +674,7 @@ kpxcCustomLoginFieldsBanner.handleTopWindowMessage = function(args) {
         kpxcCustomLoginFieldsBanner.selection.totp = selection;
         kpxcCustomLoginFieldsBanner.setSelectedField();
     } else if (message === 'string_field_selected') {
-        kpxcCustomLoginFieldsBanner.selection.stringFields = selection;
+        kpxcCustomLoginFieldsBanner.selection.fields = selection;
         kpxcCustomLoginFieldsBanner.setSelectedField();
     } else if (message === 'enable_clear_data_button') {
         kpxcCustomLoginFieldsBanner.buttons.clearData.style.display = 'inline-block';


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When storing String Fields from iframe, the paths are stored to incorrect array `stringFields`. The object handles these paths using array `fields` instead.

* Fixes #2729

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using Apple's login page: https://account.apple.com/sign-in

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
