### PR TITLE
Fix dynamic password input detection when replacing username

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -124,9 +124,10 @@ kpxcSites.combinationExceptionFound = function(existingCombination) {
         return false;
     }
 
-    // Exception for e.g. Google. They replace the username input with password input using identical className.
+    // Exception for Google. They replace the username input with password input using identical className.
     // If detected, remove the username from the combination.
-    if (existingCombination?.username?.className?.length > 0
+    if (document.location.origin === 'https://accounts.google.com'
+        && existingCombination?.username?.className?.length > 0
         && existingCombination?.password?.className?.length > 0
         && existingCombination?.username?.className === existingCombination?.password?.className) {
         return true;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
This check added in https://github.com/keepassxreboot/keepassxc-browser/pull/2863 must be restricted for Google. PayPal and Epic Games seem to still work, but without the restriction, it affects negatively with other sites.

If there's some site that actually requires the new code block, it must be enable per-site, as we usually do.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Use https://payoneer.com to check this. Without the fix username field is not filled at all.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
