### PR TITLE
Respect autocomplete off setting

### DIFF
--- a/keepassxc-browser/content/autocomplete.js
+++ b/keepassxc-browser/content/autocomplete.js
@@ -41,7 +41,7 @@ class Autocomplete {
         showGroup = true,
         afterFillSort = SORT_BY_MATCHING_CREDENTIALS_SETTING,
     ) {
-        if (input.readOnly) {
+        if (input.readOnly || kpxcFields.isAutocompleteOff(input)) {
             return;
         }
 

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -388,7 +388,18 @@ kpxcFields.handleSegmentedTOTPFields = function(inputs, combinations) {
 // Check for new password via autocomplete attribute
 kpxcFields.isAutocompleteAppropriate = function(field) {
     const autocomplete = field.getLowerCaseAttribute('autocomplete');
-    return autocomplete !== 'new-password';
+    return autocomplete?.toLowerCase() !== 'new-password';
+};
+
+// Check if autocomplete is off
+kpxcFields.isAutocompleteOff = function(field) {
+    // Ignore the check if Custom Login Fields is used
+    if (kpxcFields.isCustomLoginFieldsUsed()) {
+        return false;
+    }
+
+    const autocomplete = field.getLowerCaseAttribute('autocomplete');
+    return autocomplete?.toLowerCase() === 'off';
 };
 
 // Checks if Custom Login Fields are used for the site

--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -79,7 +79,7 @@ kpxcTOTPIcons.isValid = function(field, forced) {
         return true;
     }
 
-    if (!field || !kpxcTOTPIcons.isAcceptedTOTPField(field)) {
+    if (!field || !kpxcTOTPIcons.isAcceptedTOTPField(field) || kpxcFields.isAutocompleteOff(field)) {
         return false;
     }
 

--- a/keepassxc-browser/content/username-field.js
+++ b/keepassxc-browser/content/username-field.js
@@ -17,7 +17,8 @@ kpxcUsernameIcons.isValid = function(field) {
         || field.offsetWidth < MIN_INPUT_FIELD_OFFSET_WIDTH
         || field.readOnly
         || kpxcIcons.hasIcon(field)
-        || (!kpxcFields.isCustomLoginFieldsUsed() && !kpxcFields.isVisible(field))) {
+        || (!kpxcFields.isCustomLoginFieldsUsed() && !kpxcFields.isVisible(field))
+        || kpxcFields.isAutocompleteOff(field)) {
         return false;
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Icons or Autocomplete Menu should not be initialized for fields that have `autocomplete=off` set. If the same inputs are defined with Custom Login Fields, the check is ignored.

* Fixes #2929
* Fixes #2920

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Used a test page https://jsfiddle.net/e76wh3oj/ with:
`<input type="text" autocomplete="off"><input type="password">`

Cross-Origin iframes must be allowed to test this.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
