### PR TITLE
Fix use of old TOTP

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -560,7 +560,7 @@ keepass.createNewGroup = async function(tab, args = []) {
 
 keepass.getTotp = async function(tab, args = []) {
     const [ uuid, oldTotp ] = args;
-    if (!keepass.featuresList.newTotpSupported) {
+    if (!keepass.featuresList.newTotp) {
         return oldTotp;
     }
 


### PR DESCRIPTION
Prior to this requested change `getTotp()` checked the `newTotpSupported` `featuresList` field, but this field is always undefined and always evaluates as falsy.  The actual name of the `featuresList` field that is defined is `newTotp`, so now with this change we check that field instead. This prevents old/stale TOTP values from being unnecessarily used.  Fixes #2972.

## Testing strategy
I manually tested on https://myaccount.uscis.gov/sign-in (*not* using login.gov sign-in method).

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)