### PR TITLE
Do not allow creating or updating entries with placeholders

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig([globalIgnores(["**/*.min.js"]), {
             cloneInto: "readonly",
             compareVersion: "readonly",
             ConnectionMethod: "readonly",
+            containsPlaceholder: "readonly",
             createResult: "readonly",
             createStylesheet: "readonly",
             CreationError: "readonly",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig([globalIgnores(["**/*.min.js"]), {
             ConnectionMethod: "readonly",
             createResult: "readonly",
             createStylesheet: "readonly",
+            CreationError: "readonly",
             DatabaseState: "readonly",
             debugLogMessage: "readonly",
             DEFINED_CUSTOM_FIELDS: "readonly",

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -578,10 +578,6 @@
         "message": "Credentials cannot be saved or updated to a closed database.",
         "description": "Error message shown when credentials cannot be saved or updated and the database is closed."
     },
-    "rememberErrorReferencesUsed": {
-        "message": "References cannot be saved with username or password.",
-        "description": "Error message shown when references were used when saving credentials."
-    },
     "rememberCredentialsNotSaved": {
         "message": "Operation cancelled. Credentials are not updated.",
         "description": "Message shown when saving operation was cancelled."

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -239,6 +239,10 @@
         "message": "Context is not secure.",
         "description": "Context is not secure."
     },
+    "errorMessageCannotUseReferences": {
+        "message": "Username or password cannot contain references.",
+        "description": "Username or password cannot contain references."
+    },
     "errorNotConnected": {
         "message": "Not connected to KeePassXC.",
         "description": "Error notification shown when not connected to KeePassXC."

--- a/keepassxc-browser/_locales/en/messages.json
+++ b/keepassxc-browser/_locales/en/messages.json
@@ -574,6 +574,10 @@
         "message": "Credentials cannot be saved or updated to a closed database.",
         "description": "Error message shown when credentials cannot be saved or updated and the database is closed."
     },
+    "rememberErrorReferencesUsed": {
+        "message": "References cannot be saved with username or password.",
+        "description": "Error message shown when references were used when saving credentials."
+    },
     "rememberCredentialsNotSaved": {
         "message": "Operation cancelled. Credentials are not updated.",
         "description": "Message shown when saving operation was cancelled."

--- a/keepassxc-browser/background/client.js
+++ b/keepassxc-browser/background/client.js
@@ -44,6 +44,7 @@ const kpErrors = {
     PASSKEYS_UNKNOWN_ERROR: 31,
     PASSKEYS_INVALID_CHALLENGE: 32,
     PASSKEYS_INVALID_USER_ID: 33,
+    CANNOT_USE_REFERENCES: 34,
 
     errorMessages: {
         0: { msg: tr('errorMessageUnknown') },
@@ -80,6 +81,7 @@ const kpErrors = {
         31: { msg: tr('errorMessagePasskeysUnknownError') },
         32: { msg: tr('errorMessagePasskeysInvalidChallenge') },
         33: { msg: tr('errorMessagePasskeysInvalidUserId') },
+        34: { msg: tr('errorMessageCannotUseReferences') },
     },
 
     getError(errorCode) {

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -28,6 +28,7 @@ keepass.serverPublicKey = '';
 
 const DEFAULT_FETCH_TIMEOUT = 5000; // ms
 const MAX_RELATED_ORIGIN_LABELS = 60;
+const REF_MARKER = '{REF:';
 
 const kpActions = {
     SET_LOGIN: 'set-login',
@@ -65,6 +66,12 @@ keepass.addCredentials = async function(tab, args = []) {
 keepass.updateCredentials = async function(tab, args = []) {
     try {
         const [ entryId, username, password, url, group, groupUuid ] = args;
+
+        if (username?.includes(REF_MARKER) || password?.includes(REF_MARKER)) {
+            logError('References are not allowed in username or password');
+            return CreationError.REFERENCES;
+        }
+
         const taResponse = await keepass.testAssociation(tab);
         if (!taResponse) {
             browserAction.showDefault(tab);
@@ -102,12 +109,12 @@ keepass.updateCredentials = async function(tab, args = []) {
             // KeePassXC versions lower than 2.5.0 will have an empty parsed.error
             let successMessage = response.error;
             if (response.error === 'success' || response.error === '') {
-                successMessage = entryId ? 'updated' : 'created';
+                successMessage = entryId ? CreationError.UPDATED : CreationError.CREATED;
             }
 
             return successMessage;
         } else {
-            return 'error';
+            return CreationError.GENERAL;
         }
     } catch (err) {
         logError(`updateCredentials failed: ${err}`);

--- a/keepassxc-browser/background/keepass.js
+++ b/keepassxc-browser/background/keepass.js
@@ -28,7 +28,6 @@ keepass.serverPublicKey = '';
 
 const DEFAULT_FETCH_TIMEOUT = 5000; // ms
 const MAX_RELATED_ORIGIN_LABELS = 60;
-const REF_MARKER = '{REF:';
 
 const kpActions = {
     SET_LOGIN: 'set-login',
@@ -67,7 +66,7 @@ keepass.updateCredentials = async function(tab, args = []) {
     try {
         const [ entryId, username, password, url, group, groupUuid ] = args;
 
-        if (username?.includes(REF_MARKER) || password?.includes(REF_MARKER)) {
+        if (containsPlaceholder(username) || containsPlaceholder(password)) {
             logError('References are not allowed in username or password');
             return CreationError.REFERENCES;
         }

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -40,6 +40,14 @@ const BannerPosition = {
     TOP: 1
 };
 
+const CreationError = {
+    CANCELED: 'canceled',
+    CREATED: 'created',
+    GENERAL: 'error',
+    REFERENCES: 'references',
+    UPDATED: 'updated'
+};
+
 const ManualFill = {
     NONE: 0,
     PASSWORD: 1,

--- a/keepassxc-browser/common/global.js
+++ b/keepassxc-browser/common/global.js
@@ -190,6 +190,50 @@ const trimURL = function(url) {
     return url.indexOf('?') !== -1 ? url.split('?')[0] : url;
 };
 
+const DYNAMIC_PLACEHOLDERS = [
+    'DT_',
+    'REF:',
+    'S:',
+    'T-CONV:',
+    'T-REPLACE-RX:',
+    'URL:'
+];
+
+const STATIC_PLACEHOLDERS = [
+    'DB_DIR',
+    'NOTES',
+    'PASSWORD',
+    'TITLE',
+    'TOTP',
+    'USERNAME',
+    'URL'
+];
+
+const containsPlaceholder = function(str) {
+    const placeholderRegex = new RegExp('{(.*?)}');
+
+    const placeholderFound = placeholderRegex.exec(str);
+    if (placeholderFound === null) {
+        return false;
+    }
+
+    let placeholder = placeholderFound[1];
+    if (placeholder.endsWith('\\')) {
+        // Remove escape if placeholder is used with \\{PLACEHOLDER\\}
+        placeholder = placeholder.slice(0, -1);
+    }
+
+    if (STATIC_PLACEHOLDERS.includes(placeholder)) {
+        return true;
+    }
+
+    if (DYNAMIC_PLACEHOLDERS.some((pl) => placeholder.startsWith(pl))) {
+        return true;
+    }
+
+    return false;
+};
+
 const debugLogMessage = function(message, extra) {
     console.debug(`[Debug ${getFileAndLine()}] ${EXTENSION_NAME} - ${message}`);
 
@@ -228,6 +272,7 @@ const elementsOverlap = function(rect1, rect2) {
 // Exports for tests
 if (typeof module === 'object') {
     module.exports = {
+        containsPlaceholder,
         compareVersion,
         elementsOverlap,
         matchesWithNodeName,

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -372,7 +372,7 @@ kpxcBanner.verifyResult = async function(code) {
     if (code === CreationError.GENERAL) {
         kpxcUI.createNotification('error', tr('rememberErrorCannotSaveCredentials'));
     } else if (code === CreationError.REFERENCES) {
-        kpxcUI.createNotification('error', tr('rememberErrorReferencesUsed'));
+        kpxcUI.createNotification('error', tr('errorMessageCannotUseReferences'));
     } else if (code === CreationError.CREATED) {
         kpxcUI.createNotification(
             'success',

--- a/keepassxc-browser/content/banner.js
+++ b/keepassxc-browser/content/banner.js
@@ -369,21 +369,23 @@ kpxcBanner.updateCredentials = async function(credentials = {}) {
 };
 
 kpxcBanner.verifyResult = async function(code) {
-    if (code === 'error') {
+    if (code === CreationError.GENERAL) {
         kpxcUI.createNotification('error', tr('rememberErrorCannotSaveCredentials'));
-    } else if (code === 'created') {
+    } else if (code === CreationError.REFERENCES) {
+        kpxcUI.createNotification('error', tr('rememberErrorReferencesUsed'));
+    } else if (code === CreationError.CREATED) {
         kpxcUI.createNotification(
             'success',
             tr('rememberCredentialsSaved', kpxcBanner.credentials.username || tr('rememberEmptyUsername')),
         );
         await kpxc.retrieveCredentials(true); // Forced reload
-    } else if (code === 'updated') {
+    } else if (code === CreationError.UPDATED) {
         kpxcUI.createNotification(
             'success',
             tr('rememberCredentialsUpdated', kpxcBanner.credentials.username || tr('rememberEmptyUsername')),
         );
         await kpxc.retrieveCredentials(true); // Forced reload
-    } else if (code === 'canceled') {
+    } else if (code === CreationError.CANCELED) {
         kpxcUI.createNotification('warning', tr('rememberCredentialsNotSaved'));
     } else {
         kpxcUI.createNotification('error', tr('rememberErrorDatabaseClosed'));

--- a/tests/global.spec.ts
+++ b/tests/global.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
+    containsPlaceholder,
     compareVersion,
     elementsOverlap,
     matchesWithNodeName,
@@ -133,5 +134,27 @@ test('Test elementsOverlap()', async ({ page }) => {
 
     // Overlay is outside the input field
     expect(elementsOverlap(inputRect, { left: 210, top: 0, right: 240, bottom: 40 })).toBe(false);
+});
+
+test('Test containsPlaceholder()', async ({ page }) => {
+    // Dynamic placeholders
+    expect(containsPlaceholder('')).toBe(false);
+    expect(containsPlaceholder('testString{REF:nothing')).toBe(false); // Placeholder is not finished
+    expect(containsPlaceholder('testString{REF:P@T:Other Entry}something')).toBe(true);
+    expect(containsPlaceholder('{URL:USERNAME}yes')).toBe(true);
+    expect(containsPlaceholder('{URL:USERNAME}yes{REF:A@O:Attribute 1}')).toBe(true);
+    expect(containsPlaceholder('{NOTAREALPLACEHOLDER:USERNAME}yes')).toBe(false); // Unknown placeholder
+    expect(containsPlaceholder('{TITLE2}')).toBe(false);
+    expect(containsPlaceholder('yes{URL:PORT}')).toBe(true);
+    expect(containsPlaceholder('yes{S:KPEX_PASSKEYS_USER_ID}no')).toBe(true);
+
+    // Static placeholders
+    expect(containsPlaceholder('{TITLE}')).toBe(true);
+    expect(containsPlaceholder('{USERNAME}')).toBe(true);
+    expect(containsPlaceholder('{PASSWORD}')).toBe(true);
+    expect(containsPlaceholder('{URL}')).toBe(true);
+    expect(containsPlaceholder('{NOTES}')).toBe(true);
+    expect(containsPlaceholder('{TOTP}')).toBe(true);
+    expect(containsPlaceholder('\\{TOTP\\}')).toBe(true);
 });
 

--- a/tests/global.spec.ts
+++ b/tests/global.spec.ts
@@ -95,7 +95,7 @@ test('Test trimURL()', async ({ page }) => {
 // Check if different popups/overlays partially covers or touches the input field
 test('Test elementsOverlap()', async ({ page }) => {
     const inputRect = { left: 0, top: 5, right: 200, bottom: 28 }
-   
+
     // Fully covered
     expect(elementsOverlap(inputRect, { left: -2, top: 0, right: 220, bottom: 40 })).toBe(true);
 
@@ -144,12 +144,12 @@ test('Test containsPlaceholder()', async ({ page }) => {
     expect(containsPlaceholder('{URL:USERNAME}yes')).toBe(true);
     expect(containsPlaceholder('{URL:USERNAME}yes{REF:A@O:Attribute 1}')).toBe(true);
     expect(containsPlaceholder('{NOTAREALPLACEHOLDER:USERNAME}yes')).toBe(false); // Unknown placeholder
-    expect(containsPlaceholder('{TITLE2}')).toBe(false);
     expect(containsPlaceholder('yes{URL:PORT}')).toBe(true);
     expect(containsPlaceholder('yes{S:KPEX_PASSKEYS_USER_ID}no')).toBe(true);
 
     // Static placeholders
     expect(containsPlaceholder('{TITLE}')).toBe(true);
+    expect(containsPlaceholder('{TITLE2}')).toBe(false);
     expect(containsPlaceholder('{USERNAME}')).toBe(true);
     expect(containsPlaceholder('{PASSWORD}')).toBe(true);
     expect(containsPlaceholder('{URL}')).toBe(true);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When creating or updating entries from Credential Banner, do not allow using placeholders in username or password. This could cause unwanted references to other entries, and might lead to data extraction.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Try using a reference (for example `{REF:P@T:Other Entry}`) in username or password.

Automated tests added for the new `containsPlaceholder()`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
