### PR TITLE
Update toolbar icons on every open tab in all windows

### DIFF
--- a/keepassxc-browser/background/browserAction.js
+++ b/keepassxc-browser/background/browserAction.js
@@ -8,13 +8,14 @@ browserAction.show = async function(tab, popupData) {
     page.popupData = popupData;
 
     browserActionWrapper.setIcon({
-        path: await browserAction.generateIconName(popupData.iconType)
+        path: await browserAction.generateIconName(popupData.iconType),
+        tabId: tab.id
     });
 
     if (popupData.popup && tab?.id) {
         browserActionWrapper.setPopup({
-            tabId: tab.id,
-            popup: `popups/${popupData.popup}.html`
+            popup: `popups/${popupData.popup}.html`,
+            tabId: tab.id
         });
 
         let badgeText = '';
@@ -38,6 +39,11 @@ browserAction.showDefault = async function(tab) {
     const response = await keepass.isConfigured().catch((err) => {
         logError('Cannot show default popup: ' + err);
     });
+
+    // This should not be possible. Database cannot be open without a hash.
+    if (!keepass.isDatabaseClosed && !keepass.associated.hash) {
+        return;
+    }
 
     if (!response && !keepass.isKeePassXCAvailable) {
         popupData.iconType = 'cross';

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -989,18 +989,25 @@ keepass.updateDatabase = async function() {
 
 keepass.updateDatabaseHashToContent = async function() {
     try {
-        const tab = await getCurrentTab();
-        if (tab?.id) {
-            // Send message to content script
-            browser.tabs.sendMessage(tab.id, {
-                action: 'check_database_hash',
-                hash: { old: keepass.previousDatabaseHash, new: keepass.databaseHash },
-                connected: keepass.isKeePassXCAvailable
-            }).catch((err) => {
-                logError('No content script available for this tab.');
-            });
-            keepass.previousDatabaseHash = keepass.databaseHash;
+        // Get all active tabs from all windows
+        const currentWindowTabs = await browser.tabs.query({ active: true, currentWindow: true, discarded: false });
+        const otherTabs = await browser.tabs.query({ active: true, currentWindow: false, discarded: false });
+        const allTabs = [ ...currentWindowTabs, ...otherTabs ];
+
+        for (const tab of allTabs) {
+            if (tab?.id) {
+                // Send message to content script
+                browser.tabs.sendMessage(tab.id, {
+                    action: 'check_database_hash',
+                    hash: { old: keepass.previousDatabaseHash, new: keepass.databaseHash },
+                    connected: keepass.isKeePassXCAvailable
+                }).catch((err) => {
+                    logError('No content script available for this tab.');
+                });
+            }
         }
+
+        keepass.previousDatabaseHash = keepass.databaseHash;
     } catch (err) {
         logError(`updateDatabaseHashToContent failed: ${err}`);
     }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If multiple windows are open, updating the toolbar icon did not work if database was changed, or opened/locked.

Added `tabId` parameter to `setIcon()` API call. Without it Firefox could understood that we are at current tab, but Chromium-based browsers did not update the icon correclty. For example the state would be displayed as `bang` (not connected to database) instead of `locked`.

In some cases `browserAction.show()` was triggered with Chromium-based browsers even when database was shown as open but the was no database hash available (yet). In this case the function should just return. Protocol V2 gets rid of this issue.

Modified `keepass.updateDatabaseHashToContent()` in a way that it first gets a list of all opened tabs from all windows, and triggers the toolbar icon change to all of those tabs instead of the current active one.

* Fixes #1616

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

Open a few windows and go to some page (new tab page does not count, because browsers ignore browser actions to those tabs) in each of them. Switch databases and lock/unlock them. Toolbar icon should change on all windows.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
