### PR TITLE
Add 'mfaCode' to accepted token fields

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -18,7 +18,8 @@ const acceptedOTPFields = [
     'twofa',
     'two-factor',
     'twofactor',
-    'verification_pin'
+    'verification_pin',
+    'mfaCode'
 ];
 
 const acceptedParents = [


### PR DESCRIPTION
Add mfaCode as accepted token name field. It is used by portal.emnify.com

## Type of change
- ✅ New feature (change that adds functionality)