### PR TITLE
Fix detecting transitions

### DIFF
--- a/keepassxc-browser/content/observer-helper.js
+++ b/keepassxc-browser/content/observer-helper.js
@@ -245,6 +245,30 @@ kpxcObserverHelper.findInputsFromShadowDOM = function(target) {
     return inputFields;
 };
 
+// Detects animations and transitions. Triggers handleObserverAdd() again on animationend/transitionend.
+kpxcObserverHelper.handleTransitions = function(target) {
+    const targetHasAnimations = target?.classList?.toString()?.includes('animate');
+    const targetHasDurations = target?.classList?.toString()?.includes('duration');
+
+    if (targetHasAnimations || targetHasDurations) {
+        const animations = target.getAnimations();
+        const transitionTime = animations[0]?.currentTime ?? 0;
+
+        // Animation found, but transition has not finished
+        if (animations && transitionTime === 0) {
+            target.addEventListener(
+                targetHasAnimations ? 'animationend' : 'transitionend',
+                () => {
+                    kpxcObserverHelper.handleObserverAdd(target);
+                },
+                {
+                    once: true,
+                },
+            );
+        }
+    }
+};
+
 // Adds elements to a monitor array. Identifies the input fields.
 kpxcObserverHelper.handleObserverAdd = async function(target) {
     if (kpxcObserverHelper.ignoredElement(target)) {
@@ -256,6 +280,8 @@ kpxcObserverHelper.handleObserverAdd = async function(target) {
         kpxc.init();
         return;
     }
+
+    kpxcObserverHelper.handleTransitions(target);
 
     const inputs = kpxcObserverHelper.getInputs(target);
     if (inputs.length === 0) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds basic support for detecting animations and transitions when inspecting DOM content. If an element is found with an animation or transition defined in the `classList`, and there's an object retrieved via `.getAnimations()`, the observer class will add an event listeners for `animationend` and/or `transitionend`. After animation or transition has been finished, `.handleObserverAdd()` will be called again.

It's highly possible that more complex sites will not be triggered by this, but at least it works great with some previously reported sites.

Fixes #2768
Fixes #2437
Fixes #2847

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Used following sites for testing. Open, close and reopen the sidebar for login fields.
https://www.thomann.de/
https://www.inwx.de/de

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
