### PR TITLE
Fix TOTP icon border

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -140,7 +140,7 @@ TOTPFieldIcon.prototype.createIcon = function(field, segmented = false) {
     const className = getIconClass('kpxc-totp-icon');
     const size = this.calculateIconSize(field);
 
-    const icon = kpxcUI.createElement('div', 'kpxc ' + className,
+    const icon = kpxcUI.createElement('div', 'kpxc kpxc-totp-icon ' + className,
         {
             'title': tr('totpFieldText'),
             'size': size,

--- a/keepassxc-browser/css/totp.css
+++ b/keepassxc-browser/css/totp.css
@@ -15,7 +15,7 @@
     background-size: contain;
 }
 
-.kpxc-totp-icon.safari {
+.kpxc-totp-icon-safari {
     background: url('safari-web-extension://__MSG_@@extension_id__/icons/otp.svg') right no-repeat;
     background-size: contain;
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Fixes the border with TOTP icon when using Firefox. The missing base CSS class `kpxc-totp-icon` is added to the list.

* Fixes #2927

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually with some site with 2FA.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
