### PR TITLE
Fix incorrect error message on keyboard fill

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -441,7 +441,7 @@ const passwordFillIsAllowed = function(elem) {
 // Show a specific error notification if current database is not connected
 const showErrorNotification = async function(errorMessage, notificationType = 'error') {
     const connectedDatabase = await sendMessage('get_connected_database');
-    if (!connectedDatabase?.identifier) {
+    if (!connectedDatabase?.identifier && kpxc.databaseState === DatabaseState.UNLOCKED) {
         kpxcUI.createNotification('error', tr('errorCurrentDatabaseNotConnected'));
     } else if (!await isIframeAllowed()) {
         // Special error if we are blocking due to iframe


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Fixes an incorrect error message when using "Fill username and password" keyboard shortcut on locked database. The check only reads the database identifier, but it is missing also with locked database. To ensure the correct error message is shown, database state must be also checked.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Try using the "Fill username and password" keyboard shortcut on:
- Locked database that is connected
- Open database that is not connected

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
