### PR TITLE
Offer saving credentials with Custom Login Fields

### DIFF
--- a/keepassxc-browser/content/fields.js
+++ b/keepassxc-browser/content/fields.js
@@ -655,7 +655,8 @@ kpxcFields.useCustomLoginFields = async function() {
         passwordInputs: password ? [ password ] : [],
         totp: totp,
         fields: stringFields,
-        submitButton: submitButton
+        submitButton: submitButton,
+        form: username?.form
     });
 
     return combinations;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
If Custom Login Fields is used for a site before any credentials have been saved, the `kpxcFields.useCustomLoginFields()` function that creates the combination for it does not add the possible form to the combination at all. This causes Credential Banner not to appear.

If the input field used by Custom Login Fields have a form, store it to the combination.

* Fixes #3042

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Using https://online.s-pankki.fi/ebank/auth/initLogin.do?language=1#PIN_TAN that requires using Custom Login Fields for the inputs.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
