### PR TITLE
Remove webRequestBlocking permission from V3 manifests

### DIFF
--- a/dist/manifest_chromium.json
+++ b/dist/manifest_chromium.json
@@ -170,8 +170,7 @@
         "tabs",
         "webNavigation",
         "webRequest",
-        "webRequestAuthProvider",
-        "webRequestBlocking"
+        "webRequestAuthProvider"
     ],
     "optional_permissions": [
         "privacy"

--- a/keepassxc-browser/manifest.json
+++ b/keepassxc-browser/manifest.json
@@ -170,8 +170,7 @@
         "tabs",
         "webNavigation",
         "webRequest",
-        "webRequestAuthProvider",
-        "webRequestBlocking"
+        "webRequestAuthProvider"
     ],
     "optional_permissions": [
         "privacy"


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Having this permission in V3 manifests can Chromium-based browsers to give a warning, maybe some potentially ignoring the extension totally. Let's release a hotfix after this.

For V3 extensions, `webRequestAuthProvider` is the only required permission for HTTP Basic Auth.

* Fixes #2892

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)