### PR TITLE
Fix wrapping publicKey to ArrayBuffer

### DIFF
--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -77,7 +77,8 @@
             attestationObject: kpxcBase64ToArrayBuffer(publicKey.response.attestationObject),
             clientDataJSON: kpxcBase64ToArrayBuffer(publicKey.response.clientDataJSON),
             getAuthenticatorData: () => kpxcBase64ToArrayBuffer(publicKey.response?.authenticatorData),
-            getPublicKey: () => publicKey.response?.publicKey ? publicKey.response?.publicKey : null,
+            getPublicKey: () =>
+                publicKey.response?.publicKey ? kpxcBase64ToArrayBuffer(publicKey.response?.publicKey) : null,
             getPublicKeyAlgorithm: () => publicKey.response?.publicKeyAlgorithm,
             getTransports: () => [ 'internal' ]
         };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
This happens only with KeePassXC 2.7.12 that returns the `publicKey` to extension side (https://github.com/keepassxreboot/keepassxc/pull/12757). The extension returns it to the web page as Base64 instead of an ArrayBuffer that is the expected format. This causes passkey creation to fail with ChatGPT/OpenAI.

* Fixes #2939

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using ChatGPT/OpenAI site.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
