### PR TITLE
Display a translation placeholder missing error

### DIFF
--- a/keepassxc-browser/common/translate.js
+++ b/keepassxc-browser/common/translate.js
@@ -8,7 +8,7 @@ for (const item of items) {
         [ attr, key ] = trAttribute(key);
 
         const placeholder = item.getAttribute('data-i18n-placeholder');
-        const translation = placeholder ? browser.i18n.getMessage(key, placeholder) : browser.i18n.getMessage(key);
+        const translation = getTranslation(key, placeholder);
         if (attr) {
             item.setAttribute(attr, translation);
         } else if (item.hasAttribute('href')) {
@@ -31,4 +31,13 @@ function trAttribute(key) {
     }
 
     return [ attr, key ];
+}
+
+function getTranslation(key, placeholder) {
+    const translation = placeholder ? browser.i18n.getMessage(key, placeholder) : browser.i18n.getMessage(key);
+    if (placeholder && !translation.includes(placeholder)) {
+        return '(Error! Missing a placeholder in translation!) ' + placeholder;
+    }
+
+    return translation;
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If a translation string is missing a placeholder, the whole page will not be rendered because of an exception. Wrap the translation to a function that detects if the placeholder is missing from the translated string. In that case, return a static string for an error. The placeholder must be added to that string for the rendering to succeed.

This can happen only with Firefox.

Related issue #3014

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Remove `$1` from https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/_locales/en/messages.json#L1066 and reload the extension in Firefox. Go to the options page. Without the fix, the page is blank.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
