### PR TITLE
Show notifications always on the top window

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -939,9 +939,14 @@ browser.runtime.onMessage.addListener(async function(req, sender) {
             kpxcFill.fillAttributeToActiveElementWith(req.args);
         } else if (req.action === 'frame_message') {
             if (req.args?.[0] === 'frame_request_to_frames' && window.self !== window.top) {
+                // Handle message from top window in iframe
                 kpxcCustomLoginFieldsBanner.handleParentWindowMessage(req.args);
             } else if (req.args?.[0] === 'frame_request_to_parent' && window.self === window.top) {
+                // Handle message from iframe in top window
                 kpxcCustomLoginFieldsBanner.handleTopWindowMessage(req.args);
+            } else if (req.args?.[0] === 'notification_from_frame' && window.self === window.top) {
+                // Handle notification from iframe in top window
+                kpxcUI.createNotification(req?.args[1], req?.args[2]);
             }
         } else if (req.action === 'ignore_site') {
             kpxc.ignoreSite(req.args);

--- a/keepassxc-browser/content/ui.js
+++ b/keepassxc-browser/content/ui.js
@@ -330,8 +330,14 @@ kpxcUI.updateFromIntersectionObserver = function(iconClass, entries) {
  * @param {string} type     Notification type: (success, info, warning, error)
  * @param {string} message  The message shown
  */
-kpxcUI.createNotification = function(type, message) {
+kpxcUI.createNotification = async function(type, message) {
     if (!kpxc.settings.showNotifications || !type || !message) {
+        return;
+    }
+
+    // Send the notification to top window from iframe
+    if (window.self !== window.top) {
+        await sendMessage('frame_message', [ 'notification_from_frame', type, message ]);
         return;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If a notification is shown inside an iframe, it's highly possible that it will be partially cut off, or is displayed in strange position. If `kpxcUI.createNotification()` is called inside an iframe, pass the message to the top window and show it there instead.

* Fixes #2255

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Any site with login form inside an iframe, e.g. https://mail.163.com/ or https://issues.imfreedom.org/projects. Just don't have any entries for it, and click the Username Icon.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
