### PR TITLE
Fix a few TOTP identification bugs

### DIFF
--- a/keepassxc-browser/content/totp-field.js
+++ b/keepassxc-browser/content/totp-field.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const ignoreRegex = /(bank|coupon|post(al)?|user|zip|promo).*code|(en|de)code(d|r)*|comment|author|error/i;
-const ignoredTypes = [ 'email', 'password', 'username' ];
+const ignoreRegex = /(bank|bar|coupon|post(al)?|user|zip|promo).*code|(en|de)code(d|r)*|comment|author|error/i;
+const ignoredTypes = [ 'email', 'username' ];
 const allowedInputTypes = [ 'number', 'password', 'tel', 'text' ];
 
 const acceptedOTPFields = [
@@ -13,8 +13,10 @@ const acceptedOTPFields = [
     'idvpin',
     'mfa',
     'one_time_password',
+    'one-time password',
     'otc-confirmation-input',
     'otp',
+    'otppw',
     'token',
     'twofa',
     'two-factor',


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Fixes a few TOTP identification bugs.

First, we have a list of accepted TOTP fields, but the `ignoredTypes` field included `password` which eliminated the identification for `one-time password` variants in the allowed list. This could cause some new false-positives, but this should not be prevented.

Second, the ignore regex must include `bar` for `barcode`.

* Fixes #3028
* Fixes #3030

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

Manually using the HTML codes provided in issues in a local site.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)