### PR TITLE
Fix sending context menu message only to current frame

### DIFF
--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -59,6 +59,8 @@ const initListeners = async function() {
                 browser.tabs.sendMessage(tab.id, {
                     action: 'fill_attribute',
                     args: menuItem?.args
+                }, {
+                    frameId: item.frameId
                 }).catch((err) => {
                     logError(err);
                 });
@@ -69,6 +71,8 @@ const initListeners = async function() {
 
         browser.tabs.sendMessage(tab.id, {
             action: item.menuItemId
+        }, {
+            frameId: item.frameId
         }).catch((err) => {
             logError(err);
         });


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When running a command from context menu, currently the message is passed to all frames and content scripts. These should be restricted to the current frame only where the context menu is used.

* Fixes #2937

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually filling credentials via context menu at archive.org.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)