### PR TITLE
Fix TOTP field detection with Microsoft sites

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -13,6 +13,7 @@ const acceptedOTPFields = [
     'idvpin',
     'mfa',
     'one_time_password',
+    'otc-confirmation-input',
     'otp',
     'token',
     'twofa',


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Microsoft has changed the TOTP input field properties. It can be now detected using id `otc-confirmation-input`.

* Fixes #2831

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
