### PR TITLE
Remove injected passkeys script from DOM tree

### DIFF
--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -8,13 +8,14 @@ const PASSKEYS_WAIT_FOR_LIFETIMER = 30;
 const enablePasskeys = async function() {
     const passkeysLogDebug = function(message, extra) {
         if (kpxcPasskeysUtils.debugLogging) {
-            debugLogMessage(message, extra);   
+            debugLogMessage(message, extra);
         }
     };
 
     const passkeys = document.createElement('script');
     passkeys.src = chrome.runtime.getURL('content/passkeys.js');
     document.documentElement.appendChild(passkeys);
+    passkeys.remove();
 
     const startTimer = function(timeout) {
         return setTimeout(() => {


### PR DESCRIPTION
It helps to hide it from `document.scripts`

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Fixes #2494
Fixes #2626


## Testing strategy

With
```diff
diff --git a/keepassxc-browser/content/passkeys.js b/keepassxc-browser/content/passkeys.js
index e89f6ad..6588446 100644
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -255,6 +255,7 @@
                 value: isUserVerifyingPlatformAuthenticatorAvailable,
             });
         }
+        console.trace('passkeys.js injected');
     } catch (err) {
         console.log('Cannot override navigator.credentials: ', err);
     }
```

---

1. Go to the site from #2494 -- error
2. `Ctrl+Shift+R` -- error
3. `$ git switch fix` & reload the add-on
4. `Ctrl+Shift+R` -- it works
5. `Ctrl+Shift+R` -- it works

[testing.webm](https://github.com/user-attachments/assets/ae08228a-a739-4282-bca7-16766f2a9eaf)


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
