### PR TITLE
Fix layout issues with banners

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -65,7 +65,7 @@ kpxcBanner.create = async function(credentials = {}) {
     const className = kpxc.isFirefox ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
     const icon = kpxcUI.createElement('span', className, { 'alt': 'logo' });
 
-    const infoText = kpxcUI.createElement('span', '', {}, tr('rememberInfoText'));
+    const infoText = kpxcUI.createElement('span', 'banner-info-text', {}, tr('rememberInfoText'));
     const usernameText = kpxcUI.createElement('span', 'small', {}, tr('popupUsername') + ' ');
     const usernameSpan = kpxcUI.createElement('span', 'small info information-username', {}, credentials.username);
 

--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -91,7 +91,7 @@ kpxcCustomLoginFieldsBanner.create = async function() {
 
     const iconClassName = kpxc.isFirefox ? 'kpxc-banner-icon-moz' : 'kpxc-banner-icon';
     const icon = kpxcUI.createElement('span', iconClassName);
-    const infoText = kpxcUI.createElement('span', '', {}, tr('defineChooseCustomLoginFieldText'));
+    const infoText = kpxcUI.createElement('span', 'banner-info-text', {}, tr('defineChooseCustomLoginFieldText'));
     const separator = kpxcUI.createElement('div', 'kpxc-separator');
     const secondSeparator = kpxcUI.createElement('div', 'kpxc-separator');
 
@@ -544,7 +544,7 @@ kpxcCustomLoginFieldsBanner.markFields = function() {
         if (kpxcCustomLoginFieldsBanner.dataStep !== STEP_SELECT_STRING_FIELDS) {
             field.textContent = dataStepToString();
         }
-        
+
         // Static size for the checkbox overlay
         if (i?.getLowerCaseAttribute('type') === 'checkbox') {
             field.style.width = Pixels(CHECKBOX_OVERLAY_SIZE / zoom);

--- a/keepassxc-browser/css/banner.css
+++ b/keepassxc-browser/css/banner.css
@@ -13,7 +13,7 @@ div.kpxc-banner {
     margin: 0 auto !important;
     min-height: 2em !important;
     max-height: 4em !important;
-    overflow-x: hidden !important;
+    overflow-x: auto !important;
     padding: 4px !important;
     position: fixed !important;
     width: 100% !important;
@@ -47,6 +47,10 @@ div.kpxc-banner:hover {
 
 div.kpxc-banner .banner-info > span {
     margin: 4px;
+}
+
+div.kpxc-banner .banner-info-text {
+    text-wrap: nowrap;
 }
 
 div.kpxc-banner div.banner-info, div.banner-buttons {
@@ -113,6 +117,7 @@ div.kpxc-banner label {
     font-size: 12px !important;
     font-weight: normal !important;
     margin: 4px !important;
+    text-wrap: nowrap;
 }
 
 div.kpxc-banner-dialog {

--- a/keepassxc-browser/css/button.css
+++ b/keepassxc-browser/css/button.css
@@ -8,6 +8,7 @@
     height: 28px !important;
     margin: .2em !important;
     padding: 1px 7px 2px !important;
+    text-wrap: nowrap;
 }
 
 .kpxc-white-button {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Both Credential banner and Custom Login Fields banner wraps the text when window size is too small, and scrolling horizontally is not possible.

The texts (buttons included) are now defined with `text-wrap: nowrap;` and it's possible to scroll the banner horizontally when there is no space to display all elements.

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )
Before:
<img width="834" height="58" alt="Screenshot 2025-11-17 at 17 02 48" src="https://github.com/user-attachments/assets/9dcebefb-96a6-436b-b23a-c0dea815c51d" />

After:
<img width="835" height="59" alt="Screenshot 2025-11-17 at 17 02 30" src="https://github.com/user-attachments/assets/8cbc0ed0-c42e-4e26-a04f-afc41e999349" />

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually by resizing the window to different sizes when the banner is visible.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
