### PR TITLE
Load non-discarded tabs only

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -70,6 +70,10 @@ const initListeners = async function() {
      * @param {object} tab
      */
     browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+        // Could be not tracked yet if discarded from browser startup
+        if (tab?.id && !page.tabs[tab.id]) {
+            page.createTabEntry(tab.id);
+        }
         // If the tab URL has changed (e.g. logged in) clear credentials
         if (changeInfo.url) {
             page.clearLogins(tabId);
@@ -77,9 +81,6 @@ const initListeners = async function() {
 
         if (changeInfo.status === 'complete' && tab?.id) {
             browserAction.showDefault(tab);
-            if (!page.tabs[tab.id]) {
-                page.createTabEntry(tab.id);
-            }
         }
     });
 

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -115,7 +115,7 @@ page.initSettings = async function() {
 
 page.initOpenedTabs = async function() {
     try {
-        const tabs = await browser.tabs.query({});
+        const tabs = await browser.tabs.query({ discarded: false });
         for (const i of tabs) {
             page.createTabEntry(i.id);
         }


### PR DESCRIPTION
One may have up to a few thousand (at least) discarded tabs in a persistent browser session. Trying to send messages to all of them on the clear credentials timer can introduce noticeable jank on every tab switch.

I'm not sure whether such a targeted fix is the right approach or some more significant refactoring should be done. For example, no documentation I know says anything about tab IDs being sequentially assigned, so using an array for `page.tabs` looks a bit questionable... maybe a `Map` would be a better choice here.

## Testing strategy
Minimally tested in my main session (3+ thousand tabs). Filling fields from context menu works, and Firefox Profiler confirms the extension process freezes have been reduced significantly.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
