### PR TITLE
[passkeys] Fixes unhandled callback, double response errors & wrong return type

### DIFF
--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -620,7 +620,7 @@ keepass.passkeysRegister = async function(tab, args = []) {
         const taResponse = await keepass.testAssociation(tab, [ false ]);
         if (!taResponse || !keepass.isConnected || args.length < 2) {
             browserAction.showDefault(tab);
-            return [];
+            return null;
         }
 
         const kpAction = kpActions.PASSKEYS_REGISTER;
@@ -644,10 +644,10 @@ keepass.passkeysRegister = async function(tab, args = []) {
         }
 
         browserAction.showDefault(tab);
-        return [];
+        return null;
     } catch (err) {
         logError(`passkeysRegister failed: ${err}`);
-        return [];
+        return null;
     }
 };
 
@@ -656,7 +656,7 @@ keepass.passkeysGet = async function(tab, args = []) {
         const taResponse = await keepass.testAssociation(tab, [ false ]);
         if (!taResponse || !keepass.isConnected || args.length < 2) {
             browserAction.showDefault(tab);
-            return [];
+            return null;
         }
 
         const kpAction = kpActions.PASSKEYS_GET;
@@ -679,10 +679,10 @@ keepass.passkeysGet = async function(tab, args = []) {
         }
 
         browserAction.showDefault(tab);
-        return [];
+        return null;
     } catch (err) {
         logError(`passkeysGet failed: ${err}`);
-        return [];
+        return null;
     }
 };
 
@@ -828,7 +828,7 @@ keepass.reconnect = async function(tab = null, connectionTimeout = 1500) {
     } else {
         keepassClient.connectToNative();
     }
