### PR TITLE
Fix Google password input

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -106,6 +106,8 @@ kpxcSites.exceptionFound = function(identifier, field) {
     } else if (document.location.origin === 'https://login.dei.gr' &&
         identifier?.value?.includes('show-reveal-password')) {
         return true;
+    } else if (document.location.origin === 'https://accounts.google.com' && field?.id === 'password') {
+        return true;
     }
 
     return false;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -108,6 +108,14 @@ kpxcFields.getExistingCombination = function(combination) {
             existingCombination.passwordInputs.push(combination.password);
         }
 
+        // Exception for Google. They replace the username input with password input using identical className.
+        // If detected, remove the username from the combination.
+        if (existingCombination?.username?.className?.length > 0
+            && existingCombination?.password?.className?.length > 0
+            && existingCombination?.username?.className === existingCombination?.password?.className) {
+            existingCombination.username = null;
+        }
+
         return existingCombination;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Google changed their password login flow a little and it broke our combination detection. This fixes two things:

1. Detection for the `div` element that holds the password input.
2. Showing Autocomplete Menu anchored to the correct input field. Username field disappears but it's replaced with a password input that has identical classnames. The combination must remove the username input if this is detected. If the username input stays in the combination, icons are filled to that field instead of the password input.

* Fixes #2859

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
