### PR TITLE
Fix regression when returning Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -647,16 +647,11 @@ kpxcFields.useCustomLoginFields = async function() {
         kpxcTOTPIcons.newIcon(totp, kpxc.databaseState);
     }
 
-    // No values found
-    if (!username && !password && !totp && !submitButton && stringFields?.length === 0) {
-        return [];
-    }
-
     const combinations = [];
     combinations.push({
         username: username,
         password: password,
-        passwordInputs: [ password ],
+        passwordInputs: password ? [ password ] : [],
         totp: totp,
         fields: stringFields,
         submitButton: submitButton


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Regression from https://github.com/keepassxreboot/keepassxc-browser/pull/2875. We shouldn't return an empty array at this point. Even if there are no values, return a new combination but with empty values that are not handled.

* Fixes #2914

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually by setting Custom Login Fields to GitHub's login page, then going to another page at GitHub that has no login fields.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
