### PR TITLE
Initialize Custom Login Fields when automatic detection finds no fields

### DIFF
--- a/keepassxc-browser/content/custom-fields-banner.js
+++ b/keepassxc-browser/content/custom-fields-banner.js
@@ -334,6 +334,7 @@ kpxcCustomLoginFieldsBanner.confirm = async function(e) {
     if (!kpxc.settings[DEFINED_CUSTOM_FIELDS]) {
         kpxc.settings[DEFINED_CUSTOM_FIELDS] = {};
     }
+    let fieldsUpdated = false;
 
     // If the new selection is already used in some other field, clear it
     const clearIdenticalField = function(path, location) {
@@ -395,9 +396,13 @@ kpxcCustomLoginFieldsBanner.confirm = async function(e) {
         }
 
         await sendMessage('save_settings', kpxc.settings);
+        fieldsUpdated = true;
     }
 
     kpxcCustomLoginFieldsBanner.destroy();
+    if (fieldsUpdated) {
+        await kpxc.initCredentialFields();
+    }
     sendMessageToFrames(e, 'confirm_button_clicked');
 };
 

--- a/keepassxc-browser/content/keepassxc-browser.js
+++ b/keepassxc-browser/content/keepassxc-browser.js
@@ -361,7 +361,10 @@ kpxc.initCredentialFields = async function() {
 
     // Search all remaining inputs from the page, ignore the previous input fields
     const pageInputs = await kpxcFields.getAllPageInputs(formInputs);
-    if (formInputs.length === 0 && pageInputs.length === 0) {
+    // Custom Login Fields can create valid combinations even when the automatic
+    // detector rejects every input (for example, a Keycloak OpenSearch realm).
+    // Do not return before initializing those combinations.
+    if (formInputs.length === 0 && pageInputs.length === 0 && kpxc.combinations.length === 0) {
         // Run 'redetect_credentials' manually if no fields are found after a page load
         setTimeout(async function() {
             if (_called.automaticRedetectCompleted) {


### PR DESCRIPTION
## Summary

Custom Login Fields intentionally provide an override when automatic field detection cannot identify a login form. Previously, if automatic detection returned no fields, initialization returned before the custom-field combination could initialise icons or request credentials. This keeps valid custom combinations active and reinitialises them immediately after a selection is saved.

## Validation

- `npm run lint`

## Attribution

Implemented and validated by Codex, an AI coding agent, under the contributor's direction.