### PR TITLE
Passkeys: Add publicKey to response

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -77,7 +77,7 @@
             attestationObject: kpxcBase64ToArrayBuffer(publicKey.response.attestationObject),
             clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response.clientDataJSON),
             getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
-            getPublicKey: () => null,
+            getPublicKey: () => publicKey.response?.publicKey,
             getPublicKeyAlgorithm: () => publicKey.response?.publicKeyAlgorithm,
             getTransports: () => [ 'internal' ]
         };

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -77,7 +77,7 @@
             attestationObject: kpxcBase64ToArrayBuffer(publicKey.response.attestationObject),
             clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response.clientDataJSON),
             getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
-            getPublicKey: () => publicKey.response?.publicKey,
+            getPublicKey: () => publicKey.response?.publicKey ? publicKey.response?.publicKey : null,
             getPublicKeyAlgorithm: () => publicKey.response?.publicKeyAlgorithm,
             getTransports: () => [ 'internal' ]
         };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds a `publicKey` to the registration response if found. This is required by some sites, and it's part of the specifications:
https://w3c.github.io/webauthn/#sctn-public-key-easy

Related KeePassXC side PR: https://github.com/keepassxreboot/keepassxc/pull/12757

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually with the related KeePassXC PR.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
