### PR TITLE
Fix the ability to fake same-origin in passkeys

### DIFF
--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -63,6 +63,14 @@ const enablePasskeys = async function() {
         }
     };
 
+    const isSameOriginWithAncestors = function () {
+        try {
+            return window.origin === window.top.origin;
+        } catch (_err) {
+            return false;
+        }
+    };
+
     document.addEventListener('kpxc-passkeys-request', async (ev) => {
         if (!window.isSecureContext) {
             kpxcUI.createNotification('error', tr('errorMessagePasskeysContextIsNotSecure'));
@@ -72,14 +80,14 @@ const enablePasskeys = async function() {
         if (ev.detail.action === 'passkeys_create') {
             const publicKey = kpxcPasskeysUtils.buildCredentialCreationOptions(
                 ev.detail.publicKey,
-                ev.detail.sameOriginWithAncestors,
+                isSameOriginWithAncestors(),
             );
             passkeysLogDebug('Passkey request', publicKey);
             await sendResponse('passkeys_register', publicKey);
         } else if (ev.detail.action === 'passkeys_get') {
             const publicKey = kpxcPasskeysUtils.buildCredentialRequestOptions(
                 ev.detail.publicKey,
-                ev.detail.sameOriginWithAncestors,
+                isSameOriginWithAncestors(),
             );
             passkeysLogDebug('Passkey request', publicKey);
             await sendResponse('passkeys_get', publicKey);

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -137,14 +137,6 @@
         });
     };
 
-    const isSameOriginWithAncestors = function() {
-        try {
-            return window.self.origin === window.top.origin;
-        } catch (_err) {
-            return false;
-        }
-    };
-
     // Throws errors to a correct exceptions
     const throwError = function(errorCode, errorMessage) {
         if ((!errorCode && !errorMessage) || errorCode === PASSKEYS_REQUEST_CANCELED) {
@@ -193,11 +185,9 @@
                 return null;
             }
 
-            const sameOriginWithAncestors = isSameOriginWithAncestors();
             const response = await postMessageToExtension({
                 action: 'passkeys_create',
                 publicKey: options.publicKey,
-                sameOriginWithAncestors: sameOriginWithAncestors,
             });
 
             if (!response.publicKey) {
@@ -218,11 +208,9 @@
                 return originalCredentials.get(options);
             }
 
-            const sameOriginWithAncestors = isSameOriginWithAncestors();
             const response = await postMessageToExtension({
                 action: 'passkeys_get',
                 publicKey: options.publicKey,
-                sameOriginWithAncestors: sameOriginWithAncestors,
             });
 
             if (!response.publicKey) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Moved the same-origin check from the page script to the content script to prevent bypassing

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )

[bypass.webm](https://github.com/user-attachments/assets/b522f835-944c-4482-a4ee-b5b9fa69cacf)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

In Chrome & Firefox via https://bafkreicoivsxk7xkdkd4k4r4lx2ptqjrkfusc5entbw7mrzlwrvzaxdx4y.ipfs.dweb.link/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Breaking change (causes existing functionality to change)
