### PR TITLE
Offer the TOTP entry picker when no login was pre-selected for the page

### DIFF
--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -789,33 +789,39 @@ kpxc.updateDatabaseState = async function() {
 
 // Updates the TOTP Autocomplete Menu
 kpxc.updateTOTPList = async function() {
-    let uuid = await sendMessage('page_get_login_id');
-    if (uuid === undefined || kpxc.credentials.length === 0) {
-        // Credential haven't been selected
-        logDebug('Error: No credentials selected for TOTP.');
+    // Nothing was retrieved for this page at all -> genuinely nothing to offer.
+    if (kpxc.credentials.length === 0) {
+        logDebug('Error: No credentials available for TOTP.');
         return;
     }
 
-    // Use the first credential available if not set
-    if (uuid === '') {
-        uuid = kpxc.credentials[0].uuid;
+    const uuid = await sendMessage('page_get_login_id');
+
+    // A specific entry was used to log in on this page (via KeePassXC): keep the original
+    // behaviour and narrow to entries sharing its username (covers the "same account,
+    // TOTP stored in a separate database" use case, and auto-fills a single match).
+    if (uuid !== undefined && uuid !== '') {
+        const credentials = kpxc.credentials.find(c => c.uuid === uuid);
+        if (credentials) {
+            const username = credentials.login;
+            const password = credentials.password;
+
+            // If no username is set, compare with a password
+            const credentialList = kpxc.credentials.filter(c => kpxc.entryHasTotp(c)
+                && (c.login === username || (!username && c.password === password)));
+
+            // Filter TOTP Autocomplete Menu with matching 2FA credentials
+            kpxcTOTPAutocomplete.elements = kpxcUserAutocomplete.elements.filter(e => credentialList.some(u => u.uuid === e.uuid));
+            return credentialList;
+        }
     }
 
-    const credentials = kpxc.credentials.find(c => c.uuid === uuid);
-    if (credentials) {
-        const username = credentials.login;
-        const password = credentials.password;
-
-        // If no username is set, compare with a password
-        const credentialList = kpxc.credentials.filter(c => kpxc.entryHasTotp(c)
-            && (c.login === username || (!username && c.password === password)));
-
-        // Filter TOTP Autocomplete Menu with matching 2FA credentials
-        kpxcTOTPAutocomplete.elements = kpxcUserAutocomplete.elements.filter(e => credentialList.some(u => u.uuid === e.uuid));
-        return credentialList;
-    }
-
-    return [];
+    // No login was pre-selected for this page (e.g. an SSO flow lands straight on the 2FA
+    // step). Instead of giving up with "No TOTP found", offer EVERY entry that matches
+    // this page and has a TOTP, so fillFromTOTP() shows the picker for more than one match.
+    const credentialList = kpxc.credentials.filter(c => kpxc.entryHasTotp(c));
+    kpxcTOTPAutocomplete.elements = kpxcUserAutocomplete.elements.filter(e => credentialList.some(u => u.uuid === e.uuid));
+    return credentialList;
 };
 
 // Enable certain settings based on predefined sites list


### PR DESCRIPTION
## Summary

`kpxc.updateTOTPList()` returns early with **"No TOTP found."** whenever
`page_get_login_id` is `undefined` — i.e. whenever no entry was filled through
KeePassXC on the current tab. This is common with SSO / IdP flows that navigate
straight to a standalone 2FA code page: there is no preceding KeePassXC login on
that tab, so `getLoginId()` returns `undefined`, and the user never reaches the
entry picker that `fillFromTOTP()` already supports for multiple matches.

It is especially visible when several entries share one host (e.g. multiple
Microsoft 365 tenants on `login.microsoftonline.com`): clicking the in-field TOTP
icon just reports "No TOTP found." with no way to choose.

## Change

`updateTOTPList()` is restructured so that:

- it only bails when there are genuinely no credentials for the page;
- when a login **was** pre-selected, behaviour is unchanged (narrow to entries
  sharing that username; a single match still auto-fills);
- when **no** login was pre-selected, it returns every page-matching entry that
  has a TOTP, so `fillFromTOTP()` shows the existing picker for more than one
  match instead of failing.

Because it is user-initiated (clicking the in-field TOTP icon), it never silently
fills the wrong account — it only offers a choice.

## Related

Addresses the situation described in #1850 and #2622.

## Testing

- One matching TOTP entry, no prior login → fills directly (unchanged).
- Multiple matching TOTP entries, no prior login → picker now appears
  (previously "No TOTP found.").
- A prior KeePassXC login on the tab → unchanged (narrowed to the logged-in
  account).
