### PR TITLE
Fix input field detection when label contains overlaying elements

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -507,7 +507,8 @@ kpxcFields.isTopElement = function(elem, rect) {
     const getTopmostElement = (element, x, elementRect) => {
         const topElement = rootNode.elementFromPoint(x, elementRect.top + (elementRect.height / 2));
         return element?.labels &&
-            (element.labels[0] === topElement || element.labels[0].contains(topElement)) &&
+            (element.labels[0] === topElement ||
+                (element.labels[0] instanceof Node && element.labels[0].contains(topElement))) &&
             elementsOverlap(elementRect, topElement.getBoundingClientRect())
             ? element
             : topElement;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -506,9 +506,8 @@ kpxcFields.isTopElement = function(elem, rect) {
     // Also allows if the topmost element is a child of the label (e.g., span inside label).
     const getTopmostElement = (element, x, elementRect) => {
         const topElement = rootNode.elementFromPoint(x, elementRect.top + (elementRect.height / 2));
-        return element?.labels &&
-            (element.labels[0] === topElement ||
-                (element.labels[0] instanceof Node && element.labels[0].contains(topElement))) &&
+        return element?.labels instanceof NodeList &&
+            element.labels[0]?.contains(topElement) &&
             elementsOverlap(elementRect, topElement.getBoundingClientRect())
             ? element
             : topElement;

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -503,10 +503,11 @@ kpxcFields.isTopElement = function(elem, rect) {
 
     // Returns the topmost element from point x, height/2
     // If the input has a label as the top element and it's inside the input, allow it.
+    // Also allows if the topmost element is a child of the label (e.g., span inside label).
     const getTopmostElement = (element, x, elementRect) => {
         const topElement = rootNode.elementFromPoint(x, elementRect.top + (elementRect.height / 2));
         return element?.labels &&
-            element.labels[0] === topElement &&
+            (element.labels[0] === topElement || element.labels[0].contains(topElement)) &&
             elementsOverlap(elementRect, topElement.getBoundingClientRect())
             ? element
             : topElement;


### PR DESCRIPTION
Allow input field detection when the topmost element is a child of the label (e.g., span overlay in Material Design labels). This fixes detection on pages using <label><input/><span>Label</span></label> pattern where the span is positioned absolutely and blocks elementFromPoint.

This change allows to properly detect login and password fields on login pages based on Material Design, like the one my company uses. 

HTML snippet with the fields not properly detected: 
```
<form class="loginFormInputs" method="post" action="https://[REDACTED]" autocomplete="off" onsubmit="login.disabled = true; return true;">

            <label class="pure-material-textfield-outlined">
              <input type="text" id="username" name="username" placeholder="" autocorrect="off" required autofocus>
              <span>Login</span>
            </label>

            <label class="pure-material-textfield-outlined passwordField">
              <input type="password" id="password" name="password" placeholder="" required>
              <span>Password</span>
            </label>
</form>
```

## Screenshots or videos
<img width="433" height="269" alt="image" src="https://github.com/user-attachments/assets/995c1f30-4fc6-4f37-9b61-c837d38f0ba2" />


## Testing strategy

Tested on the login page of my company and it detects the fields properly. I also tried a few other websites and detection was still working. 

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
