### PR TITLE
Always create Credential Banner to the top window

### DIFF
--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -163,8 +163,9 @@ kpxcBanner.create = async function(credentials = {}) {
     this.shadowRoot.append(banner);
     kpxcBanner.wrapper = wrapper;
 
-    if (window.self === window.top && !kpxcBanner.created) {
-        window.parent.document.body.appendChild(wrapper);
+    // Always create the banner to the top document. Useful if we are inside an iframe.
+    if (!kpxcBanner.created) {
+        window.top.document.body.appendChild(wrapper);
         kpxcUI.observeWrapper(wrapper);
         kpxcBanner.created = true;
     }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If changed credentials are detected with a login form that is inside an iframe, the current comparison for `window.self` and `window.top` prevents creating the Credential Banner. Instead, if we want to show the banner, create it always to the root document (`window.top`).

* Fixes #2983

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using https://www.found.fi/en/auctions/. It will open a new tab after entering credentials, but the Credential Banner should be visible when returning to the tab.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
