### PR TITLE
Fix detecting new password input in form

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -104,8 +104,8 @@ kpxcFields.getExistingCombination = function(combination) {
         existingCombination.password ??= combination.password;
         if (existingCombination.passwordInputs?.length === 0) {
             existingCombination.passwordInputs = combination.passwordInputs;
-        } else {
-            existingCombination.passwordInputs.push(combination.password);
+        } else if (combination?.password) {
+            existingCombination.password = combination.password;
         }
 
         // Remove username field from combination with certain sites (replaced by password input)

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -105,6 +105,7 @@ kpxcFields.getExistingCombination = function(combination) {
         if (existingCombination.passwordInputs?.length === 0) {
             existingCombination.passwordInputs = combination.passwordInputs;
         } else if (combination?.password) {
+            // If password field is found in the current combination, force assign it to the existing combination
             existingCombination.password = combination.password;
         }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Continues from https://github.com/keepassxreboot/keepassxc-browser/pull/2682. It's enough to replace the combination password field without adding it to the `passwordInputs` list.

* Fixes #2710

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Tested this with the same sites in https://github.com/keepassxreboot/keepassxc-browser/pull/2682:
https://app.fastmail.com/
https://www.patreon.com/

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
