### PR TITLE
Improve retry on input field detection with Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -646,6 +646,11 @@ kpxcFields.useCustomLoginFields = async function() {
         kpxcTOTPIcons.newIcon(totp, kpxc.databaseState);
     }
 
+    // No values found
+    if (!username && !password && !totp && !submitButton && stringFields?.length === 0) {
+        return [];
+    }
+
     const combinations = [];
     combinations.push({
         username: username,

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -361,7 +361,7 @@ kpxc.initCredentialFields = async function() {
 
     // Search all remaining inputs from the page, ignore the previous input fields
     const pageInputs = await kpxcFields.getAllPageInputs(formInputs);
-    if (formInputs.length === 0 && pageInputs.length === 0 && !kpxcFields.isCustomLoginFieldsUsed()) {
+    if (formInputs.length === 0 && pageInputs.length === 0) {
         // Run 'redetect_credentials' manually if no fields are found after a page load
         setTimeout(async function() {
             if (_called.automaticRedetectCompleted) {
@@ -653,7 +653,10 @@ kpxc.retrieveCredentials = async function(force = false) {
     }
 
     kpxc.url = document.location.href;
-    kpxc.submitUrl = kpxc.getFormActionUrl(kpxc.combinations[0]);
+    
+    // Search for first combination that has username or password input set
+    const firstCombination = kpxc.combinations?.find((combination) => combination?.username || combination?.password);
+    kpxc.submitUrl = kpxc.getFormActionUrl(firstCombination);
 
     if (kpxc.settings.autoRetrieveCredentials && kpxc.url && kpxc.submitUrl) {
         await kpxc.retrieveCredentialsCallback(


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Found out this when trying to solve https://github.com/keepassxreboot/keepassxc-browser/issues/2874.

We currently ignore the automatic redetect credentials re-request if Custom Login Fields are used for the site. This can cause a scenario where some of the input fields are found with the normal detection, but none are found when using Custom Login Fields. This retry method should be used whether Custom Login Fields are used or not.

Also noticed that the first combination selected for `kpxc.getFormActionUrl()` can be actually an empty combination. A combination that has username or password input should be selected instead. To prevent empty combinations to be created, `kpxcFields.useCustomLoginFields()` now returns immediately if no values are found/set.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually at https://app.tuta.com when choosing Custom Login Fields.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
