### PR TITLE
Fix Apple school page password input detection

### DIFF
--- a/keepassxc-browser/common/sites.js
+++ b/keepassxc-browser/common/sites.js
@@ -77,7 +77,10 @@ kpxcSites.exceptionFound = function(identifier, field) {
 
     if (document.location.origin === 'https://idmsa.apple.com'
         && ((typeof identifier === 'string' && identifier === 'password_text_field')
-        || (typeof identifier === 'object' && [ 'password', 'form-row', 'show-password' ].every(c => identifier.contains(c))))) {
+        || (typeof identifier === 'object'
+            && ([ 'password', 'form-row', 'show-password' ].every(c => identifier.contains(c))
+                || [ 'password', 'show-password', 'show-placeholder' ].every(c => identifier.contains(c)))
+        ))) {
         return true;
     } else if (document.location.origin.startsWith('https://signin.ebay.')
                && (identifier === 'null' || identifier?.value === 'null' || identifier === 'pass')) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
https://school.apple.com/ is using different identifiers for the password input than the normal Apple login page. New class identifiers added to `sites.js`. Without the fix clicking the username icon after password input appears does nothing.

* Fixes #3077

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )
Go to https://school.apple.com/ and enter any email address to get the password input visible.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
