### PR TITLE
Ignore password buttons on form submit button detection

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -66,6 +66,8 @@ kpxcForm.getFormSubmitButton = function(form) {
         return;
     }
 
+    const hasPasswordClassOrId = (button) => button
+        && (button?.classList.value?.includes('password') || button?.id?.includes('password'));
     const action = kpxc.submitUrl || form.action;
 
     // Check if the site needs a special handling for retrieving the form submit button
@@ -88,13 +90,19 @@ kpxcForm.getFormSubmitButton = function(form) {
         b => !b.getAttribute('formAction')
     );
     if (buttons.length > 0) {
-        return buttons.at(-1);
+        const lastButton = buttons.at(-1);
+        // Accept button if it has no indication for password
+        if (!hasPasswordClassOrId(lastButton)) {
+            return buttons.at(-1);
+        }
     }
 
     // Try to find similar buttons outside the form which are added via 'form' property
     for (const e of form.elements) {
-        if ((matchesWithNodeName(e, 'BUTTON') && (e.type === 'button' || e.type === 'submit' || e.type === ''))
-            || (matchesWithNodeName(e, 'INPUT') && (e.type === 'button' || e.type === 'submit'))) {
+        const isSubmitButton = matchesWithNodeName(e, 'BUTTON')
+            && (e.type === 'button' || e.type === 'submit' || e.type === '');
+        const isInputButton = matchesWithNodeName(e, 'INPUT') && (e.type === 'button' || e.type === 'submit');
+        if ((isSubmitButton || isInputButton) && !hasPasswordClassOrId(e)) {
             return e;
         }
     }

--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -67,7 +67,8 @@ kpxcForm.getFormSubmitButton = function(form) {
     }
 
     const hasPasswordClassOrId = (button) => button
-        && (button?.classList.value?.includes('password') || button?.id?.includes('password'));
+        && (button?.classList.value?.toLowerCase()?.includes('password')
+            || button?.id?.toLowerCase()?.includes('password'));
     const action = kpxc.submitUrl || form.action;
 
     // Check if the site needs a special handling for retrieving the form submit button


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When detecting submit buttons from form, ignore any buttons thas includes `password` in the `classList` or `id`. This prevents triggering the Credential Banner when it's not actually needed.

* Fixes #2880

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using https://community.cryptomator.org/signup page.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
