### PR TITLE
Passkeys: cross-origin iframes & Permissions Policy support

### DIFF
--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -73,10 +73,15 @@ const enablePasskeys = async function() {
      */
     const isAllowedByPolicy = function (action) {
         // https://www.w3.org/TR/webauthn-2/#sctn-permissions-policy
+        // https://www.w3.org/TR/webauthn-2/#sctn-iframe-guidance
+        const feature = `publickey-credentials-${action}`;
+
+        // https://www.w3.org/TR/permissions-policy/#the-policy-object
         const policy = document.featurePolicy || document.permissionsPolicy;
-        if (policy) {
+
+        if (policy?.features().includes(feature)) {
             passkeysLogDebug('Checking Permissions Policy');
-            return policy.allowsFeature(`publickey-credentials-${action}`);
+            return policy.allowsFeature(feature);
         }
 
         // fallback to sameOriginWithAncestors

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -67,8 +67,21 @@ const enablePasskeys = async function() {
         }
     };
 
-    const isSameOriginWithAncestors = function () {
+    /**
+     * @param {'create' | 'get'} action
+     * @returns {boolean}
+     */
+    const isAllowedByPolicy = function (action) {
+        // https://www.w3.org/TR/webauthn-2/#sctn-permissions-policy
+        const policy = document.featurePolicy || document.permissionsPolicy;
+        if (policy) {
+            passkeysLogDebug('Checking Permissions Policy');
+            return policy.allowsFeature(`publickey-credentials-${action}`);
+        }
+
+        // fallback to sameOriginWithAncestors
         try {
+            passkeysLogDebug('Checking sameOriginWithAncestors');
             return window.origin === window.top.origin;
         } catch (_err) {
             return false;
@@ -84,14 +97,14 @@ const enablePasskeys = async function() {
         if (ev.detail.action === 'passkeys_create') {
             const publicKey = kpxcPasskeysUtils.buildCredentialCreationOptions(
                 ev.detail.publicKey,
-                isSameOriginWithAncestors(),
+                isAllowedByPolicy('create'),
             );
             passkeysLogDebug('Passkey request', publicKey);
             await sendResponse('passkeys_register', publicKey);
         } else if (ev.detail.action === 'passkeys_get') {
             const publicKey = kpxcPasskeysUtils.buildCredentialRequestOptions(
                 ev.detail.publicKey,
-                isSameOriginWithAncestors(),
+                isAllowedByPolicy('get'),
             );
             passkeysLogDebug('Passkey request', publicKey);
             await sendResponse('passkeys_get', publicKey);

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -79,7 +79,10 @@ const enablePasskeys = async function() {
         // https://www.w3.org/TR/permissions-policy/#the-policy-object
         const policy = document.featurePolicy || document.permissionsPolicy;
 
-        if (policy?.features().includes(feature)) {
+        if (
+            action === 'get' && // remove it since WebAuthn 3
+            policy?.features().includes(feature)
+        ) {
             passkeysLogDebug('Checking Permissions Policy');
             return policy.allowsFeature(feature);
         }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Support of:
- https://www.w3.org/TR/webauthn-2/#sctn-permissions-policy
- https://www.w3.org/TR/webauthn-2/#sctn-iframe-guidance

Both legacy and draft APIs are used. If a browser doesn't support either of these, fallback to `sameOriginWithAncestors` mode.

> [!IMPORTANT]
> Firefox users need to go to `about:config`, find `dom.security.featurePolicy.webidl.enabled` and toggle it to `true`. 

- Resolves #2850
- Resolves #2877
- Resolves #2988
- Resolves #3082
- and partially https://github.com/keepassxreboot/keepassxc-browser/issues/2808#issuecomment-3862622617


## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

1. In Chrome and Firefox on <https://account.aliyun.com/login/login.htm> via debugger checked that `isAllowedByPolicy() === true`.
2. In Firefox on <https://accountscenter.facebook.com/passkey/management> created a passkey.
3. In Chrome and Firefox on <https://bafkreibpvliu64zcxj5uvu4a5ha3oxy4mgtmrylkmdtrfo6w6y2pprmjr4.ipfs.dweb.link/>

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )

- https://www.w3.org/TR/permissions-policy/#the-policy-object

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
