### PR TITLE
Fix getting submitted username for Credential Banner

### DIFF
--- a/keepassxc-browser/content/form.js
+++ b/keepassxc-browser/content/form.js
@@ -267,9 +267,16 @@ kpxcForm.onSubmit = async function(e) {
     }
 
     // Use the first text field in the form if only username input is missing
-    const usernameValue = await kpxcForm.getUsernameValue(!usernameField && passwordField
+    let usernameValue = await kpxcForm.getUsernameValue(!usernameField && passwordField
         ? form?.querySelector('input[type=text]')
         : usernameField);
+
+    // If the form username differs (input has removed etc.) use the username stored in the submitted object
+    const creds = await sendMessage('page_get_submitted');
+    if (creds?.username && creds.username !== usernameValue) {
+        usernameValue = creds.username;
+    }
+
     await kpxcForm.activateCredentialBanner(usernameValue, passwordInputs, passwordField);
 };
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Sites with two phase login (a separate username and password field pages), when showing the Credential Banner, the username has no longer a valid input field inside the form. The value retrieved for the banner is empty, or incorrect value from another text input.

Instead, rely on the `page_get_submitted` request that has the previously entered username in the background script's memory. If the form username differs from the submitted one, use the previously submitted username. Pages where the login form that has both fields, the `page_get_submitted` returns an empty object, and the username value from the form is used normally.

* Fixes #2981

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Use site https://www.blsk.de/de/home.html or Microsoft login page to test the fix. Without the fix, username for the first page is always "1". With Microsoft's login page, the username is empty.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)