### PR TITLE
Fix search form detection for route names

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -401,8 +401,17 @@ kpxcFields.isCustomLoginFieldsUsed = function() {
 kpxcFields.isSearchForm = function(form) {
     // Check form action
     const formAction = form.getLowerCaseAttribute('action');
-    if (formAction?.includes('search') && !formAction?.includes('research')) {
-        return true;
+    if (formAction) {
+        try {
+            // Match search as a URL path or query token. A substring match is too broad:
+            // Keycloak's /realms/opensearch/... login action was incorrectly rejected.
+            const actionUrl = new URL(formAction, document.location.href);
+            if (/(?:^|[/?&=_-])search(?:$|[/?&=_.-])/.test(actionUrl.pathname + actionUrl.search)) {
+                return true;
+            }
+        } catch (_err) {
+            // Keep evaluating the form's other identifying properties below.
+        }
     }
 
     // Ignore form with search classes

--- a/tests/assert.js
+++ b/tests/assert.js
@@ -69,8 +69,8 @@ async function assertSearchField(classStr, properties, testName, expectedResult)
     kpxcAssert(isSearchfield, expectedResult, Tests.SEARCH_FIELDS, testName);
 }
 
-async function assertSearchForm(properties, testName, expectedResult) {
-    const form = kpxcUI.createElement('form', '', { action: 'search' });
+async function assertSearchForm(action, properties, testName, expectedResult) {
+    const form = kpxcUI.createElement('form', '', { action: action });
     const input = kpxcUI.createElement('input', '', properties);
     form.appendChild(input);
     document.body.appendChild(form);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -50,7 +50,9 @@ async function testSearchFields() {
         assertSearchField(field[0], field[1], field[2], field[3]);
     }
 
-    assertSearchForm({ id: 'username', type: 'text', }, 'Generic input field under search form', true);
+    assertSearchForm('/search', { id: 'username', type: 'text', }, 'Generic input field under search form', true);
+    assertSearchForm('/realms/opensearch/login-actions/authenticate',
+        { id: 'username', type: 'text', }, 'Input field under an OpenSearch realm login form', false);
 }
 
 // TOTP fields (kpxcTOTPIcons)


### PR DESCRIPTION
## Summary

Avoid treating every form whose action merely contains the substring `search` as a search form. The check now recognises `search` as a route or query token, avoiding false positives for authentication routes with compound route names while retaining normal search-form filtering.

Adds regression coverage for a login form whose route name contains `opensearch`.

## Validation

- `npm run lint`

## Attribution

Implemented and validated by Codex, an AI coding agent, under the contributor's direction.