-    
+
     keepass.generateNewKeyPair();
     const keyChangeResult = await keepass
         .changePublicKeys(tab, !!connectionTimeout, connectionTimeout)

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -58,9 +58,13 @@ const enablePasskeys = async function() {
     const sendResponse = async function(command, publicKey) {
         const lifetimeTimer = startTimer(publicKey?.timeout);
 
-        const ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
-        if (ret) {
-            passkeysLogDebug('Passkey response', ret.response);
+        let ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
+        passkeysLogDebug('Passkey response', ret);
+
+        // Any error not related to passkeys (no connection to KPXC, database not opened, unknown error, etc.)
+        if (ret === null) {
+            ret = { response: { errorCode: PASSKEYS_REQUEST_CANCELED } };
+        }
 
             let errorMessage;
             if (ret.response?.errorCode) {
@@ -78,7 +82,6 @@ const enablePasskeys = async function() {
             kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
             lifetimeTimer.promise.catch(() => {}); // prevent error in console
             lifetimeTimer.abort();
-        }
     };
 
     const isSameOriginWithAncestors = function () {

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -58,7 +58,7 @@ const enablePasskeys = async function() {
     const sendResponse = async function(command, publicKey) {
         const lifetimeTimer = startTimer(publicKey?.timeout);
 
-        let ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
+        let ret = await chrome.runtime.sendMessage({ action: command, args: [publicKey, window.location.origin] });
         passkeysLogDebug('Passkey response', ret);
 
         // Any error not related to passkeys (no connection to KPXC, database not opened, unknown error, etc.)
@@ -66,22 +66,22 @@ const enablePasskeys = async function() {
             ret = { response: { errorCode: PASSKEYS_REQUEST_CANCELED } };
         }
 
-            let errorMessage;
-            if (ret.response?.errorCode) {
-                errorMessage = await chrome.runtime.sendMessage({
-                    action: 'get_error_message',
-                    args: ret.response.errorCode,
-                });
-                kpxcUI.createNotification('error', errorMessage);
+        let errorMessage;
+        if (ret.response?.errorCode) {
+            errorMessage = await chrome.runtime.sendMessage({
+                action: 'get_error_message',
+                args: ret.response.errorCode,
+            });
+            kpxcUI.createNotification('error', errorMessage);
 
-                if (!kpxcPasskeysUtils.passkeysFallback && letTimerRunOut(ret.response.errorCode)) {
-                    await lifetimeTimer.promise;
-                }
+            if (!kpxcPasskeysUtils.passkeysFallback && letTimerRunOut(ret.response.errorCode)) {
+                await lifetimeTimer.promise;
             }
+        }
 
-            kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
-            lifetimeTimer.promise.catch(() => {}); // prevent error in console
-            lifetimeTimer.abort();
+        kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
+        lifetimeTimer.promise.catch(() => { }); // prevent error in console
+        lifetimeTimer.abort();
     };
 
     const isSameOriginWithAncestors = function () {

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -2,6 +2,7 @@
 
 const PASSKEYS_NO_LOGINS_FOUND = 15;
 const PASSKEYS_CREDENTIAL_IS_EXCLUDED = 21;
+const PASSKEYS_REQUEST_CANCELED = 22;
 const PASSKEYS_WAIT_FOR_LIFETIMER = 30;
 
 // Apply a script to the page for intercepting Passkeys (WebAuthn) requests
@@ -43,12 +44,15 @@ const enablePasskeys = async function() {
         };
     };
 
+    // https://www.w3.org/TR/webauthn-2/#sctn-assertion-privacy
+    // https://www.w3.org/TR/webauthn-2/#sctn-getAssertion:~:text=constructAssertionAlg%20and%20terminate%20this%20algorithm%2E-,Return,details
     const letTimerRunOut = function (errorCode) {
-        return (
-            errorCode === PASSKEYS_WAIT_FOR_LIFETIMER ||
-            errorCode === PASSKEYS_CREDENTIAL_IS_EXCLUDED ||
-            errorCode === PASSKEYS_NO_LOGINS_FOUND
-        );
+        return [
+            PASSKEYS_NO_LOGINS_FOUND,
+            PASSKEYS_CREDENTIAL_IS_EXCLUDED,
+            PASSKEYS_REQUEST_CANCELED,
+            PASSKEYS_WAIT_FOR_LIFETIMER,
+        ].includes(errorCode);
     };
 
     const sendResponse = async function(command, publicKey) {

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -39,7 +39,7 @@ const enablePasskeys = async function() {
             promise,
             abort() {
                 clearTimeout(timerId);
-                reject();
+                reject('the timer has been aborted');
             }
         };
     };
@@ -60,6 +60,8 @@ const enablePasskeys = async function() {
 
         const ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
         if (ret) {
+            passkeysLogDebug('Passkey response', ret.response);
+
             let errorMessage;
             if (ret.response?.errorCode) {
                 errorMessage = await chrome.runtime.sendMessage({
@@ -73,8 +75,8 @@ const enablePasskeys = async function() {
                 }
             }
 
-            passkeysLogDebug('Passkey response', ret.response);
             kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
+            lifetimeTimer.promise.catch(() => {}); // prevent error in console
             lifetimeTimer.abort();
         }
     };

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -28,12 +28,12 @@ const enablePasskeys = async function() {
     const startTimer = function (timeout) {
         let resolve, reject;
         /** @type {Promise<void>} */
-        let promise = new Promise((_resolve, _reject) => {
+        const promise = new Promise((_resolve, _reject) => {
             resolve = _resolve;
             reject = _reject;
         });
 
-        let timerId = setTimeout(resolve, timeout);
+        const timerId = setTimeout(resolve, timeout);
 
         return {
             promise,
@@ -58,28 +58,26 @@ const enablePasskeys = async function() {
     const sendResponse = async function(command, publicKey) {
         const lifetimeTimer = startTimer(publicKey?.timeout);
 
-        let ret = await chrome.runtime.sendMessage({ action: command, args: [publicKey, window.location.origin] });
+        const ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
         passkeysLogDebug('Passkey response', ret);
 
-        // Any error not related to passkeys (no connection to KPXC, database not opened, unknown error, etc.)
-        if (ret === null) {
-            ret = { response: { errorCode: PASSKEYS_REQUEST_CANCELED } };
-        }
-
+        // `null` - any error not related to passkeys (no connection to KPXC, database not opened, unknown error, etc.)
+        const errorCode = ret === null ? PASSKEYS_REQUEST_CANCELED : ret.response.errorCode;
         let errorMessage;
-        if (ret.response?.errorCode) {
+
+        if (errorCode) {
             errorMessage = await chrome.runtime.sendMessage({
                 action: 'get_error_message',
-                args: ret.response.errorCode,
+                args: errorCode,
             });
             kpxcUI.createNotification('error', errorMessage);
 
-            if (!kpxcPasskeysUtils.passkeysFallback && letTimerRunOut(ret.response.errorCode)) {
+            if (!kpxcPasskeysUtils.passkeysFallback && letTimerRunOut(errorCode)) {
                 await lifetimeTimer.promise;
             }
         }
 
-        kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
+        kpxcPasskeysUtils.sendPasskeysResponse(ret.response, errorCode, errorMessage);
         lifetimeTimer.promise.catch(() => { }); // prevent error in console
         lifetimeTimer.abort();
     };

--- a/keepassxc-browser/content/passkeys-inject.js
+++ b/keepassxc-browser/content/passkeys-inject.js
@@ -21,16 +21,26 @@ const enablePasskeys = async function() {
     document.documentElement.appendChild(passkeys);
     passkeys.remove();
 
-    const startTimer = function(timeout) {
-        return setTimeout(() => {
-            throw new DOMException('lifetimeTimer has expired', 'NotAllowedError');
-        }, timeout);
-    };
+    /**
+     * @param {number=} timeout
+     */
+    const startTimer = function (timeout) {
+        let resolve, reject;
+        /** @type {Promise<void>} */
+        let promise = new Promise((_resolve, _reject) => {
+            resolve = _resolve;
+            reject = _reject;
+        });
 
-    const stopTimer = function(lifetimeTimer) {
-        if (lifetimeTimer) {
-            clearTimeout(lifetimeTimer);
-        }
+        let timerId = setTimeout(resolve, timeout);
+
+        return {
+            promise,
+            abort() {
+                clearTimeout(timerId);
+                reject();
+            }
+        };
     };
 
     const letTimerRunOut = function (errorCode) {
@@ -41,29 +51,27 @@ const enablePasskeys = async function() {
         );
     };
 
-    const sendResponse = async function(command, publicKey, callback) {
+    const sendResponse = async function(command, publicKey) {
         const lifetimeTimer = startTimer(publicKey?.timeout);
 
         const ret = await chrome.runtime.sendMessage({ action: command, args: [ publicKey, window.location.origin ] });
         if (ret) {
             let errorMessage;
-            if (ret.response && ret.response.errorCode) {
+            if (ret.response?.errorCode) {
                 errorMessage = await chrome.runtime.sendMessage({
                     action: 'get_error_message',
                     args: ret.response.errorCode,
                 });
                 kpxcUI.createNotification('error', errorMessage);
 
-                if (kpxcPasskeysUtils.passkeysFallback) {
-                    kpxcPasskeysUtils.sendPasskeysResponse(undefined, ret.response?.errorCode, errorMessage);
-                } else if (letTimerRunOut(ret?.response?.errorCode)) {
-                    return;
+                if (!kpxcPasskeysUtils.passkeysFallback && letTimerRunOut(ret.response.errorCode)) {
+                    await lifetimeTimer.promise;
                 }
             }
 
             passkeysLogDebug('Passkey response', ret.response);
             kpxcPasskeysUtils.sendPasskeysResponse(ret.response, ret.response?.errorCode, errorMessage);
-            stopTimer(lifetimeTimer);
+            lifetimeTimer.abort();
         }
     };
 

--- a/keepassxc-browser/content/passkeys.js
+++ b/keepassxc-browser/content/passkeys.js
@@ -1,6 +1,7 @@
 'use strict';
 
 (async () => {
+    const PASSKEYS_NO_LOGINS_FOUND = 15;
     const PASSKEYS_ATTESTATION_NOT_SUPPORTED = 20;
     const PASSKEYS_CREDENTIAL_IS_EXCLUDED = 21;
     const PASSKEYS_REQUEST_CANCELED = 22;
@@ -163,18 +164,13 @@
         });
     };
 
-    // Throws errors to a correct exceptions
+    /**
+     * Throws errors to a correct exceptions
+     * @param {number} errorCode
+     * @param {string} errorMessage
+     * @returns {never}
+     */
     const throwError = function(errorCode, errorMessage) {
-        if ((!errorCode && !errorMessage) || errorCode === PASSKEYS_REQUEST_CANCELED) {
-            // No error or canceled by user. Stop the timer but throw no exception. Fallback with be called instead.
-            return;
-        }
-
-        if (errorCode === PASSKEYS_WAIT_FOR_LIFETIMER || errorCode === PASSKEYS_CREDENTIAL_IS_EXCLUDED) {
-            // Timer handled in the content script
-            return;
-        }
-
         if ([ PASSKEYS_DOMAIN_RPID_MISMATCH, PASSKEYS_DOMAIN_IS_NOT_VALID ].includes(errorCode)) {
             throw new DOMException(errorMessage, DOMException.SECURITY_ERR);
         }
@@ -189,6 +185,10 @@
 
         if (
             [
+                PASSKEYS_NO_LOGINS_FOUND,
+                PASSKEYS_CREDENTIAL_IS_EXCLUDED,
+                PASSKEYS_REQUEST_CANCELED,
+                PASSKEYS_WAIT_FOR_LIFETIMER,
                 PASSKEYS_ATTESTATION_NOT_SUPPORTED,
                 PASSKEYS_INVALID_URL_PROVIDED,
                 PASSKEYS_INVALID_USER_VERIFICATION,
@@ -219,7 +219,6 @@
             if (!response.publicKey) {
                 if (!response.fallback) {
                     throwError(response?.errorCode, response?.errorMessage);
-                    return null;
                 }
                 await waitForFocus();
                 return originalCredentials.create(options);
@@ -244,7 +243,6 @@
             if (!response.publicKey) {
                 if (!response.fallback) {
                     throwError(response?.errorCode, response?.errorMessage);
-                    return null;
                 }
                 await waitForFocus();
                 return originalCredentials.get(options);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Fixed errors in processing error messages when passkeys are missing or a request is rejected.

1. The `setTimeout` callback was returning an error that was silently discarded. As a result, the page context never received the error, and the `Promise` remained pending forever.

2. When `kpxcPasskeysUtils.passkeysFallback === true`, `kpxcPasskeysUtils.sendPasskeysResponse` was being called (and sending a response) twice because of a missing `return ;`.

3. According to the WebAuthn specification, cancelled or rejected operations always return errors, not `null`. Some websites don’t expect this and throw a script error on the page, which also leads to an endless wait for UI updates. (<https://www.w3.org/TR/webauthn-2/#sctn-getAssertion>)

4. Fix lost callback on DB connection failure

------

- Fixes #3045
- Fixes #2501

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

On <https://webauthn.io/>

1. Try to authenticate without passkeys. Wait for the timeout (1 min).
2. Register.
3. Try to authenticate, but reject the passkey request. Wait for the timeout.

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )

- [`Promise.withResolvers` browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers#browser_compatibility), [Firefox `strict_min_version`](https://github.com/keepassxreboot/keepassxc-browser/blob/d1ab3b4eb56bfb0a86779ca4775b3c364ffd0156/dist/manifest_firefox.json#L189)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Refactor (significant modification to existing code)
