### PR TITLE
Fix typos in various places

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -127,7 +127,7 @@ For classes and enum-like Objects.
 
 For global/const variables and enum-like Object values.
 
-#### Indention
+#### Indentation
 - For **JavaScript files** (*.js): 4 spaces
 - For **HTML files** (*.ui*): 2 spaces
 - For **JSON files** (*.json): 2 spaces

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please see this [document](https://keepassxc.org/docs/KeePassXC_GettingStarted.h
 ## How it works
 
 KeePassXC-Browser communicates with KeePassXC through _keepassxc-proxy_. The proxy handles listening to STDIN/STDOUT
-and transfers these messages through Unix domain sockets / named pipes to KeePassXC. This means KeePassXC can be used and started normally without inteference from
+and transfers these messages through Unix domain sockets / named pipes to KeePassXC. This means KeePassXC can be used and started normally without interference from
 Native Messaging API. KeePassXC-Browser starts only the proxy application and there's no risk of shutting down KeePassXC or losing any unsaved changes. You don't need to install keepassxc-proxy separately. It is included in the KeePassXC application package. Alternatively you can use
 [keepassxc-proxy-rust](https://github.com/varjolintu/keepassxc-proxy-rust) as a proxy if you prefer a non-Qt solution.
 

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -694,7 +694,7 @@ keepass.migrateKeyRing = function() {
     return new Promise((resolve, reject) => {
         browser.storage.local.get('keyRing').then((item) => {
             const keyring = item.keyRing;
-            // Change dates to numbers, for compatibilty with Chromium based browsers
+            // Change dates to numbers, for compatibility with Chromium based browsers
             if (keyring) {
                 let num = 0;
                 for (const keyHash in keyring) {

--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -329,7 +329,7 @@ kpxcFields.getIdFromXPath = function(target) {
     return xpath;
 };
 
-// Generate uniqe ID from properties (new method)
+// Generate unique ID from properties (new method)
 kpxcFields.getIdFromProperties = function(target) {
     if (target.name) {
         return `${target.nodeName} ${target.type} ${target.name} ${target.placeholder}`;
@@ -365,7 +365,7 @@ kpxcFields.getElementFromXPathId = function(xpath) {
 
 // Checks if inputs or combinations contain segmented TOTP fields
 kpxcFields.handleSegmentedTOTPFields = function(inputs, combinations) {
-    // Check for multiple segmented TOTP fields when there are no inputs, or combination contains the segemented fields
+    // Check for multiple segmented TOTP fields when there are no inputs, or combination contains the segmented fields
     const segmentedFields = combinations.filter(c => c.totp);
     if (combinations.length === 0
         || segmentedFields.length === DEFAULT_SEGMENTED_TOTP_FIELDS
@@ -575,7 +575,7 @@ kpxcFields.prepareId = function(id) {
 };
 
 /**
- * Returns the first parent element satifying the {@code predicate} mapped by {@code resultFn} or else {@code defaultVal}.
+ * Returns the first parent element satisfying the {@code predicate} mapped by {@code resultFn} or else {@code defaultVal}.
  * @param {HTMLElement} element     The start element (excluded, starting with the parents)
  * @param {function} predicate      Matcher for the element to find, type (HTMLElement) => boolean
  * @param {function} resultFn       Callback function of type (HTMLElement) => {*} called for the first matching element

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -393,7 +393,7 @@ kpxc.initCredentialFields = async function() {
     }
 };
 
-// Intializes the login lists for popup and Autocomplete Menu
+// Initializes the login lists for popup and Autocomplete Menu
 kpxc.initLoginPopup = function() {
     if (kpxc.credentials.length === 0) {
         return;
@@ -612,7 +612,7 @@ kpxc.rememberCredentials = async function(usernameValue, passwordValue, urlValue
     return true;
 };
 
-// Save credentials triggered fron the context menu
+// Save credentials triggered from the context menu
 kpxc.rememberCredentialsFromContextMenu = async function() {
     if (kpxc.databaseState === DatabaseState.LOCKED) {
         kpxcUI.createNotification('error', tr('rememberErrorDatabaseClosed'));


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
I encountered the typo in the readme and decided to run codespell to check if there are more.

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )
unchanged: "splitted" (non-doc) and some in the changelog history which I didn't want to touch.
```text
codespell --skip="*.min.js,_locales"
./CHANGELOG:62: reseting ==> resetting
./CHANGELOG:437: owerflow ==> overflow
./CHANGELOG:592: wilcard ==> wildcard
./CHANGELOG:873: identation ==> indentation
./keepassxc-browser/content/banner.js:396: splitted ==> split
./keepassxc-browser/content/banner.js:399: splitted ==> split
./keepassxc-browser/content/banner.js:400: splitted ==> split
./keepassxc-browser/content/banner.js:403: splitted ==> split
./keepassxc-browser/content/banner.js:409: splitted ==> split
./keepassxc-browser/content/banner.js:410: splitted ==> split
./keepassxc-browser/content/ui.js:55: splitted ==> split
./keepassxc-browser/content/ui.js:56: splitted ==> split
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Documentation (non-code change)
