### PR TITLE
Russian localization fix

### DIFF
--- a/keepassxc-browser/_locales/ru/messages.json
+++ b/keepassxc-browser/_locales/ru/messages.json
@@ -1295,7 +1295,7 @@
         "description": "Label for adding site manually on Site Preferences tab."
     },
     "optionsSitePreferencesManualAddHelp": {
-        "message": "Сетевой адрес должен начинаться с <code>https://</code>, <code>http://</code>, <code>file://</code>, or <code>ftp://</code> и должен содержать не менее 5 символов.",
+        "message": "Сетевой адрес должен начинаться с <code>https://</code>, <code>http://</code>, <code>file://</code>, или <code>ftp://</code> и должен содержать не менее 5 символов.",
         "description": "Help text for adding site manually on Site Preferences tab."
     },
     "optionsSitePreferencesConfirmation": {


### PR DESCRIPTION
Simple fix in Russian localization ("or" translated to "или" on line 1298).
Current translation (before fix):
<img width="879" height="131" alt="Um7UoHkIro" src="https://github.com/user-attachments/assets/f935f39b-932d-4475-8f15-89e785393fb0" />
