### PR TITLE
Fix/refactor credential saving

### DIFF
--- a/dist/manifest_firefox.json
+++ b/dist/manifest_firefox.json
@@ -41,6 +41,7 @@
             "background/httpauth.js",
             "background/offscreen.js",
             "background/browserAction.js",
+            "background/credentials.js",
             "background/tabs.js",
             "background/page.js",
             "background/event.js",
@@ -189,7 +190,7 @@
     "applications": {
         "gecko": {
             "id": "keepassxc-browser@keepassxc.org",
-            "strict_min_version": "100.0"
+            "strict_min_version": "115.0"
         }
     },
     "storage": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig([globalIgnores(["**/*.min.js"]), {
             createResult: "readonly",
             createStylesheet: "readonly",
             CreationError: "readonly",
+            credentials: "readonly",
             DatabaseState: "readonly",
             debugLogMessage: "readonly",
             DEFINED_CUSTOM_FIELDS: "readonly",

--- a/keepassxc-browser/background/background_service.js
+++ b/keepassxc-browser/background/background_service.js
@@ -13,6 +13,7 @@ try {
         'offscreen.js',
         'browserAction.js',
         'tabs.js',
+        'credentials.js',
         'page.js',
         'event.js',
         'init.js'

--- a/keepassxc-browser/background/credentials.js
+++ b/keepassxc-browser/background/credentials.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * @Object credentials
+ * Handles credential saving, and storing submitted credentials temporarily to session storage.
+ */
+const credentials = {};
+
+credentials.clearRedirectCount = async function(tabId) {
+    await this.setRedirectCount(tabId, 0);
+};
+
+credentials.setRedirectCount = async function(tabId, count) {
+    const item = await browser.storage.session.get(String(tabId));
+    const creds = item[String(tabId)];
+    if (creds) {
+        creds.redirectCount = count;
+        await browser.storage.session.set({ [String(tabId)]: creds });
+    }
+};
+
+credentials.getRedirectCount = async function(tabId) {
+    if (!tabId) {
+        return 0;
+    }
+
+    const item = await browser.storage.session.get(String(tabId));
+    const creds = item[String(tabId)];
+    return creds ? creds.redirectCount : 0;
+};
+
+credentials.incrementRedirectCount = async function(tabId) {
+    const redirectCount = await credentials.getRedirectCount(tabId);
+    await credentials.setRedirectCount(tabId, redirectCount + 1);
+};
+
+credentials.clearSubmittedCredentials = async function(tabId) {
+    await browser.storage.session.remove(String(tabId));
+};
+
+credentials.getSubmittedCredentials = async function(tab) {
+    if (!tab?.id) {
+        return {};
+    }
+
+    const tabId = String(tab.id);
+    const creds = await browser.storage.session.get(tabId);
+    return creds[tabId];
+};
+
+credentials.setSubmittedCredentials = async function(tab, args = []) {
+    if (!tab?.id || args.length === 0) {
+        return;
+    }
+
+    const [ submitted, username, password, url, oldCredentials ] = args;
+    await browser.storage.session.set({ [String(tab.id)]: {
+        oldCredentials: oldCredentials,
+        password: password,
+        redirectCount: 0,
+        submitted: submitted,
+        url: url,
+        username: username
+    } });
+};
+

--- a/keepassxc-browser/background/event.js
+++ b/keepassxc-browser/background/event.js
@@ -150,7 +150,7 @@ kpxcEvent.onUpdateAvailableKeePassXC = async function() {
 kpxcEvent.onRemoveCredentialsFromTabInformation = async function(tab) {
     const id = tab?.id || tabs.currentTabId;
     page.clearCredentials(id);
-    page.clearSubmittedCredentials();
+    credentials.clearSubmittedCredentials(id);
 };
 
 kpxcEvent.onLoginPopup = async function(tab, logins) {
@@ -199,8 +199,8 @@ kpxcEvent.getColorTheme = async function(tab) {
     return page.settings.colorTheme;
 };
 
-kpxcEvent.pageGetRedirectCount = async function() {
-    return page.redirectCount;
+kpxcEvent.pageGetRedirectCount = async function(tab) {
+    return await credentials.getRedirectCount(tab?.id);
 };
 
 kpxcEvent.pageClearLogins = async function(tab, alreadyCalled) {
@@ -278,17 +278,17 @@ kpxcEvent.messageHandlers = {
     'load_settings': kpxcEvent.onLoadSettings,
     'lock_database': kpxcEvent.lockDatabase,
     'page_clear_logins': kpxcEvent.pageClearLogins,
-    'page_clear_submitted': page.clearSubmittedCredentials,
+    'page_clear_submitted': credentials.clearSubmittedCredentials,
     'page_get_autosubmit_performed': page.getAutoSubmitPerformed,
     'page_get_login_id': page.getLoginId,
     'page_get_manual_fill': page.getManualFill,
     'page_get_redirect_count': kpxcEvent.pageGetRedirectCount,
-    'page_get_submitted': page.getSubmitted,
+    'page_get_submitted': credentials.getSubmittedCredentials,
     'page_set_allow_iframes': page.setAllowIframes,
     'page_set_autosubmit_performed': page.setAutoSubmitPerformed,
     'page_set_login_id': page.setLoginId,
     'page_set_manual_fill': page.setManualFill,
-    'page_set_submitted': page.setSubmitted,
+    'page_set_submitted': credentials.setSubmittedCredentials,
     'passkeys_get': keepass.passkeysGet,
     'passkeys_register': keepass.passkeysRegister,
     'password_get_filled': kpxcEvent.passwordGetFilled,

--- a/keepassxc-browser/background/init.js
+++ b/keepassxc-browser/background/init.js
@@ -16,9 +16,9 @@ const initListeners = async function() {
      * Form submit is counted as one.
      * @param {object} details
      */
-    browser.webNavigation.onCommitted.addListener((details) => {
+    browser.webNavigation.onCommitted.addListener(async (details) => {
         if (details.transitionQualifiers?.[0] === 'client_redirect' || details.transitionType === 'form_submit') {
-            page.redirectCount += 1;
+            await credentials.incrementRedirectCount(details.tabId);
             return;
         }
 
@@ -27,7 +27,7 @@ const initListeners = async function() {
             page.clearLogins(details.tabId);
         }
 
-        page.redirectCount = 0;
+        await credentials.clearRedirectCount(details.tabId);
     });
 
     // Main event listener

--- a/keepassxc-browser/background/page.js
+++ b/keepassxc-browser/background/page.js
@@ -62,9 +62,6 @@ page.isSafari = false;
 page.manualFill = ManualFill.NONE;
 page.menuContexts = [ 'editable' ];
 page.passwordFilled = false;
-page.redirectCount = 0;
-page.submitted = false;
-page.submittedCredentials = {};
 
 page.popupData = {
     iconType: 'normal',
@@ -175,20 +172,6 @@ page.clearAllLogins = function() {
     });
 };
 
-page.setSubmittedCredentials = function(submitted, username, password, url, oldCredentials, tabId) {
-    page.submittedCredentials.submitted = submitted;
-    page.submittedCredentials.username = username;
-    page.submittedCredentials.password = password;
-    page.submittedCredentials.url = url;
-    page.submittedCredentials.oldCredentials = oldCredentials;
-    page.submittedCredentials.tabId = tabId;
-};
-
-page.clearSubmittedCredentials = async function() {
-    page.submitted = false;
-    page.submittedCredentials = {};
-};
-
 // Retrieves the credentials. Returns cached values when found.
 // Page reload or tab switch clears the cache.
 // If the retrieval is forced (from Credential Banner), get new credentials normally.
@@ -249,20 +232,6 @@ page.getBannerPosition = async function(tab) {
 page.setBannerPosition = async function(tab, position) {
     page.settings.bannerPosition = position;
     await browser.storage.local.set({ 'settings': page.settings });
-};
-
-page.getSubmitted = async function(tab) {
-    // Do not return any credentials if the tab ID does not match.
-    if (tab?.id !== page.submittedCredentials.tabId) {
-        return {};
-    }
-
-    return page.submittedCredentials;
-};
-
-page.setSubmitted = async function(tab, args = []) {
-    const [ submitted, username, password, url, oldCredentials ] = args;
-    page.setSubmittedCredentials(submitted, username, password, url, oldCredentials, tab.id);
 };
 
 page.getAutoSubmitPerformed = async function(tab) {

--- a/keepassxc-browser/background/tabs.js
+++ b/keepassxc-browser/background/tabs.js
@@ -40,23 +40,24 @@ tabs.clearTimeout = function(tabId) {
 };
 
 // Creates a new tab object to the list
-tabs.createTabEntry = function(tabId) {
+tabs.createTabEntry = async function(tabId) {
     if (!tabId) {
         return;
     }
 
     tabs.tabList.set(tabId, structuredClone(TAB_OBJECT));
-    page.clearSubmittedCredentials();
+    await credentials.clearSubmittedCredentials(tabId);
     page.setFillAttributeContextMenuItemVisible(false);
 };
 
 // Deletes a tab object from the list
-tabs.deleteTabEntry = function(tabId) {
+tabs.deleteTabEntry = async function(tabId) {
     if (!tabId) {
         return;
     }
 
     tabs.tabList.delete(tabId);
+    await credentials.clearSubmittedCredentials(tabId);
 };
 
 // Returns a tab object from tabId
@@ -81,7 +82,7 @@ tabs.initOpenedTabs = async function() {
     try {
         const openedTabs = await browser.tabs.query({ discarded: false });
         for (const i of openedTabs) {
-            tabs.createTabEntry(i.id);
+            await tabs.createTabEntry(i.id);
         }
 
         // Set initial tab ID
@@ -109,7 +110,7 @@ tabs.onActivated = async function(activeInfo) {
         if (info && info.id) {
             if (info.status === 'complete') {
                 if (!tabs.getTabFromId(info.id)) {
-                    tabs.createTabEntry(info.id);
+                    await tabs.createTabEntry(info.id);
                 }
                 tabs.switchTab(info);
             }
@@ -125,12 +126,12 @@ tabs.onActivated = async function(activeInfo) {
  * functions if tab is created in foreground
  * @param {object} tab
  */
-tabs.onCreated = function(tab) {
+tabs.onCreated = async function(tab) {
     if (tab?.id > 0 && tab?.selected) {
         tabs.currentTabId = tab.id;
 
         if (!tabs.getTabFromId(tab.id)) {
-            tabs.createTabEntry(tab.id);
+            await tabs.createTabEntry(tab.id);
         }
 
         tabs.switchTab(tab);
@@ -147,7 +148,7 @@ tabs.onRemoved = async function(tabId, _removeInfo) {
         const currentTab = await getCurrentTab();
         tabs.currentTabId = currentTab ? currentTab.id : -1;
     }
-    tabs.deleteTabEntry(tabId);
+    await tabs.deleteTabEntry(tabId);
     tabs.clearTimeout(tabId);
 };
 
@@ -157,10 +158,10 @@ tabs.onRemoved = async function(tabId, _removeInfo) {
  * @param {object} changeInfo
  * @param {object} tab
  */
-tabs.onUpdated = function(tabId, changeInfo, tab) {
+tabs.onUpdated = async function(tabId, changeInfo, tab) {
     // Could not be tracked yet if discarded at browser startup
     if (tabId && !tabs.getTabFromId(tabId)) {
-        tabs.createTabEntry(tabId);
+        await tabs.createTabEntry(tabId);
     }
     // If the tab URL has changed (e.g. logged in) clear credentials
     if (changeInfo.url) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Refactors credential saving in the background scripts. Removes functions from `page.js` and creates a new `credentials.js` instead. Submitted credentials are no longer temporarily stored to the background script / service worker, because in Manifest V3 those might not be permanent, and can cause data loss. Instead, the credentials are stored directly to the extension's session storage.

This should also fix bugs with various sites where the Credential Banner disappears, even if the redirect allowance is set to `Infinite`.

* Fixes #1831

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Manually using multiple sites listed in the ticket.

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )
Minimum version requirement for Firefox is bumped to 115 (which is the oldest ESR still supported) because `browser.storage.session` requires it:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/session

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
