### PR TITLE
Hide the form-switch animation when the options page loads the initial values

### DIFF
--- a/keepassxc-browser/options/options.css
+++ b/keepassxc-browser/options/options.css
@@ -82,6 +82,10 @@ pre {
     white-space: pre-line;
 }
 
+.no-transitions * {
+    transition: none !important;
+}
+
 .table > caption {
     color: var(--kpxc-text-color);
 }

--- a/keepassxc-browser/options/options.css
+++ b/keepassxc-browser/options/options.css
@@ -82,7 +82,8 @@ pre {
     white-space: pre-line;
 }
 
-.no-transitions * {
+.no-transitions .form-switch .form-check-input,
+.no-transitions .form-check-input {
     transition: none !important;
 }
 

--- a/keepassxc-browser/options/options.css
+++ b/keepassxc-browser/options/options.css
@@ -82,7 +82,6 @@ pre {
     white-space: pre-line;
 }
 
-.no-transitions .form-switch .form-check-input,
 .no-transitions .form-check-input {
     transition: none !important;
 }

--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -19,7 +19,7 @@
     <script src="options.js"></script>
     <script src="../common/translate.js" defer></script>
   </head>
-  <body class="pt-3 pb-5">
+  <body class="pt-3 pb-5 no-transitions">
     <div class="container-fluid">
       <div class="row">
         <nav class="col-md-3 col-lg-2 sidebar">

--- a/keepassxc-browser/options/options.js
+++ b/keepassxc-browser/options/options.js
@@ -991,6 +991,11 @@ window.addEventListener('scroll', function() {
         options.initCustomLoginFields();
         options.initSitePreferences();
         options.initAbout();
+
+        // The form-switch transitions should complete in 150 ms
+        setTimeout(() => {
+            document.body.classList.remove('no-transitions');
+        }, 200);
     } catch (err) {
         console.log('Error loading options page: ' + err);
     }


### PR DESCRIPTION
This hides the bootstrap animation on the `form-switch` elements in the Settings page when the page loads the initial values.


## Screenshots or videos

When I open the Settings, I see this distracting animation:

https://github.com/user-attachments/assets/590d8153-0824-488d-b288-8041cda97a04


## Testing strategy

When I was testing without `setTimeout` then the animation still showed up for me. I don't know how the browser internals keeps track of it but adding a short timeout seems reasonable to me.

To test, simply open the settings page and use your browser's hard reload shortcut.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
