### PR TITLE
Fix passkeys exclusion rules for `xml`

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -69,7 +69,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [

--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -82,7 +82,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -69,7 +69,6 @@
                 "<all_urls>"
             ],
             "exclude_matches": [
-                "*://*/*.xml*",
                 "file:///*.xml*"
             ],
             "js": [


### PR DESCRIPTION
Not all URLs containing `.xml` point to XML files. For example:
  - https://bafybeifvkyzsg6skzb3tsk7u7sueex574fzzwfoad7sebudldbv6sazuki.ipfs.dweb.link/test.xml.html
  - https://bafybeifvkyzsg6skzb3tsk7u7sueex574fzzwfoad7sebudldbv6sazuki.ipfs.dweb.link/test.xml/html
  - https://bafybeifvkyzsg6skzb3tsk7u7sueex574fzzwfoad7sebudldbv6sazuki.ipfs.dweb.link/?test=.xml

Not all XML files containing `.xml`:
- https://v1.ispdb.net/office365.com

Type checking is implemented in

https://github.com/keepassxreboot/keepassxc-browser/blob/c2dd4cbb98b1dd8df347d2228d3f01cbe6095e74/keepassxc-browser/content/passkeys-inject.js#L90-L94


[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )


## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy

Through the self-written site above. (You can substitute another URL path)

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )

- #2506
- #2287

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
