### PR TITLE
Fix icon placement for two step login scenario where username is hidden

### DIFF
--- a/keepassxc-browser/content/icon-handler.js
+++ b/keepassxc-browser/content/icon-handler.js
@@ -53,10 +53,11 @@ kpxcIcons.addIconsFromForm = async function(form) {
                     kpxcIcons.addIcon(c.passwordInputs[0], kpxcIcons.iconTypes.DEFAULT);
                 }
             }
-
-            if (c.username && !c.username.readOnly && kpxcFields.isVisible(c.username)) {
+            const usernameFieldVisible = c.username && kpxcFields.isVisible(c.username);
+            
+            if (c.username && !c.username.readOnly && usernameFieldVisible) {
                 kpxcIcons.addIcon(c.username, kpxcIcons.iconTypes.DEFAULT);
-            } else if (c.password && (!c.username || c.username.readOnly || !kpxcFields.isVisible(c.username))) {
+            } else if (c.password && (!c.username || (c.username && (c.username.readOnly || !usernameFieldVisible)))) {
                 // Single password field, or username field is hidden (e.g. two-step login)
                 kpxcIcons.addIcon(c.password, kpxcIcons.iconTypes.DEFAULT);
             }

--- a/keepassxc-browser/content/icon-handler.js
+++ b/keepassxc-browser/content/icon-handler.js
@@ -54,10 +54,10 @@ kpxcIcons.addIconsFromForm = async function(form) {
                 }
             }
 
-            if (c.username && !c.username.readOnly) {
+            if (c.username && !c.username.readOnly && kpxcFields.isVisible(c.username)) {
                 kpxcIcons.addIcon(c.username, kpxcIcons.iconTypes.DEFAULT);
-            } else if (c.password && (!c.username || (c.username && c.username.readOnly))) {
-                // Single password field
+            } else if (c.password && (!c.username || c.username.readOnly || !kpxcFields.isVisible(c.username))) {
+                // Single password field, or username field is hidden (e.g. two-step login)
                 kpxcIcons.addIcon(c.password, kpxcIcons.iconTypes.DEFAULT);
             }
         }


### PR DESCRIPTION
In some two-step login scenarios, where the username is filled during the first step and the password is provided in the next, the icon placement might not work properly if the username input is kept hidden.

This fix checks whether username input is visible, if not then icon is displayed on password input.



## Screenshots or videos
<img width="1465" height="373" alt="screenshot_keepassxc_20260429" src="https://github.com/user-attachments/assets/94ed5f6d-dcb9-4143-9e8a-41ccd320a031" />


## Testing strategy
Manually tested on some corporate publicly inaccessible login screen. Currently I do not know of any other site that would have the same behaviour.


## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)


