### PR TITLE
Fix filling credentials with readonly username

### DIFF
--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -245,16 +245,9 @@ kpxcFill.fillInCredentials = async function(combination, predefinedUsername, uui
         skipAutoSubmit = selectedCredentials.skipAutoSubmit === 'true';
     }
 
-    // Update the password field if form has been updated with a new identical element (Moodle).
-    // If found, replace the new input field to the combination.
-    if (combination?.form && combination?.password && !combination.form.contains(combination.password)) {
-        const formInputs = kpxcObserverHelper.getInputs(combination.form);
-        const newPasswordField = formInputs?.find((formInput) =>
-            formInput?.getLowerCaseAttribute('type') === 'password');
-        if (newPasswordField && areNamedNodeMapsEqual(combination.password.attributes, newPasswordField.attributes)) {
-            combination.password = newPasswordField;
-        }
-    }
+    // Additional checks
+    checkIdenticalPasswordFields(combination);
+    checkReadOnlyUsernameField(combination);
 
     // Fill password
     if (combination.password && matchesWithNodeName(combination.password, 'INPUT')) {
@@ -451,6 +444,27 @@ const showErrorNotification = async function(errorMessage, notificationType = 'e
     }
 };
 
+// Update the password field if form has been updated with a new identical element (Moodle).
+// If found, replace the new input field to the combination.
+const checkIdenticalPasswordFields = function(combination) {
+    if (combination?.form && combination?.password && !combination.form.contains(combination.password)) {
+        const newPasswordField = getPasswordFieldFromForm(combination);
+        if (newPasswordField && areNamedNodeMapsEqual(combination.password.attributes, newPasswordField.attributes)) {
+            combination.password = newPasswordField;
+        }
+    }
+};
+
+// Sometimes username field is changed to readOnly. Look for a password field instead inside the form.
+const checkReadOnlyUsernameField = function(combination) {
+    if (combination?.username && combination?.username?.readOnly && combination?.form && !combination?.password) {
+        const passwordField = getPasswordFieldFromForm(combination);
+        if (kpxcFields.isVisible(passwordField)) {
+            combination.password = passwordField;
+        }
+    }
+};
+
 // Checks if two NamedNodeMaps (attribute lists) are equal
 const areNamedNodeMapsEqual = function(currentNodeMap, newNodeMap) {
     if (!currentNodeMap || !newNodeMap) {
@@ -472,4 +486,13 @@ const areNamedNodeMapsEqual = function(currentNodeMap, newNodeMap) {
     }
 
     return true;
+};
+
+const getPasswordFieldFromForm = function(combination) {
+    if (!combination) {
+        return undefined;
+    }
+
+    const formInputs = kpxcObserverHelper.getInputs(combination.form);
+    return formInputs?.find((formInput) => formInput?.getLowerCaseAttribute('type') === 'password');
 };

--- a/keepassxc-browser/content/fill.js
+++ b/keepassxc-browser/content/fill.js
@@ -494,5 +494,7 @@ const getPasswordFieldFromForm = function(combination) {
     }
 
     const formInputs = kpxcObserverHelper.getInputs(combination.form);
-    return formInputs?.find((formInput) => formInput?.getLowerCaseAttribute('type') === 'password');
+    return formInputs?.find(
+        formInput => formInput?.getLowerCaseAttribute('type') === 'password' && !formInput?.readOnly
+    );
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
In some cases where a password fill is expected, username input field changed to readonly, and the Username Icon is not detected for the password input. Filling from the icon or using popup from the extension toolbar doesn't work. 

This fix adds a workaround for the previously unidentified password input to the combination, and performs the fill anyway with both scenarios.  Actual detection problem of the password field detection needs a lot more work, and is done separately because many other sites have the same issue.

Refactored some of the code, moving additional checks made during the fill to a separate functions.

* Fixes #2953

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using https://my.uclahealth.org/. No actual account needed to test the site.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
