### PR TITLE
Update "Credential is excluded." message to a more descriptive error

### DIFF
--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "Passkey not registered due to URL exclusion. Remove existing entry for this site or its exclusion.",
-        "description": "Passkey not registered due to URL exclusion. Remove existing entry for this site or its exclusion."
+        "message": "Passkey not registered due to an existing credential. Remove the existing credential to continue.",
+        "description": "Passkey not registered due to an existing credential. Remove the existing credential to continue."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request canceled.",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "You are trying to register a new entry, but an entry associated with this website already exists.",
-        "description": "You are trying to register a new entry, but an entry associated with this website already exists."
+        "message": "The passkey could not be registered because the request was rejected due to an excluded existing credential. Try using a different account or removing the existing passkey entry.",
+        "description": "The passkey could not be registered because the request was rejected due to an excluded existing credential. Try using a different account or removing the existing passkey entry."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request canceled.",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "The passkey could not be registered because the request was rejected due to an excluded existing credential. Try using a different account or removing the existing passkey entry.",
-        "description": "The passkey could not be registered because the request was rejected due to an excluded existing credential. Try using a different account or removing the existing passkey entry."
+        "message": "Passkey not registered due to URL exclusion. Remove existing entry for this site or its exclusion.",
+        "description": "Passkey not registered due to URL exclusion. Remove existing entry for this site or its exclusion."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request canceled.",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "Credential is excluded.",
-        "description": "Credential is excluded."
+        "message": "You are trying to register a new entry, but an entry associated with this website already exists.",
+        "description": "You are trying to register a new entry, but an entry associated with this website already exists."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request canceled.",

--- a/keepassxc-browser/_locales/en_GB/messages.json
+++ b/keepassxc-browser/_locales/en_GB/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "Credential is excluded.",
-        "description": "Credential is excluded."
+        "message": "You are trying to register a new entry, but an entry associated with this website already exists.",
+        "description": "You are trying to register a new entry, but an entry associated with this website already exists."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request cancelled.",

--- a/keepassxc-browser/_locales/en_GB/messages.json
+++ b/keepassxc-browser/_locales/en_GB/messages.json
@@ -184,8 +184,8 @@
         "description": "Attestation not supported."
     },
     "errorMessagePasskeysCredentialIsExcluded": {
-        "message": "You are trying to register a new entry, but an entry associated with this website already exists.",
-        "description": "You are trying to register a new entry, but an entry associated with this website already exists."
+        "message": "Credential is excluded.",
+        "description": "Credential is excluded."
     },
     "errorMessagePasskeysRequestCanceled": {
         "message": "Passkeys request cancelled.",


### PR DESCRIPTION
See https://github.com/keepassxreboot/keepassxc-browser/issues/2033#issuecomment-4167130475

## Testing strategy
Did not test. 


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
