### PR TITLE
Ignore non-'visible' overlays

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -479,6 +479,10 @@ kpxcFields.isOverlayOnTop = function(rect) {
             continue;
         }
 
+        if (getComputedStyle(overlay).visibility != 'visible') {
+            continue;
+        }
+
         const overlayRect = overlay?.getBoundingClientRect();
         if (overlayRect && elementsOverlap(rect, overlayRect)) {
             return true;


### PR DESCRIPTION
Check if popover / overlay is hidden with the `visibility` CSS property before checking if it blocks an input field.

## Testing strategy
The bug was noticed on https://wizzair.com/ as the "Sign in" option's fields were often not found by the extension. Debugging showed that the fields were overlapping with the `#navigation-language-selector` language selection dialog, which had `visibility: hidden` in CSS. The bug might not appear on the site with different screen sizes. it's somewhat layout dependent


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
