### PR TITLE
Fix URL input fields to support wildcard characters in Firefox

### DIFF
--- a/keepassxc-browser/options/options.html
+++ b/keepassxc-browser/options/options.html
@@ -792,7 +792,7 @@
                   <div class="form-group was-validated pb-3">
                     <label for="manualUrl" data-i18n="optionsSitePreferencesManualAddText"></label>
                     <div class="input-group w-75" id="manualUrlGroup">
-                      <input class="form-control form-control-sm" type="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="5" maxlength="2000" required>
+                      <input class="form-control form-control-sm" inputmode="url" id="manualUrl" aria-label="Manual URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="5" maxlength="2000" required>
                       <button class="btn btn-sm btn-primary" type="button" id="sitePreferencesManualAdd" data-i18n="[title]addSitePreferenceButtonTitle">
                         <i class="fa fa-plus" aria-hidden="true"></i>
                         <span data-i18n="optionsButtonAdd"></span>
@@ -819,7 +819,7 @@
                         <tr class="clone d-none">
                           <td class="text-nowrap">
                             <div class="input-group was-validated" id="manualUrlGroup">
-                              <input class="form-control form-control-sm site-preferences-input" type="url" id="editUrl" aria-label="Edit URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="5" maxlength="2000" required disabled>
+                              <input class="form-control form-control-sm site-preferences-input" inputmode="url" id="editUrl" aria-label="Edit URL" pattern="file://.*|ftp://.*|http://.*|https://.*" minlength="5" maxlength="2000" required disabled>
                               <button class="btn btn-sm btn-primary" type="button" id="sitePreferencesEditUrl" data-i18n="[title]editSitePreferenceButtonTitle">
                                 <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
                                 <span data-i18n="optionsButtonEdit"></span>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

Replace strict `type` to [`inputmode`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode)

Fixes #1612

## Screenshots or videos
[NOTE]: # ( Use if available. )
[NOTE]: # ( Do not include screenshots of your actual database credentials! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( Also describe how to test the changes manually. )

In Firefox add `http://*.example/*` rule to "Site Preferences"

## Additional information, resources etc.
[NOTE]: # ( Use if available. )
[NOTE]: # ( If you used any AI, please disclose it here. )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
